### PR TITLE
update .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zhangshanmin @aiduxiaoxiong @xiaoxiang781216 @GUIDINGLI @smile0425 @tanghao-xiaomi
+* @aiduxiaoxiong @smile0425 @tanghao-xiaomi


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

Update. github/CODEOWNERS, only @aiduxiaoxiong @smile0425 @tanghao-xiaomi will be retained, These people are automatically added reviewers


