### PR TITLE
chore(ci): switch workflows to use dev branch

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -10,5 +10,5 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   checkpatch:
-    uses: open-vela/public-actions/.github/workflows/checkpatch.yml@trunk
+    uses: open-vela/public-actions/.github/workflows/checkpatch.yml@dev
     secrets: inherit

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,5 +10,5 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   docs:
-    uses: open-vela/public-actions/.github/workflows/docs.yml@trunk
+    uses: open-vela/public-actions/.github/workflows/docs.yml@dev
     secrets: inherit

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,10 +2,10 @@ name: 'Close stale issues and PR'
 on:
   schedule:
     - cron: '30 1 * * *'
-  workflow_dispatch: # 允许手动触发
+  workflow_dispatch: # Manual triggering is allowed.
 
 jobs:
   stale:
-    uses: open-vela/public-actions/.github/workflows/stale.yml@trunk
+    uses: open-vela/public-actions/.github/workflows/stale.yml@dev
     secrets: inherit
 


### PR DESCRIPTION
Switch all workflow references from `@trunk` to `@dev` branch of public-actions for unified workflow management.

### Changes
- `checkpatch.yml`: `@trunk` → `@dev`
- `docs.yml`: `@trunk` → `@dev`
- `stale.yml`: `@trunk` → `@dev`