### PR TITLE
Install additional development tools for Quickstart (Ubuntu)

### DIFF
--- a/en/quickstart/openvela_ubuntu_quick_start.md
+++ b/en/quickstart/openvela_ubuntu_quick_start.md
@@ -25,11 +25,11 @@ Before you begin, please ensure your development environment meets the following
 
 Before you start, you need to install the necessary packages for compiling openvela.
 
-Open a terminal and run the following commands to update the package list and install Git, CMake, Python 3, and the build-essential toolchain.
+Open a terminal and run the following commands to update the package list and install  Git, curl, CMake, Python 3, libc++abi-dev, and the build-essential toolchain.
 
 ```Bash
 sudo apt update
-sudo apt install git cmake python3 build-essential
+sudo apt install git curl cmake python3 libc++abi-dev build-essential
 ```
 
 ### 4. Install Git LFS

--- a/zh-cn/quickstart/openvela_ubuntu_quick_start.md
+++ b/zh-cn/quickstart/openvela_ubuntu_quick_start.md
@@ -25,11 +25,11 @@
 
 在开始之前，您需要安装编译 openvela 所需的软件包。
 
-打开终端，执行以下命令，更新软件包列表并安装 Git、CMake、Python 3 和 build-essential 工具链。
+打开终端，执行以下命令，更新软件包列表并安装 Git、curl、CMake、Python 3、libc++abi-dev 和 build-essential 工具链。
 
 ```Bash
 sudo apt update
-sudo apt install git cmake python3 build-essential
+sudo apt install git curl cmake python3 libc++abi-dev build-essential
 ```
 
 ### 4. 安装 Git LFS 组件


### PR DESCRIPTION
# Test in a fresh Ubuntu 22.04.5 virtual machine using the trunk branch.

While following the **Quickstart (Ubuntu) `trunk` tutorial**, I encountered some issues that required installing two additional development tools:  **curl** and **libc++abi-dev** .

**Specifically, `libc++abi-dev` is necessary when compiling `goldfish-arm64-v8a-ap` using `build.sh`; otherwise, the build will fail. Thanks to @yanxingyu17 for the solution provided in the issue #456 .**

1. In **Step 1: Preparations → 4. Install Git LFS**, the first attempt to use `curl` failed because it was not installed.
Installing it manually with the following command was required before continuing:
<img width="849" height="528" alt="Image" src="https://github.com/user-attachments/assets/a779dad3-ab30-4470-b19d-84295be6ddaa" />

```
sudo apt install curl
```
2.When compiling with **./build.sh** as per the latest documentation, **the build failed due to missing dependencies.**
**The error was resolved by installing the libc++abi-dev package using**

```bash
sudo apt install libc++abi-dev
```

---

 **The following error occurred during compilation when this dependency was missing.**

```bash
./build.sh vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ --cmake -j$(nproc)
```

The information in my terminal window is as follows:

```bash
foam@foam-virtual-machine:~/openvela$ ./build.sh vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ --cmake -j$(nproc)
WARNING: no packages found matching dfu-util
WARNING: no packages found matching genromfs
WARNING: no packages found matching gettext
WARNING: no packages found matching gperf
WARNING: no packages found matching kconfig-frontends
WARNING: no packages found matching nasm
WARNING: no packages found matching net-tools
WARNING: no packages found matching nodejs
WARNING: no packages found matching npm
WARNING: no packages found matching pkgconf
WARNING: no packages found matching protobuf-c-compiler
WARNING: no packages found matching protobuf-compiler
WARNING: no packages found matching yasm
*************************************************************************************
The environment of Vela depends on above tools, Run the following command to install:

 sudo apt-get update
 sudo apt-get install -y dfu-util genromfs gettext gperf kconfig-frontends nasm net-tools nodejs npm pkgconf protobuf-c-compiler protobuf-compiler yasm

*************************************************************************************
*****************************
* __      __      _         *
* \ \    / /     | |        *
*  \ \  / / ___  | |  __ _  *
*   \ \/ / / _ \ | | / _` | *
*    \  / |  __/ | || (_| | *
*     \/   \___| |_| \__,_| *
*                           *
*****************************
  cmake --build cmake_out/vela_goldfish-arm64-v8a-ap -j16 
[1/3308] AIDL:Gen and Updating /home/f...er/aidl/android/os/IServiceManager.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceManager.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceManager.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceManager.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[2/3308] AIDL:Gen and Updating /home/f.../aidl/android/app/ProcessStateEnum.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/app/ProcessStateEnum.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/app/ProcessStateEnum.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/app/ProcessStateEnum.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[3/3308] AIDL:Gen and Updating /home/f...android/content/pm/ApexStagedEvent.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/ApexStagedEvent.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/ApexStagedEvent.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/ApexStagedEvent.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[4/3308] AIDL:Gen and Updating /home/f.../content/pm/IPackageChangeObserver.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageChangeObserver.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageChangeObserver.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageChangeObserver.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[5/3308] AIDL:Gen and Updating /home/f...d/content/pm/IPackageManagerNative.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageManagerNative.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageManagerNative.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IPackageManagerNative.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[6/3308] AIDL:Gen and Updating /home/f...oid/content/pm/IStagedApexObserver.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IStagedApexObserver.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IStagedApexObserver.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/IStagedApexObserver.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[7/3308] AIDL:Gen and Updating /home/f...roid/content/pm/PackageChangeEvent.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/PackageChangeEvent.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/PackageChangeEvent.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/PackageChangeEvent.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[8/3308] AIDL:Gen and Updating /home/f.../android/content/pm/StagedApexInfo.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/StagedApexInfo.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/StagedApexInfo.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/content/pm/StagedApexInfo.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[9/3308] AIDL:Gen and Updating /home/f...der/aidl/android/os/ConnectionInfo.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/ConnectionInfo.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ConnectionInfo.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ConnectionInfo.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[11/3308] AIDL:Gen and Updating /home/...er/aidl/android/os/IClientCallback.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/IClientCallback.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IClientCallback.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IClientCallback.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[12/3308] AIDL:Gen and Updating /home/...r/aidl/android/os/IServiceCallback.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceCallback.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceCallback.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/os/IServiceCallback.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[13/3308] AIDL:Gen and Updating /home/...idl/android/os/ServiceWithMetadata.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceWithMetadata.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceWithMetadata.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceWithMetadata.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[14/3308] AIDL:Gen and Updating /home/...r/aidl/android/os/ServiceDebugInfo.cpp
FAILED: apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceDebugInfo.cpp /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceDebugInfo.cpp 
cd /home/foam/openvela/apps/external/android/frameworks/native/libs && aidl --lang=cpp -h/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -o/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/apps/external/android/frameworks/native/libs/binder/aidl -I/home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl /home/foam/openvela/apps/external/android/frameworks/native/libs/binder/aidl/android/os/ServiceDebugInfo.aidl
aidl: error while loading shared libraries: libc++abi.so.1: cannot open shared object file: No such file or directory
[16/3308] cd /home/foam/openvela/nuttx...a/nuttx/cmake/nuttx_generate_dts.cmake
ninja: build stopped: subcommand failed.
Error: ############# build ../vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ fail ##############
```

---

**After installing this additional dependency**

```bash
foam@foam-virtual-machine:~/openvela$ ./build.sh vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ --cmake -j$(nproc) distclean
Build target distclean:
  there is no need to distclean in cmake, delete 'cmake_out/vela_goldfish-arm64-v8a-ap' directly
foam@foam-virtual-machine:~/openvela$ ./build.sh vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ --cmake -j$(nproc)
*****************************
* __      __      _         *
* \ \    / /     | |        *
*  \ \  / / ___  | |  __ _  *
*   \ \/ / / _ \ | | / _` | *
*    \  / |  __/ | || (_| | *
*     \/   \___| |_| \__,_| *
*                           *
*****************************
Build CMake configuration:
  cmake -B cmake_out/vela_goldfish-arm64-v8a-ap -S /home/foam/openvela/nuttx -DBOARD_CONFIG=../vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap/ -DEXTRA_FLAGS="-Wno-cpp -Wno-deprecated-declarations" -GNinja
-- Initializing NuttX
Loaded configuration '/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/.config.compressed'
Minimal configuration saved to '/home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/defconfig.tmp'
  Select HOST_LINUX=y
--   CMake:  3.23.0
--   Ninja:  1.10.1
--   Board:  vela
--   Config: goldfish-arm64-v8a-ap
--   Appdir: /home/foam/openvela/apps
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/foam/openvela/prebuilts/tools/linux/x86_64/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- Configuring done
-- Generating done
-- Build files have been written to: /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap/bin_host
-- The C compiler identification is GNU 13.4.0
-- The CXX compiler identification is GNU 13.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/foam/openvela/prebuilts/gcc/linux-x86_64/aarch64-none-elf/bin/aarch64-none-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/foam/openvela/prebuilts/gcc/linux-x86_64/aarch64-none-elf/bin/aarch64-none-elf-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/foam/openvela/prebuilts/gcc/linux-x86_64/aarch64-none-elf/bin/aarch64-none-elf-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- libmetal version: 1.7.0 (/home/foam/openvela/nuttx)
-- Build type:  
-- Host:    Linux/x86_64
-- Target:  NuttX/aarch64
-- Machine: arm64
-- Vendor: none
-- open-amp version: 1.7.0 (/home/foam/openvela/nuttx/openamp/open-amp)
-- Host:    Linux/x86_64
-- Target:  NuttX/aarch64
-- Machine: arm64
-- C_FLAGS :  -Wall -Wextra
-- Looking for include file stdatomic.h
-- Looking for include file stdatomic.h - found
-- Looking for include file fcntl.h
-- Looking for include file fcntl.h - found
-- Configuring done
-- Generating done
-- Build files have been written to: /home/foam/openvela/cmake_out/vela_goldfish-arm64-v8a-ap
  cmake --build cmake_out/vela_goldfish-arm64-v8a-ap -j16 
[3290/3305] Linking CXX executable nuttx
[3291/3305] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
[3294/3305] cd /home/foam/openvela/cma...penvela/boards/vela/prebuilts/data/ ::
256+0 records in
256+0 records out
268435456 bytes (268 MB, 256 MiB) copied, 0.0882396 s, 3.0 GB/s
mkfs.fat 4.2 (2021-01-31)
Copying data
Copying dummy
[3297/3305] Linking CXX executable first_link
Memory region         Used Size  Region Size  %age Used
[3300/3305] Linking CXX executable second_link
Memory region         Used Size  Region Size  %age Used
[3303/3305] Linking CXX executable final_nuttx
Memory region         Used Size  Region Size  %age Used
[3305/3305] cd /home/foam/openvela/cma...tx vela_ap.elf && cp nuttx vela_ap.bin

```

After compiling, then use it.
```bash
./emulator.sh cmake_out/vela_goldfish-arm64-v8a-ap/
```

<img width="1881" height="1106" alt="Image" src="https://github.com/user-attachments/assets/571ce4c9-6932-499f-9cbc-1476378ce1d0" />

