### PR TITLE
docs: add AI-assisted setup option to quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ If you want to experience openvela, we provide a fully functional emulator that 
 
 [Quick Start (Ubuntu)](./en/quickstart/openvela_ubuntu_quick_start.md)
 
+> **AI-Assisted Setup**: If you use an AI coding assistant, simply run `git clone https://github.com/open-vela/.claude.git .claude`, then tell the AI "Help me set up the openvela development environment" to automate the entire setup process. See [openvela AI Skills](https://github.com/open-vela/.claude) for details.
+
 ### Quick App Development
 
 [Quick App Quick Start](https://iot.mi.com/vela/quickapp/zh/guide/start/use-ide.html)

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -48,7 +48,7 @@ Vela 的命名源自拉丁语中船帆的含义，也是南方星空中船帆星
 
 - **标准兼容和高可移植性**
 
-    openvela 内核基于 Apache NuttX ，这个被称为 “Tiny Linux” 的系统为 openvela 提供了高标准的 POSIX 兼容性。通过持续提升其 POSIX 兼容性，openvela 当前已达到 88% 的兼容水平。这种高标准的兼容性意味着在其他标准操作系统（例如 Linux）上开发的软件可以轻松迁移到 openvela，几乎不需要额外的工作。
+    openvela 内核基于 Apache NuttX ，这个被称为 "Tiny Linux" 的系统为 openvela 提供了高标准的 POSIX 兼容性。通过持续提升其 POSIX 兼容性，openvela 当前已达到 88% 的兼容水平。这种高标准的兼容性意味着在其他标准操作系统（例如 Linux）上开发的软件可以轻松迁移到 openvela，几乎不需要额外的工作。
 
 - **全面的连接套件**
 
@@ -128,6 +128,8 @@ openvela 采用双分支模型来平衡系统的创新性与稳定性。请根�
 如果您想要体验 openvela，我们提供一个功能完备的模拟器，无需硬件平台即可使用。有关详细信息，请参阅如下指南。
 
 [快速入门（Ubuntu）](./zh-cn/quickstart/openvela_ubuntu_quick_start.md)
+
+> **AI 辅助搭建**：如果您使用 AI 编程助手，只需 `git clone https://github.com/open-vela/.claude.git .claude`，然后告诉 AI "帮我搭建 openvela 开发环境"，即可自动完成全部搭建流程。详见 [openvela AI Skills](https://github.com/open-vela/.claude)。
 
 ### 快应用开发
 

--- a/en/quickstart/openvela_ubuntu_quick_start.md
+++ b/en/quickstart/openvela_ubuntu_quick_start.md
@@ -8,6 +8,20 @@ This guide will walk you through setting up the development environment, downloa
 >
 > This guide is only for **Ubuntu 22.04**. Compiling in Windows Subsystem for Linux (WSL) or Docker container environments is not supported.
 
+> **AI-Assisted Setup (Optional)**
+>
+> If you use an AI coding assistant (e.g., [Claude Code](https://docs.anthropic.com/en/docs/claude-code)), you can automate the entire setup process using openvela AI Skills:
+>
+> ```bash
+> git clone https://github.com/open-vela/.claude.git .claude
+> ```
+>
+> Then tell your AI assistant: "Help me set up the openvela development environment".
+>
+> The AI will automatically handle environment detection, dependency installation, source selection, code download, compilation, and emulator launch, providing targeted solutions if any issues arise.
+>
+> To set up manually, continue with the steps below.
+
 ## Step 1: Preparations
 
 Before you begin, please ensure your development environment meets the following requirements.

--- a/zh-cn/quickstart/openvela_ubuntu_quick_start.md
+++ b/zh-cn/quickstart/openvela_ubuntu_quick_start.md
@@ -8,6 +8,20 @@
 >
 > 本文仅适配 **Ubuntu 22.04**。不支持在 Windows Subsystem for Linux (WSL) 或 Docker 容器环境中进行编译。
 
+> **AI 辅助搭建（可选）**
+>
+> 如果您使用 AI 编程助手（如 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)），可以通过 openvela AI Skills 自动完成以下全部搭建流程：
+>
+> ```bash
+> git clone https://github.com/open-vela/.claude.git .claude
+> ```
+>
+> 然后告诉 AI 助手："帮我搭建 openvela 开发环境"。
+>
+> AI 将自动完成环境检测、依赖安装、代码源选择、源码下载、编译和模拟器启动，并在遇到问题时提供针对性的解决方案。
+>
+> 如需手动搭建，请继续阅读以下步骤。
+
 ## 步骤一：准备工作
 
 在开始之前，请确保您的开发环境满足以下要求。


### PR DESCRIPTION
## Summary

Add AI-assisted setup option to the Ubuntu quick start guide and project READMEs, pointing developers to the `openvela-quickstart` skill in the [.claude repository](https://github.com/open-vela/.claude).

## Changes

- **zh-cn/quickstart/openvela_ubuntu_quick_start.md**: Add "AI 辅助搭建" tip block before Step 1
- **en/quickstart/openvela_ubuntu_quick_start.md**: Add "AI-Assisted Setup" tip block before Step 1
- **README_zh-cn.md**: Add AI quickstart note in 快速入门 section
- **README.md**: Add AI quickstart note in Quick Start section

## Why

The manual setup process involves 4 steps with many decision points (SSH vs HTTPS, Gitee vs GitHub vs GitCode, dev vs trunk). New developers frequently encounter issues like SSH auth failures, Google source access, Git LFS corruption, OOM, and Kconfig errors.

The [openvela-quickstart skill](https://github.com/open-vela/.claude/pull/2) automates the entire flow and provides targeted troubleshooting when issues arise. Adding a visible entry point in the existing docs lets developers discover this option without changing the manual guide structure.

## Related PR

- https://github.com/open-vela/.claude/pull/2 (adds the openvela-quickstart skill)