### PR TITLE
Update Hello_World.md

### DIFF
--- a/en/app_dev/system_apps/hello_world/Hello_World.md
+++ b/en/app_dev/system_apps/hello_world/Hello_World.md
@@ -91,7 +91,7 @@ config EXAMPLES_HELLO
                 Enable the \"Hello, World!\" example
 
 if EXAMPLES_HELLO
-//The following directives < default "hello" > need to be run :
+# The following directives < default "hello" > need to be run :
 config EXAMPLES_HELLO_PROGNAME
         string "Program name"
         default "hello"


### PR DESCRIPTION
The Kconfig file does not support C++/C-style comments `//`. Only `# ` can be used for comments in Kconfig files.

The current Kconfig file uses `//` comments.
```bash
//The following directives < default "hello" > need to be run :
```

It should be changed to use `#` comments instead.
```bash
# The following directives < default "hello" > need to be run :
```
