### PR TITLE
docs: refactor and enhance sched/mem/signal/msgqueue API documentation

### DIFF
--- a/doxygen/api/kernel/mem.md
+++ b/doxygen/api/kernel/mem.md
@@ -1,60 +1,25 @@
-# 内存管理
+# 内存管理 API
 
-openvela 提供了灵活的内存管理系统，支持标准的 POSIX 内存分配接口以及扩展的内存管理功能。内存管理系统支持多种构建模式：
+openvela 提供灵活的内存管理系统，支持标准 POSIX 内存分配接口以及扩展的内存管理功能。
 
-- **Flat Build**：只有一个用户堆，通过标准的 `malloc/free` 访问。
-- **Protected Build**：有两个堆，一个内核堆和一个用户堆，通过 MPU 保护。
-- **Kernel Build**：一个内核堆和多个用户堆（每个任务组一个）。
+头文件：`#include <stdlib.h>`（标准分配）、`#include <nuttx/mm/mm.h>`（内核堆/堆管理）
 
-openvela 内存管理支持以下 API：
+## openvela 实现说明
 
-**标准内存分配接口**：
-- `malloc()`
-- `free()`
-- `calloc()`
-- `realloc()`
-- `reallocarray()`
-- `memalign()`
-- `posix_memalign()`
-- `aligned_alloc()`
-- `valloc()`
-- `zalloc()`
+- **构建模式影响**：
+  - **Flat Build**：只有一个用户堆，`malloc/free` 直接操作
+  - **Protected Build**：内核堆 + 用户堆，通过 MPU 保护隔离
+  - **Kernel Build**：内核堆 + 多个用户堆（每个任务组一个）
+- **对齐保证**：`malloc()` 返回的内存按 `MM_ALIGN`（默认 8 或 16 字节）对齐
+- **线程安全**：所有标准分配接口（malloc/free/calloc 等）在多任务环境中是线程安全的
+- **延迟释放**：`*_delayfree()` 系列接口用于中断上下文中无法立即释放内存的场景
+- **已知不兼容**：`posix_memalign()` 当前不检查 `alignment` 参数有效性，不返回 `EINVAL`
 
-**内存信息查询接口**：
-- `mallinfo()`
-- `mallinfo_task()`
-- `malloc_size()` / `malloc_usable_size()`
-- `mallopt()`
 
-**内核堆接口**（需要 `CONFIG_MM_KERNEL_HEAP`）：
-- `kmm_malloc()`
-- `kmm_free()`
-- `kmm_calloc()`
-- `kmm_realloc()`
-- `kmm_zalloc()`
-- `kmm_memalign()`
-- `kmm_mallinfo()`
-- `kmm_heapmember()`
-- `kmm_initialize()`
-- `kmm_checkcorruption()`
+## 标准内存分配
 
-**堆管理接口**：
-- `mm_initialize()`
-- `mm_uninitialize()`
-- `mm_addregion()`
-- `mm_extend()`
-- `mm_brkaddr()`
-- `mm_heapmember()`
-- `umm_initialize()`
-- `umm_heapmember()`
 
-**调试接口**：
-- `mm_memdump()`
-- `mm_checkcorruption()`
-- `umm_checkcorruption()`
-- `kmm_checkcorruption()`
-
-## 1、malloc
+### malloc
 
 ```c
 void *malloc(size_t size);
@@ -80,9 +45,10 @@ void *malloc(size_t size);
 - 返回的指针可以传递给 `free()`、`realloc()` 等函数。
 - 在多任务环境中，`malloc()` 是线程安全的。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 2、free
+
+### free
 
 ```c
 void free(void *ptr);
@@ -107,9 +73,10 @@ void free(void *ptr);
 - 不要释放非动态分配的内存（如栈上的变量或全局变量）。
 - 释放内存后，该内存可能不会立即返回给系统，而是保留在堆中供后续分配使用。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 3、calloc
+
+### calloc
 
 ```c
 void *calloc(size_t n, size_t elem_size);
@@ -136,9 +103,10 @@ void *calloc(size_t n, size_t elem_size);
 - 返回的内存所有字节都被设置为 0。
 - 对于需要零初始化的数据结构，推荐使用 `calloc()` 而不是 `malloc()` + `memset()`。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 4、realloc
+
+### realloc
 
 ```c
 void *realloc(void *ptr, size_t size);
@@ -166,9 +134,10 @@ void *realloc(void *ptr, size_t size);
 - 返回的指针可能与原指针不同，成功调用后原指针不应再使用。
 - 如果 `realloc()` 失败，原内存块不会被释放，调用者仍需负责释放它。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 5、reallocarray
+
+### reallocarray
 
 ```c
 void *reallocarray(void *ptr, size_t n, size_t elem_size);
@@ -197,7 +166,42 @@ void *reallocarray(void *ptr, size_t n, size_t elem_size);
 
 **POSIX 兼容性**：兼容 BSD/glibc 扩展接口。
 
-## 6、memalign
+
+### zalloc
+
+```c
+void *zalloc(size_t size);
+```
+
+分配指定大小的内存块并将所有字节初始化为零。这是 openvela 提供的便捷函数，功能等同于 `calloc(1, size)`，但语义更清晰。
+
+**参数**：
+
+- `size` 要分配的内存大小（字节）。
+
+**返回值**：
+
+成功时返回指向分配并清零的内存的指针，失败时返回 `NULL` 并设置 `errno`：
+
+- `ENOMEM` 可用内存不足。
+
+**注意**：
+
+- 与 `malloc()` 不同，返回的内存已被清零。
+- 与 `calloc(1, size)` 功能相同，但调用更简洁。
+
+**POSIX 兼容性**：openvela 扩展接口。
+
+---
+
+
+以下接口用于查询堆的使用情况和内存分配统计信息，对于调试和监控内存使用非常有用。
+
+
+## 对齐内存分配
+
+
+### memalign
 
 ```c
 void *memalign(size_t alignment, size_t size);
@@ -224,7 +228,8 @@ void *memalign(size_t alignment, size_t size);
 
 **POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时，推荐使用 `posix_memalign()`）。
 
-## 7、posix_memalign
+
+### posix_memalign
 
 ```c
 int posix_memalign(void **memptr, size_t alignment, size_t size);
@@ -253,7 +258,8 @@ int posix_memalign(void **memptr, size_t alignment, size_t size);
 
 **POSIX 兼容性**：部分兼容 `POSIX` 同名接口（不返回 `EINVAL`）。
 
-## 8、aligned_alloc
+
+### aligned_alloc
 
 ```c
 void *aligned_alloc(size_t alignment, size_t size);
@@ -275,9 +281,10 @@ void *aligned_alloc(size_t alignment, size_t size);
 - 分配的内存可以使用 `free()` 正常释放。
 - 此函数是 C11 标准的一部分，比 `memalign()` 更具可移植性。
 
-**POSIX 兼容性**：完美兼容 C11 标准接口。
+**POSIX 兼容性**：兼容 C11 标准接口。
 
-## 9、valloc
+
+### valloc
 
 ```c
 void *valloc(size_t size);
@@ -303,38 +310,11 @@ void *valloc(size_t size);
 
 **POSIX 兼容性**：兼容 BSD 扩展接口（已过时，推荐使用 `posix_memalign()`）。
 
-## 10、zalloc
 
-```c
-void *zalloc(size_t size);
-```
+## 内存信息查询
 
-分配指定大小的内存块并将所有字节初始化为零。这是 openvela 提供的便捷函数，功能等同于 `calloc(1, size)`，但语义更清晰。
 
-**参数**：
-
-- `size` 要分配的内存大小（字节）。
-
-**返回值**：
-
-成功时返回指向分配并清零的内存的指针，失败时返回 `NULL` 并设置 `errno`：
-
-- `ENOMEM` 可用内存不足。
-
-**注意**：
-
-- 与 `malloc()` 不同，返回的内存已被清零。
-- 与 `calloc(1, size)` 功能相同，但调用更简洁。
-
-**POSIX 兼容性**：openvela 扩展接口。
-
----
-
-## 一、内存信息查询接口
-
-以下接口用于查询堆的使用情况和内存分配统计信息，对于调试和监控内存使用非常有用。
-
-## 1、mallinfo
+### mallinfo
 
 ```c
 struct mallinfo mallinfo(void);
@@ -365,7 +345,8 @@ struct mallinfo mallinfo(void);
 
 **POSIX 兼容性**：兼容 glibc 扩展接口。
 
-## 2、mallinfo_task
+
+### mallinfo_task
 
 ```c
 struct mallinfo_task mallinfo_task(FAR const struct malltask *task);
@@ -400,7 +381,8 @@ struct mallinfo_task mallinfo_task(FAR const struct malltask *task);
 
 **POSIX 兼容性**：openvela 扩展接口。
 
-## 3、malloc_size
+
+### malloc_size
 
 ```c
 size_t malloc_size(void *ptr);
@@ -424,7 +406,8 @@ size_t malloc_size(void *ptr);
 
 **POSIX 兼容性**：兼容 glibc/macOS 扩展接口。
 
-## 4、mallopt
+
+### mallopt
 
 ```c
 int mallopt(int param, int value);
@@ -458,13 +441,14 @@ int mallopt(int param, int value);
 
 ---
 
-## 二、内核堆接口
 
-当启用 `CONFIG_MM_KERNEL_HEAP` 时，openvela 提供独立的内核堆接口。内核堆用于内核态的内存分配，与用户堆完全隔离，确保内核数据的安全性。
 
-在 Protected Build 和 Kernel Build 模式下，内核堆和用户堆使用不同的内存区域，由 MPU 或 MMU 保护。用户态代码无法直接访问内核堆内存。
 
-### 1、kmm_initialize
+
+## 内核堆接口
+
+
+### kmm_initialize
 
 ```c
 void kmm_initialize(void *heap_start, size_t heap_size);
@@ -486,7 +470,8 @@ void kmm_initialize(void *heap_start, size_t heap_size);
 - 此函数只应调用一次，重复调用会导致未定义行为。
 - 需要启用 `CONFIG_MM_KERNEL_HEAP` 配置。
 
-### 2、kmm_malloc
+
+### kmm_malloc
 
 ```c
 void *kmm_malloc(size_t size);
@@ -507,7 +492,8 @@ void *kmm_malloc(size_t size);
 - 分配的内存只能使用 `kmm_free()` 释放。
 - 内核堆分配的内存不应传递给用户态代码。
 
-### 3、kmm_free
+
+### kmm_free
 
 ```c
 void kmm_free(void *mem);
@@ -528,7 +514,8 @@ void kmm_free(void *mem);
 - 只能释放内核堆分配的内存，不能用于释放用户堆内存。
 - 可以使用 `kmm_heapmember()` 检查指针是否属于内核堆。
 
-### 4、kmm_calloc
+
+### kmm_calloc
 
 ```c
 void *kmm_calloc(size_t n, size_t elem_size);
@@ -545,7 +532,8 @@ void *kmm_calloc(size_t n, size_t elem_size);
 
 成功时返回指向分配并清零的内存的指针，失败时返回 `NULL`。
 
-### 5、kmm_realloc
+
+### kmm_realloc
 
 ```c
 void *kmm_realloc(void *oldmem, size_t newsize);
@@ -562,7 +550,8 @@ void *kmm_realloc(void *oldmem, size_t newsize);
 
 成功时返回指向重新分配内存的指针（可能与原指针不同），失败时返回 `NULL`（原内存块保持不变）。
 
-### 6、kmm_zalloc
+
+### kmm_zalloc
 
 ```c
 void *kmm_zalloc(size_t size);
@@ -578,7 +567,8 @@ void *kmm_zalloc(size_t size);
 
 成功时返回指向分配并清零的内存的指针，失败时返回 `NULL`。
 
-### 7、kmm_memalign
+
+### kmm_memalign
 
 ```c
 void *kmm_memalign(size_t alignment, size_t size);
@@ -599,7 +589,27 @@ void *kmm_memalign(size_t alignment, size_t size);
 
 - 用于内核需要对齐内存的场景，如 DMA 缓冲区。
 
-### 8、kmm_mallinfo
+
+### kmm_malloc_size
+
+```c
+size_t kmm_malloc_size(void *mem);
+```
+
+获取内核堆中已分配内存块的实际可用大小。
+
+**参数**：
+
+- `mem` 指向内核堆中已分配的内存块。
+
+**返回值**：
+
+返回内存块的实际可用大小（字节）。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### kmm_mallinfo
 
 ```c
 struct mallinfo kmm_mallinfo(void);
@@ -625,7 +635,8 @@ struct mallinfo kmm_mallinfo(void);
 
 - 可用于监控内核内存使用情况。
 
-### 9、kmm_heapmember
+
+### kmm_heapmember
 
 ```c
 bool kmm_heapmember(void *mem);
@@ -646,7 +657,100 @@ bool kmm_heapmember(void *mem);
 - 可用于确定内存块应该使用 `kmm_free()` 还是 `free()` 释放。
 - 在内存管理代码中用于路由释放请求到正确的堆。
 
-### 10、kmm_checkcorruption
+
+### kmm_addregion
+
+```c
+void kmm_addregion(void *heapstart, size_t heapsize);
+```
+
+向内核堆添加一个新的内存区域。允许内核堆使用非连续的内存区域。
+
+**参数**：
+
+- `heapstart` 新内存区域的起始地址。
+- `heapsize` 新内存区域的大小（字节）。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 需要启用 `CONFIG_MM_KERNEL_HEAP`。
+- 最大区域数量由 `CONFIG_MM_REGIONS` 配置。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### kmm_extend
+
+```c
+void kmm_extend(void *mem, size_t size, int region);
+```
+
+扩展内核堆的指定内存区域。新增内存必须与现有区域在物理地址上相邻。
+
+**参数**：
+
+- `mem` 新增内存的起始地址。
+- `size` 新增内存的大小（字节）。
+- `region` 区域索引（从 0 开始）。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### kmm_delayfree
+
+```c
+void kmm_delayfree(void *mem);
+```
+
+延迟释放内核堆内存。将释放操作推迟到安全的时机执行，适用于中断上下文或持有自旋锁时无法立即释放内存的场景。
+
+**参数**：
+
+- `mem` 指向要释放的内核堆内存。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 在中断处理程序中释放内存时应使用此函数，而非 `kmm_free()`。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### kmm_memdump
+
+```c
+void kmm_memdump(const struct mm_memdump_s *dump);
+```
+
+转储内核堆的内存分配信息到系统日志，用于调试内存泄漏。
+
+**参数**：
+
+- `dump` 指向转储条件结构体，指定过滤条件（PID、序列号范围等）。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 需要启用 `CONFIG_MM_BACKTRACE` 以获取分配调用栈信息。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### kmm_checkcorruption
 
 ```c
 void kmm_checkcorruption(void);
@@ -669,11 +773,13 @@ void kmm_checkcorruption(void);
 
 ---
 
-## 三、堆管理接口
 
-以下接口用于堆的初始化、扩展和管理，通常由系统启动代码或驱动程序使用。这些函数操作 `struct mm_heap_s` 堆结构，提供了对多个独立堆的管理能力。
 
-### 1、mm_initialize
+
+## 堆管理接口
+
+
+### mm_initialize
 
 ```c
 struct mm_heap_s *mm_initialize(const char *name, void *heapstart, size_t heapsize);
@@ -696,7 +802,8 @@ struct mm_heap_s *mm_initialize(const char *name, void *heapstart, size_t heapsi
 - 堆大小必须足够大以容纳堆管理开销。
 - 系统可以有多个独立的堆，如用户堆、内核堆、图形堆等。
 
-### 2、mm_uninitialize
+
+### mm_uninitialize
 
 ```c
 void mm_uninitialize(struct mm_heap_s *heap);
@@ -716,7 +823,8 @@ void mm_uninitialize(struct mm_heap_s *heap);
 
 - 销毁前应确保堆中没有活动的分配。
 
-### 3、mm_addregion
+
+### mm_addregion
 
 ```c
 void mm_addregion(struct mm_heap_s *heap, void *heapstart, size_t heapsize);
@@ -739,7 +847,8 @@ void mm_addregion(struct mm_heap_s *heap, void *heapstart, size_t heapsize);
 - 新增区域可以在物理上与已有区域不连续。
 - 最大区域数量由 `CONFIG_MM_REGIONS` 配置。
 
-### 4、mm_extend
+
+### mm_extend
 
 ```c
 void mm_extend(struct mm_heap_s *heap, void *mem, size_t size, int region);
@@ -763,7 +872,8 @@ void mm_extend(struct mm_heap_s *heap, void *mem, size_t size, int region);
 - 新增的内存区域必须与现有区域在物理地址上相邻。
 - 与 `mm_addregion()` 不同，此函数用于扩展已有区域而非添加新区域。
 
-### 5、mm_brkaddr
+
+### mm_brkaddr
 
 ```c
 void *mm_brkaddr(struct mm_heap_s *heap, int region);
@@ -784,7 +894,29 @@ void *mm_brkaddr(struct mm_heap_s *heap, int region);
 
 - 用于确定可以扩展的内存位置。
 
-### 6、mm_heapmember
+
+### mm_sbrk
+
+```c
+int mm_sbrk(struct mm_heap_s *heap, intptr_t incr, void **mem);
+```
+
+扩展或收缩堆的 break 地址（类似 UNIX sbrk 语义）。
+
+**参数**：
+
+- `heap` 堆结构指针。
+- `incr` 增量（正值扩展，负值收缩）。
+- `mem` 输出参数，返回之前的 break 地址。
+
+**返回值**：
+
+成功返回 0，失败返回 -1。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_heapmember
 
 ```c
 bool mm_heapmember(struct mm_heap_s *heap, void *mem);
@@ -805,7 +937,129 @@ bool mm_heapmember(struct mm_heap_s *heap, void *mem);
 
 - 用于确定内存分配来源，以便使用正确的接口释放。
 
-### 7、umm_initialize
+
+### mm_free
+
+```c
+void mm_free(struct mm_heap_s *heap, void *mem);
+```
+
+从指定堆释放内存。这是底层堆释放接口，`free()` 和 `kmm_free()` 内部调用此函数。
+
+**参数**：
+
+- `heap` 堆结构指针。
+- `mem` 指向要释放的内存块。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_malloc_size
+
+```c
+size_t mm_malloc_size(struct mm_heap_s *heap, void *mem);
+```
+
+获取指定堆中已分配内存块的实际可用大小。
+
+**参数**：
+
+- `heap` 堆结构指针。
+- `mem` 指向已分配的内存块。
+
+**返回值**：
+
+返回内存块的实际可用大小（字节）。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_delayfree
+
+```c
+void mm_delayfree(struct mm_heap_s *heap, void *mem);
+```
+
+延迟释放指定堆的内存。适用于中断上下文或持有自旋锁时无法立即释放的场景。
+
+**参数**：
+
+- `heap` 堆结构指针。
+- `mem` 指向要释放的内存块。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_heapfree
+
+```c
+size_t mm_heapfree(struct mm_heap_s *heap);
+```
+
+查询指定堆的空闲内存总量。
+
+**参数**：
+
+- `heap` 堆结构指针。
+
+**返回值**：
+
+返回堆中空闲内存的总大小（字节）。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_heapfree_largest
+
+```c
+size_t mm_heapfree_largest(struct mm_heap_s *heap);
+```
+
+查询指定堆中最大的连续空闲块大小。这决定了单次分配可用的最大内存。
+
+**参数**：
+
+- `heap` 堆结构指针。
+
+**返回值**：
+
+返回最大连续空闲块的大小（字节）。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### mm_notify_pressure
+
+```c
+void mm_notify_pressure(size_t remaining, size_t largest);
+```
+
+发送内存压力通知。当堆空闲内存低于阈值时，通知注册的监听者释放缓存等可回收内存。
+
+**参数**：
+
+- `remaining` 当前剩余空闲内存（字节）。
+- `largest` 当前最大连续空闲块（字节）。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+## 用户堆接口
+
+
+### umm_initialize
 
 ```c
 void umm_initialize(void *heap_start, size_t heap_size);
@@ -827,7 +1081,8 @@ void umm_initialize(void *heap_start, size_t heap_size);
 - 此函数只应调用一次。
 - 用户堆是 `malloc()` 等标准接口的默认堆。
 
-### 8、umm_heapmember
+
+### umm_heapmember
 
 ```c
 bool umm_heapmember(void *mem);
@@ -849,11 +1104,73 @@ bool umm_heapmember(void *mem);
 
 ---
 
-## 四、调试接口
 
-以下接口用于内存调试和问题诊断。这些功能对于检测内存泄漏、内存损坏和优化内存使用非常有用。
 
-### 1、mm_memdump
+
+### umm_addregion
+
+```c
+void umm_addregion(void *heapstart, size_t heapsize);
+```
+
+向用户堆添加一个新的内存区域。
+
+**参数**：
+
+- `heapstart` 新内存区域的起始地址。
+- `heapsize` 新内存区域的大小（字节）。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### umm_extend
+
+```c
+void umm_extend(void *mem, size_t size, int region);
+```
+
+扩展用户堆的指定内存区域。新增内存必须与现有区域相邻。
+
+**参数**：
+
+- `mem` 新增内存的起始地址。
+- `size` 新增内存的大小（字节）。
+- `region` 区域索引。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+### umm_delayfree
+
+```c
+void umm_delayfree(void *mem);
+```
+
+延迟释放用户堆内存。适用于中断上下文。
+
+**参数**：
+
+- `mem` 指向要释放的用户堆内存。
+
+**返回值**：
+
+无返回值。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+
+## 调试与诊断
+
+
+### mm_memdump
 
 ```c
 void mm_memdump(struct mm_heap_s *heap, const struct mm_memdump_s *dump);
@@ -876,7 +1193,8 @@ void mm_memdump(struct mm_heap_s *heap, const struct mm_memdump_s *dump);
 - 输出信息包括每个分配块的地址、大小、分配者 PID 和分配时的调用栈（如果启用了 `CONFIG_MM_BACKTRACE`）。
 - 常用于诊断内存泄漏，找出哪些代码分配了内存但未释放。
 
-### 2、mm_checkcorruption
+
+### mm_checkcorruption
 
 ```c
 void mm_checkcorruption(struct mm_heap_s *heap);
@@ -898,7 +1216,8 @@ void mm_checkcorruption(struct mm_heap_s *heap);
 - 检测的问题包括：块头损坏、双重释放、越界写入等。
 - 此函数会遍历整个堆，对性能有影响，主要用于调试。
 
-### 3、umm_checkcorruption
+
+### umm_checkcorruption
 
 ```c
 void umm_checkcorruption(void);
@@ -918,3 +1237,26 @@ void umm_checkcorruption(void);
 
 - 需要启用 `CONFIG_DEBUG_MM` 配置。
 - 可以在怀疑有内存问题时调用此函数进行检查。
+
+
+### umm_memdump
+
+```c
+void umm_memdump(const struct mm_memdump_s *dump);
+```
+
+转储用户堆的内存分配信息到系统日志。
+
+**参数**：
+
+- `dump` 指向转储条件结构体。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 需要启用 `CONFIG_MM_BACKTRACE` 以获取调用栈。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。

--- a/doxygen/api/kernel/msgqueue.md
+++ b/doxygen/api/kernel/msgqueue.md
@@ -1,57 +1,58 @@
-# 消息队列
+# 消息队列 API
 
-openvela 内核支持 POSIX 命名的消息队列用于任务间的通讯，任何任务都可以通过消息队列来发送或接收。在中断中可以发送消息给消息队列。
+openvela 提供符合 POSIX 标准的消息队列接口，用于任务间的异步消息传递。消息队列支持优先级排序，高优先级消息优先被接收。
 
-openvela 消息队列支持以下 API：
+头文件：`#include <mqueue.h>`
 
-- `mq_open()`
-- `mq_close()`
-- `mq_unlink()`
-- `mq_send()`
-- `mq_timedsend()`
-- `mq_receive()`
-- `mq_timedreceive()`
-- `mq_notifiy()`
-- `mq_setattr()`
-- `mq_getattr()`
+## openvela 实现说明
 
-## 一、mq_open
+- **中断中发送**：`mq_send()` 可在中断上下文中调用，但行为不同：不检查队列大小，使用预分配消息（数量由 `PREALLOC_MQ_IRQ_MSGS` 配置）
+- **通知行为差异**：`mq_notify()` 即使有任务在等待接收消息，仍会发送通知信号，与 POSIX 规范不完全一致
+- **超时时间**：`mq_timedsend()` 和 `mq_timedreceive()` 使用基于 Epoch 的绝对时间
+
+## 队列管理
+
+### mq_open
 
 ```c
 mqd_t mq_open(const char *mqName, int oflags, ...);
 ```
 
-在调用任务和消息队列之间建立一个连接。在成功调用 `mq_open` 之后，这个任务可以用其返回值来使用消息队列。这个消息队列描述符将一直可用直到调用 `mq_close()`。
+在调用任务和消息队列之间建立连接。成功调用后，返回的消息队列描述符可用于后续操作，直到调用 `mq_close()`。
 
 **参数**：
 
-- `mqName` 打开队列的名字。
+- `mqName` 消息队列的名称。
 - `oflags` 打开标志位，可以是以下的任意组合：
-    - `O_RDONLY`。打开可读权限。
-    - `O_WRONLY`。打开可写权限。
-    - `O_RDWR`。打开可读可写权限。
-    - `O_CREAT`。如果消息队列不存在，则创建它。
-    - `O_EXCL`。打开时必须存在。
-    - `O_NONBLOCK`。不需要等待数据。
-- `...` 可选参数。当使用 `O_CREAT` 标志时，POSIX 要求提供第三个和第四个参数：
-    - `mode`。`mode` 的参数类型为 `mode_t`。在 POSIX 规范中，`mode` 用来提供消息队列的文件权限位。这个参数是必须的，但是在当前实现中没有被使用。
-    - `attr`。用于初始化 `mq_attr` 的指针。如果 `attr` 为 `NULL`，则使用默认值来创建消息队列。如果为非 `NULL`，则在创建消息队列时将 `attr` 里的参数用于消息队列的创建，其中 `mq_maxmsg` 用来设置在消息队列上同时存在消息的最大个数，`mq_msgsize` 用来设置每条消息最大的大小。
+  - `O_RDONLY` 只读。
+  - `O_WRONLY` 只写。
+  - `O_RDWR` 读写。
+  - `O_CREAT` 如果消息队列不存在则创建。
+  - `O_EXCL` 与 `O_CREAT` 配合，如果队列已存在则失败。
+  - `O_NONBLOCK` 非阻塞模式。
+- `...` 可选参数，当使用 `O_CREAT` 时需要提供：
+  - `mode`（`mode_t`）文件权限位。当前实现中未使用，但 POSIX 要求提供。
+  - `attr`（`struct mq_attr *`）队列属性。如果为 `NULL` 则使用默认值。`mq_maxmsg` 设置最大消息数，`mq_msgsize` 设置最大消息大小。
 
 **返回值**：
 
-消息队列描述符或者-1(`ERROR`)
+成功时返回消息队列描述符（`mqd_t`），失败时返回 -1（`ERROR`）并设置 `errno`：
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+- `ENOENT` 未设置 `O_CREAT` 且指定的队列不存在。
+- `EEXIST` 同时设置了 `O_CREAT` 和 `O_EXCL`，但队列已存在。
+- `EINVAL` 参数无效（如 `mqName` 为 `NULL`）。
+- `ENOMEM` 内存不足，无法创建队列。
+- `ENFILE` 系统消息队列数量已达上限。
 
-## 二、mq_close
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+### mq_close
 
 ```c
 int mq_close(mqd_t mqdes);
 ```
 
-用来在调用任务中表示对 `mqdes` 已完成使用。`mq_close()` 用来释放系统分配给这个任务的资源。
-
-如果这个任务在消息队列上附加了一个通知请求，这个通知请求会被去除，并且消息队列可以提供另一个任务用来获取通知。
+关闭消息队列描述符，释放系统分配给该任务的资源。如果任务在该队列上注册了通知请求，通知会被取消。
 
 **参数**：
 
@@ -59,238 +60,244 @@ int mq_close(mqd_t mqdes);
 
 **返回值**：
 
-- `OK` 消息队列关闭成功则为 0，否则为 -1（`ERROR`）。
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
 
-**假设**：
+- `EBADF` `mqdes` 不是有效的消息队列描述符。
 
-- `mq_send()` 或者 `mq_receive()` 阻塞时调用 `mq_close()` 的任务行为是未定义的。
-- 在成功调用 `mq_close()` 后再次使用同一个 `mqdes` 调用 `mq_close()` 的行为是未定义的。
+**注意**：
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+- 在 `mq_send()` 或 `mq_receive()` 阻塞时调用 `mq_close()` 的行为是未定义的。
+- 关闭后再次使用同一 `mqdes` 的行为是未定义的。
 
-## 三、mq_unlink
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+### mq_unlink
 
 ```c
-int mq_unlink(const char* mqName);
+int mq_unlink(const char *mqName);
 ```
 
-删除以 `mqName` 命名的消息队列。如果有一个或者多个任务打开了这个消息队列的时候调用了 `mq_unlink()`，则将推迟消息队列的删除，直到所有消息队列都被关闭。
+删除指定名称的消息队列。如果有任务仍然打开了该队列，删除会推迟到所有描述符都关闭后执行。
 
 **参数**：
 
-- `mqName` 消息队列的名字。
+- `mqName` 消息队列的名称。
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+**返回值**：
 
-## 四、mq_send
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
+
+- `ENOENT` 指定名称的队列不存在。
+- `EINVAL` `mqName` 为 `NULL`。
+
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+## 消息发送
+
+### mq_send
 
 ```c
-int mq_send(mqd_t mqdes, const void *msg, size_t msqglen, int prio);
+int mq_send(mqd_t mqdes, const void *msg, size_t msglen, int prio);
 ```
 
-将指定消息 `msg` 发送到消息队列 `mqdes`。`msglen` 这个参数指定了 `msg` 的字节长度。这个长度必须不大于从 `mq_getattr()` 获取的最大长度。
+将消息发送到消息队列。消息按优先级排序，高优先级消息排在低优先级之前。`prio` 不能超过 `MQ_PRIO_MAX`。
 
-如果消息队列没有满，`mq_send` 将会根据 `prio` 优先级放入消息队列的指定位置。高优先级的消息会被插在低优先级的消息之前。`prio` 的值必须不能超过 `MQ_PRIO_MAX`。
+如果队列已满且未设置 `O_NONBLOCK`，调用阻塞直到有空间可用。如果设置了 `O_NONBLOCK`，立即返回错误。
 
-如果消息队列已满并且没有设置 `O_NONBLOCK`，`mq_send()` 将会被阻塞，直到消息队列有可用空间。
+**参数**：
 
-如果消息队列已满并且设置了 `O_NONBLOCK`，消息并不会被加入消息队列，并且会返回一个错误。
+- `mqdes` 消息队列描述符。
+- `msg` 要发送的消息。
+- `msglen` 消息的字节长度，不能超过 `mq_msgsize`。
+- `prio` 消息优先级。
 
-**注意**：`mq_send` 可以在中断中被调用。它的行为在中断中会有不同：
+**返回值**：
 
-- 它不会去检查队列的大小。总是会发送消息，即使队列中已经有了很多消息。这是因为在中断中不能等待消息队列未满。
-- 它不会去申请新的内存（因为不能在中断中申请内存）。也就是说，会有一个提前申请的内存，仅用于从中断中发送消息。提前申请消息的数量由 `PREALLOC_MQ_IRQ_MSGS` 设置。
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
+
+- `EAGAIN` 队列已满且设置了 `O_NONBLOCK`。
+- `EINVAL` `msg` 或 `mqdes` 为 `NULL`，或 `prio` 无效。
+- `EPERM` 消息队列未以写模式打开。
+- `EMSGSIZE` `msglen` 超过队列的 `mq_msgsize`。
+- `EINTR` 被信号中断。
+
+**注意**：
+
+- `mq_send()` 可在中断上下文中调用，但行为不同：不检查队列大小（总是发送），使用预分配消息（数量由 `PREALLOC_MQ_IRQ_MSGS` 配置），不分配新内存。
+
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+### mq_timedsend
+
+```c
+int mq_timedsend(mqd_t mqdes, const void *msg, size_t msglen, int prio,
+                 const struct timespec *abstime);
+```
+
+带超时的消息发送。行为与 `mq_send()` 相同，但在队列满时最多阻塞到 `abstime` 指定的绝对时间。
 
 **参数**：
 
 - `mqdes` 消息队列描述符。
 - `msg` 要发送的消息。
 - `msglen` 消息的字节长度。
-- `prio` 消息的优先级。
+- `prio` 消息优先级。
+- `abstime` 绝对超时时间（基于 Epoch）。
 
 **返回值**：
 
-如果成功，`mq_send` 将会返回 0（`OK`）；如果失败，将会返回 -1（`ERROR`），同时将会设置 `errno`：
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
 
-- `EAGAIN` 当队列已满，并且通过 `mqdes` 消息队列描述符设置了 `O_NONBLOCK`。
-- `EINVAL` `msg` 或者 `mqdes` 是 `NULL` 或者 `prio` 是无效值。
-- `EPERM` 消息队列被打开不是为了写。
-- `EMSGSIZE` `msglen` 超过了消息队列中的 `maxmsgsize` 属性。
-- `EINTR` 调用被信号中断。
+- `EAGAIN` 队列已满且设置了 `O_NONBLOCK`。
+- `EINVAL` `msg` 或 `mqdes` 为 `NULL`，或 `prio` 无效。
+- `EPERM` 消息队列未以写模式打开。
+- `EMSGSIZE` `msglen` 超过队列的 `mq_msgsize`。
+- `EINTR` 被信号中断。
+- `ETIMEDOUT` 超时。
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+**POSIX 兼容性**：兼容 POSIX 同名接口。
 
-## 五、mq_timedsend
+## 消息接收
 
-```c
-int mq_timedsend(mqd_t mqdes, const void *msg, size_t msqglen, int prio, const struct timespec *abstime);
-```
-
-将指定消息 `msg` 发送到消息队列 `mqdes`。`msglen` 这个参数指定了 `msg` 的字节长度。这个长度必须不大于从 `mq_getattr()` 获取的最大长度。
-
-如果消息队列没有满，`mq_timedsend` 将会根据 `prio` 优先级放入消息队列的指定位置。高优先级的消息会被插在低优先级的消息之前。`prio` 的值必须不能超过 `MQ_PRIO_MAX`。
-
-如果消息队列已满并且没有设置 `O_NONBLOCK`，`mq_timedsend()` 将会被阻塞，直到消息队列有可用空间或超时。
-
-`mq_timedsend()` 的行为和 `mq_send` 类似，除了如果消息队列已满且 `O_NONBLOCK` 没有被设置，则 `abstime` 设置一个结构体，该结构体表示了 `mq_timedsend()` 阻塞的时间上限。这个上限是从 1970 年 1 月 1 日零点零分零秒开始算起的绝对时间。
-
-如果消息队列已满，并且在调用时已超时，那么 `mq_timedsend()` 立即返回。
-
-**参数**：
-
-- `mqdes` 消息队列描述符。
-- `msg` 要发送的消息。
-- `msglen` 消息的字节长度。
-- `prio` 消息的优先级。
-- `abstime` 超时时间。
-
-**返回值**：
-
-如果成功，`mq_timedsend` 将会返回 0（`OK`）；如果失败，将会返回 -1（`ERROR`），同时将会设置 `errno`：
-
-- `EAGAIN` 当队列已满，并且通过 `mqdes` 消息队列描述符设置了 `O_NONBLOCK`。
-- `EINVAL` `msg` 或者 `mqdes` 是 `NULL` 或者 `prio` 是无效值。
-- `EPERM` 消息队列被打开不是为了写。
-- `EMSGSIZE` `msglen` 超过了消息队列中的 `maxmsgsize` 属性。
-- `EINTR` 调用被信号中断。
-- `ETIMEDOUT` 发送超时。
-
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
-
-## 六、mq_receive
+### mq_receive
 
 ```c
 ssize_t mq_receive(mqd_t mqdes, void *msg, size_t msglen, int *prio);
 ```
 
-通过 `mqdes` 从指定消息队列接收最早优先级最高的消息。如果缓冲区的大小 `msglen` 小于消息队列中 `mq_msgsize` 这个属性，`mq_receive()` 会返回一个错误；相反，将会从消息队列中移除这个消息，并把它拷贝到 `msg`。
+从消息队列接收优先级最高且最早的消息。`msglen` 不能小于队列的 `mq_msgsize`，否则返回错误。
 
-如果消息队列是空的并且 `O_NONBLOCK` 没有被设置，`mq_receive()` 将会被阻塞直到有消息被加载进这个消息队列。如果有多个任务在等待接收消息，只会有优先级最高且等待时间最长的任务会接收到消息并解除阻塞。
-
-如果队列为空并且设置了 `O_NONBLOCK`，将会返回错误 `ERROR`。
+如果队列为空且未设置 `O_NONBLOCK`，调用阻塞直到有消息可用。多个等待任务中，优先级最高且等待最久的任务优先接收。
 
 **参数**：
 
 - `mqdes` 消息队列描述符。
-- `msg` 接收消息缓冲区。
-- `msglen` 缓冲区的字节长度。
-- `prio` 如果不为 `NULL`，则存储该消息的优先级。
+- `msg` 接收消息的缓冲区。
+- `msglen` 缓冲区大小（字节）。
+- `prio` 如果非 `NULL`，存储接收到的消息的优先级。
 
 **返回值**：
 
-如果成功，返回消息的长度（以字节为单位）。失败时，返回 -1（`ERROR`）并且设置 `errno`：
+成功时返回消息长度（字节），失败时返回 -1（`ERROR`）并设置 `errno`：
 
-- `EAGAIN` 队列为空，并且 `mqdes` 设置了 `O_NONBLOCK`。
-- `EPERM` 消息队列不可读。
-- `EMSGSIZE` `msglen` 小于消息队列 `maxmsgsize` 的属性。
-- `EINTR` 调用被信号中断。
+- `EAGAIN` 队列为空且设置了 `O_NONBLOCK`。
+- `EPERM` 消息队列未以读模式打开。
+- `EMSGSIZE` `msglen` 小于队列的 `mq_msgsize`。
+- `EINTR` 被信号中断。
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+**POSIX 兼容性**：兼容 POSIX 同名接口。
 
-## 七、mq_timedreceive
+### mq_timedreceive
 
 ```c
-ssize_t mq_timedreceive(mqd_t mqdes, void *msg, size_t msglen, int *prio);
+ssize_t mq_timedreceive(mqd_t mqdes, char *msg, size_t msglen,
+                        unsigned int *prio, const struct timespec *abstime);
 ```
 
-通过 `mqdes` 从指定消息队列接收最早优先级最高的消息。如果缓冲区的大小 `msglen` 小于消息队列中 `mq_msgsize` 这个属性，`mq_timedreceive()` 会返回一个错误；相反，将会从消息队列中移除这个消息，并把它拷贝到 `msg`。
-
-如果消息队列是空的并且 `O_NONBLOCK` 没有被设置，`mq_timedreceive()` 将会被阻塞直到有消息被加载进这个消息队列或者发生超时。如果有多个任务在等待接收消息，只会有优先级最高且等待时间最长的任务会接收到消息并解除阻塞。
-
-`mq_timedreceive()` 的行为和 `mq_receive` 类似，除了如果消息队列为空且 `O_NONBLOCK` 没有被设置，则 `abstime` 设置一个结构体，该结构体表示了 `mq_timedreceive()` 阻塞的时间上限。这个上限是从 1970 年 1 月 1 日零点零分零秒开始算起的绝对时间。
-
-如果消息队列没有消息，并且在调用时已超时，那么 `mq_timedreceive()` 立即返回。
+带超时的消息接收。行为与 `mq_receive()` 相同，但在队列空时最多阻塞到 `abstime` 指定的绝对时间。
 
 **参数**：
 
 - `mqdes` 消息队列描述符。
-- `msg` 接收消息缓冲区。
-- `msglen` 缓冲区的字节长度。
-- `prio` 如果不为 `NULL`，则存储该消息的优先级。
-- `abstime` 超时时间。
+- `msg` 接收消息的缓冲区。
+- `msglen` 缓冲区大小（字节）。
+- `prio` 如果非 `NULL`，存储接收到的消息的优先级。
+- `abstime` 绝对超时时间（基于 Epoch）。
 
 **返回值**：
 
-如果成功，返回消息的长度（以字节为单位）。失败时，返回 -1（`ERROR`）并且设置 `errno`：
+成功时返回消息长度（字节），失败时返回 -1（`ERROR`）并设置 `errno`：
 
-- `EAGAIN` 队列为空，并且 `mqdes` 设置了 `O_NONBLOCK`。
-- `EPERM` 消息队列不可读。
-- `EMSGSIZE` `msglen` 小于消息队列 `maxmsgsize` 的属性。
-- `EINTR` 调用被信号中断。
-- `ETIMEDOUT` 接收超时。
+- `EAGAIN` 队列为空且设置了 `O_NONBLOCK`。
+- `EPERM` 消息队列未以读模式打开。
+- `EMSGSIZE` `msglen` 小于队列的 `mq_msgsize`。
+- `EINTR` 被信号中断。
+- `ETIMEDOUT` 超时。
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+**POSIX 兼容性**：兼容 POSIX 同名接口。
 
-## 八、mq_notify
+## 队列属性
 
-```c
-int mq_notify(mqd_t mqdes, FAR struct sigevent *notification)
-```
-
-如果 `notification` 输入参数不是 `NULL`，那么当前进程希望在有一个消息到达指定的先前为空的队列时得到通知。
-
-如果 `notification` 是 `NULL`，且当前的进程被注册为接收指定队列的通知，那么将已存在的注册取消。
-
-当通知发送到已注册的任务时，注册将被取消。之后消息队列可用于注册通知。
-
-**参数**：
-
-- `mqdes` 消息队列描述符。
-- `notification` 实时信号结构体包括：
-    - `sigev_notify` 应该是 `SIGEV_SIGNAL`（但实际上没有被使用）。
-    - `sigev_signo` 用于通知的信号。
-    - `sigev_value` 与信号量相关的值。
-
-**返回值**：
-
-如果成功，则 `mq_notify()` 返回 0；如果失败，将返回 -1，并且会设置 `errno`：
-
-- `EBADF` `mqdes` 设备描述符无效。
-- `EBUSY` 另一个进程已经对该消息队列注册通知。
-- `EINVAL` `sevp->sigev_notify` 不是一个允许的值，或者 `sevp->sigev_notify` 是 `SIGEV_SIGNAL` 并且 `sevp->sigev_signo` 不是一个有效的编号。
-- `ENOMEM` 内存不足。
-
-**POSIX 兼容性**：兼容 POSIX 同名接口。与完整的 POSIX 实现区别有：
-
-- 即使另一个任务正在等待消息队列变为空，通知信号也会发送到已注册的任务。这与 POSIX 规范不一致，该规范指出："如果一个进程已经注册了消息到达消息队列的通知，并且 `mq_receive` 当消息到达队列时某个进程在等待接收消息时被阻塞，则到达的消息将满足适当 `mq_receive()` 的……由此产生的行为就像消息队列保持空，并且不会发送任何通知。"
-
-## 九、mq_setattr
+### mq_setattr
 
 ```c
-int mq_setattr(mqd_t mqdes, const struct mq_attr *mqStat, struct mq_attr *oldMqStat)
+int mq_setattr(mqd_t mqdes, const struct mq_attr *mqStat, struct mq_attr *oldMqStat);
 ```
 
-设置与 `mqdes` 消息队列的相关属性。`mq_flag` 中只有 `O_NONBLOCK` 位才能被改变。
-
-如果 `oldMqStat` 为非空，那么 `mq_setattr()` 将在该位置存储先前的消息队列属性（就像 `mq_getattr()` 返回的一样）。
+设置消息队列属性。`mq_flags` 中只有 `O_NONBLOCK` 位可以被修改。
 
 **参数**：
 
 - `mqdes` 消息队列描述符。
 - `mqStat` 新属性。
-- `oldMqStat` 旧属性。
+- `oldMqStat` 如果非 `NULL`，存储修改前的属性。
 
 **返回值**：
 
-如果属性设置成功则返回 0（`OK`），否则返回 -1（`ERROR`）。
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+- `EBADF` `mqdes` 不是有效的描述符。
+- `EINVAL` `mqStat` 为 `NULL`。
 
-## 十、mq_getattr
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+### mq_getattr
 
 ```c
-int mq_getattr(mqd_t mqdes, struct mq_attr *mqStat)
+int mq_getattr(mqd_t mqdes, struct mq_attr *mqStat);
 ```
 
-获取与指定消息队列关联的状态信息和属性。
+获取消息队列的当前属性。
 
 **参数**：
 
 - `mqdes` 消息队列描述符。
 - `mqStat` 返回属性结构体：
-    - `mq_maxmsg` 队列中的最大消息数。
-    - `mq_msgsize` 最大消息大小。
-    - `mq_flags` 消息队列标志。
-    - `mq_curmsgs` 当前在队列中的消息数。
+  - `mq_maxmsg` 队列中的最大消息数。
+  - `mq_msgsize` 最大消息大小（字节）。
+  - `mq_flags` 消息队列标志。
+  - `mq_curmsgs` 当前队列中的消息数。
 
-**POSIX 兼容性**：完美兼容 POSIX 同名接口。
+**返回值**：
+
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
+
+- `EBADF` `mqdes` 不是有效的描述符。
+- `EINVAL` `mqStat` 为 `NULL`。
+
+**POSIX 兼容性**：兼容 POSIX 同名接口。
+
+## 通知
+
+### mq_notify
+
+```c
+int mq_notify(mqd_t mqdes, const struct sigevent *notification);
+```
+
+注册或取消消息到达通知。当消息到达先前为空的队列时，向注册的任务发送信号通知。
+
+如果 `notification` 为 `NULL`，取消当前注册。通知发送后注册自动取消，需要重新注册。
+
+**参数**：
+
+- `mqdes` 消息队列描述符。
+- `notification` 通知配置，包括：
+  - `sigev_notify` 通知方式（应为 `SIGEV_SIGNAL`）。
+  - `sigev_signo` 通知使用的信号编号。
+  - `sigev_value` 随信号传递的值。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1（`ERROR`）并设置 `errno`：
+
+- `EBADF` `mqdes` 不是有效的描述符。
+- `EBUSY` 另一个任务已注册了该队列的通知。
+- `EINVAL` `sigev_notify` 不是有效值，或信号编号无效。
+- `ENOMEM` 内存不足。
+
+**注意**：
+
+- **与 POSIX 的行为差异**：在 openvela 中，即使有任务正在 `mq_receive()` 上阻塞等待消息，通知信号仍会发送给注册的任务。POSIX 规范要求此时不发送通知（消息直接满足等待的 `mq_receive()`）。
+
+**POSIX 兼容性**：部分兼容 POSIX 同名接口（通知时机与 POSIX 规范有差异）。

--- a/doxygen/api/kernel/sched.md
+++ b/doxygen/api/kernel/sched.md
@@ -1,66 +1,23 @@
-# 调度管理
+# 调度管理 API
 
-openvela 提供了符合 POSIX 标准的任务调度接口，支持多种调度策略和任务管理功能。调度器负责决定哪个任务在何时运行，是操作系统内核的核心组件之一。
+openvela 提供符合 POSIX 标准的任务调度接口，支持多种调度策略和任务管理功能。
 
-## 一、调度策略概述
+头文件：`#include <sched.h>`
 
-openvela 支持以下调度策略：
 
-### 1、SCHED_FIFO（先进先出）
-实时调度策略，不使用时间片。任务一旦获得 CPU 就会持续运行，直到：
-- 主动让出 CPU（`sched_yield()`）
-- 被更高优先级任务抢占
-- 阻塞（等待 I/O、信号量等）
-- 终止
+## openvela 实现说明
 
-同优先级任务按 FIFO 顺序排队等待。这是确定性最强的调度策略，适合硬实时任务。
+- **调度策略**：支持 `SCHED_FIFO`（先进先出）、`SCHED_RR`（轮转，需 `CONFIG_RR_INTERVAL > 0`）、`SCHED_SPORADIC`（零星，需 `CONFIG_SCHED_SPORADIC`）和 `SCHED_OTHER`（映射到 SCHED_FIFO）。
+- **优先级范围**：通常 1~255，数值越大优先级越高。优先级 0 保留给 idle 任务。
+- **返回值风格**：task_* 系列返回负的错误码（如 `-EINVAL`），sched_* 系列遵循 POSIX 标准返回 -1 并设置 `errno`。
+- **SMP 支持**：CPU 亲和性接口需要启用 `CONFIG_SMP`。
+- **task vs pthread**：`task_create()` 创建 openvela 原生任务，`pthread_create()` 创建 POSIX 线程。两者底层共享调度器，但 task 不支持 pthread 特有功能（如 TSD、cleanup handler）。
 
-### 2、SCHED_RR（轮转调度）
-实时调度策略，使用时间片。类似 SCHED_FIFO，但同优先级任务会轮流使用 CPU，每个任务运行一个时间片后轮转到队列末尾。时间片长度可通过 `sched_rr_get_interval()` 查询。
 
-适合需要公平性的实时任务，如多个等优先级的实时线程。
+## 任务管理
 
-### 3、SCHED_SPORADIC（零星调度）
-POSIX.1b 实时扩展定义的调度策略，用于零星服务器。任务有正常优先级和低优先级两个级别，有预算时以正常优先级运行，预算耗尽后降为低优先级。预算会周期性补充。
 
-适合周期性或零星的实时任务，可以限制 CPU 使用率同时保证响应性。
-
-### 4、SCHED_OTHER/SCHED_NORMAL
-默认的分时调度策略，在 openvela 中映射到 SCHED_FIFO 或 SCHED_RR。这是非实时任务的标准策略。
-
-### 5、优先级范围
-
-- 实时优先级（SCHED_FIFO/RR）：由配置决定，通常 1-255
-- 最小优先级：`sched_get_priority_min(policy)`
-- 最大优先级：`sched_get_priority_max(policy)`
-- 数值越大，优先级越高
-
-## 二、SMP 支持
-
-在多核系统上（启用 `CONFIG_SMP`），openvela 支持 CPU 亲和性（affinity）设置，可以将任务绑定到特定 CPU 或 CPU 集合运行，用于负载均衡、缓存优化或隔离关键任务。
-
-openvela 调度管理支持以下 API：
-
-- `task_create()`
-- `task_create_with_stack()`
-- `task_delete()`
-- `task_restart()`
-- `task_setcancelstate()`
-- `task_setcanceltype()`
-- `task_testcancel()`
-- `sched_setparam()`
-- `sched_getparam()`
-- `sched_setscheduler()`
-- `sched_getscheduler()`
-- `sched_yield()`
-- `sched_get_priority_max()`
-- `sched_get_priority_min()`
-- `sched_rr_get_interval()`
-- `sched_getcpu()`
-- `sched_setaffinity()`
-- `sched_getaffinity()`
-
-## 1、task_create
+### task_create
 
 ```c
 int task_create(const char *name, int priority, int stack_size,
@@ -112,7 +69,8 @@ int task_create(const char *name, int priority, int stack_size,
 
 **POSIX 兼容性**：openvela 扩展接口（非 POSIX 标准）。
 
-## 2、task_create_with_stack
+
+### task_create_with_stack
 
 ```c
 int task_create_with_stack(const char *name, int priority,
@@ -223,7 +181,8 @@ int task_create_with_stack(const char *name, int priority,
 
 **POSIX 兼容性**：openvela 扩展接口（非 POSIX 标准，类似于某些 RTOS 的接口）。
 
-## 3、task_delete
+
+### task_delete
 
 ```c
 int task_delete(pid_t pid);
@@ -282,7 +241,8 @@ int task_delete(pid_t pid);
 
 **POSIX 兼容性**：openvela 扩展接口（非 POSIX 标准）。
 
-## 4、task_restart
+
+### task_restart
 
 ```c
 int task_restart(pid_t pid);
@@ -365,7 +325,11 @@ int task_restart(pid_t pid);
 
 **POSIX 兼容性**：openvela 扩展接口（非 POSIX 标准）。
 
-## 5、task_setcancelstate
+
+## 任务取消
+
+
+### task_setcancelstate
 
 ```c
 int task_setcancelstate(int state, int *oldstate);
@@ -438,7 +402,8 @@ int task_setcancelstate(int state, int *oldstate);
 
 **POSIX 兼容性**：类似 `pthread_setcancelstate()`，但适用于所有任务类型。
 
-## 6、task_setcanceltype
+
+### task_setcanceltype
 
 ```c
 int task_setcanceltype(int type, int *oldtype);
@@ -507,7 +472,8 @@ int task_setcanceltype(int type, int *oldtype);
 
 **POSIX 兼容性**：类似 `pthread_setcanceltype()`，但适用于所有任务类型。
 
-## 7、task_testcancel
+
+### task_testcancel
 
 ```c
 void task_testcancel(void);
@@ -588,115 +554,11 @@ void task_testcancel(void);
 
 **POSIX 兼容性**：类似 `pthread_testcancel()`，但适用于所有任务类型。
 
-## 8、sched_setparam
 
-```c
-int sched_setparam(pid_t pid, const struct sched_param *param);
-```
+## 调度策略与参数
 
-修改指定任务的调度参数（主要是优先级），但不改变调度策略。这是调整任务优先级的标准接口，比 `sched_setscheduler()` 更轻量，语义更清晰。
 
-优先级是调度系统中最重要的参数，决定了任务在同一策略下的执行顺序。动态调整优先级是实时系统中常见的需求，例如实现优先级继承或优先级天花板协议。
-
-**参数**：
-
-- `pid` 目标任务的 PID。特殊值 0 表示修改调用任务自身的参数。必须是有效的任务 PID。
-- `param` 指向 `struct sched_param` 结构的指针，包含新的调度参数。主要字段：
-  - `sched_priority`：新的优先级值（必需），必须在当前调度策略的有效范围内
-  - 对于 SCHED_SPORADIC 策略，还包括 `sched_ss_low_priority`、`sched_ss_repl_period`、`sched_ss_init_budget`、`sched_ss_max_repl` 等零星服务器参数
-
-**返回值**：
-
-- 成功：返回 0
-- 失败：返回 -1 并设置 `errno`：
-  - `EINVAL`：`param` 中的优先级超出当前策略允许的范围，或 SCHED_SPORADIC 参数无效
-  - `ESRCH`：指定的任务不存在（PID 无效或任务已终止）
-  - `EPERM`：调用者没有权限修改目标任务的调度参数（通常需要超级用户权限或同一用户）
-  - `EFAULT`：`param` 指向无效内存
-
-**注意**：
-
-- **保持策略不变**：此函数只修改调度参数，不改变调度策略。如果需要同时修改策略和参数，使用 `sched_setscheduler()`。
-- **优先级范围**：每种调度策略有其有效的优先级范围，可以通过 `sched_get_priority_min()` 和 `sched_get_priority_max()` 查询。超出范围会导致 `EINVAL` 错误。
-- **立即生效**：优先级修改立即生效，调度器会重新评估任务优先级：
-  - 如果新优先级更高，任务可能立即抢占当前任务
-  - 如果新优先级更低，任务可能被其他高优先级任务抢占
-  - 对于阻塞任务，新优先级在任务恢复运行时生效
-- **优先级继承**：在实现互斥锁的优先级继承协议时，通常使用此函数临时提升低优先级任务的优先级，避免优先级反转。
-- **典型用法**：
-  ```c
-  struct sched_param param;
-  param.sched_priority = 100;  // 设置新优先级
-  
-  if (sched_setparam(0, &param) == 0) {
-      printf("Priority changed to %d\n", param.sched_priority);
-  } else {
-      perror("sched_setparam");
-  }
-  ```
-- **查询当前参数**：使用 `sched_getparam()` 获取任务当前的调度参数，然后修改需要改变的字段。
-- **实时系统调优**：在实时系统中，根据任务的实际执行情况动态调整优先级，可以优化系统响应性和吞吐量。
-- **权限要求**：修改其他任务的优先级通常需要特权。在嵌入式系统中，通常所有任务运行在同一权限级别，这一限制可能较宽松。
-- **对运行任务的影响**：修改当前运行任务（pid=0）的优先级可能立即触发重新调度，如果系统中有更高优先级的就绪任务。
-- **SCHED_SPORADIC 参数**：对于零星调度任务，`param` 中的其他字段（如 `sched_ss_low_priority`）也可以通过此函数修改，实现动态调整零星服务器行为。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 9、sched_getparam
-
-```c
-int sched_getparam(pid_t pid, struct sched_param *param);
-```
-
-查询指定任务的当前调度参数（主要是优先级）。这是获取任务优先级和其他调度参数的标准接口，常用于监控、调试和动态调度决策。
-
-调度参数包括基本优先级以及特定策略相关的参数（如零星调度的补充周期），了解这些参数有助于理解任务的调度行为。
-
-**参数**：
-
-- `pid` 目标任务的 PID。特殊值 0 表示查询调用任务自身的参数。必须是有效的任务 PID。
-- `param` 指向 `struct sched_param` 结构的指针，用于接收查询结果。函数会填充此结构：
-  - `sched_priority`：任务的基本优先级（始终设置）
-  - 对于 SCHED_SPORADIC 策略，还包括 `sched_ss_low_priority`、`sched_ss_repl_period`、`sched_ss_init_budget`、`sched_ss_max_repl` 等零星服务器参数
-  - 其他策略（SCHED_FIFO、SCHED_RR、SCHED_OTHER）通常只设置 `sched_priority`
-
-**返回值**：
-
-- 成功：返回 0，并在 `param` 中填充任务的调度参数
-- 失败：返回 -1 并设置 `errno`：
-  - `ESRCH`：指定的任务不存在（PID 无效或任务已终止）
-  - `EINVAL`：参数 `pid` 为负值
-  - `EFAULT`：`param` 指向无效内存（NULL 或不可写）
-
-**注意**：
-
-- **只读查询**：此函数不修改任务状态，是纯查询操作，开销很小。
-- **完整调度信息**：通常与 `sched_getscheduler()` 配合使用，获取完整的调度信息（策略 + 参数）：
-  ```c
-  int policy = sched_getscheduler(0);
-  struct sched_param param;
-  sched_getparam(0, &param);
-  printf("Policy: %d, Priority: %d\n", policy, param.sched_priority);
-  ```
-- **典型用法**：
-  ```c
-  struct sched_param param;
-  if (sched_getparam(0, &param) == 0) {
-      printf("Current priority: %d\n", param.sched_priority);
-  } else {
-      perror("sched_getparam");
-  }
-  ```
-- **动态调整参考**：在动态调整优先级前，先用此函数获取当前参数，然后修改特定字段，最后用 `sched_setparam()` 应用更改。
-- **监控工具**：系统监控工具常用此函数显示任务的优先级，帮助分析调度行为和诊断优先级反转等问题。
-- **零星调度参数**：对于 SCHED_SPORADIC 策略的任务，此函数返回完整的零星服务器配置，包括预算、补充周期等。
-- **参数初始化**：在调用前无需初始化 `param` 结构，函数会完全覆盖其内容。但确保 `param` 指向有效内存。
-- **任务诊断**：在调试实时系统时，可以定期查询关键任务的优先级，验证优先级继承等机制是否正常工作。
-- **原子性**：查询操作是原子的，返回的参数是一致的快照，不会出现部分更新的情况。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 10、sched_setscheduler
+### sched_setscheduler
 
 ```c
 int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
@@ -759,9 +621,10 @@ int sched_setscheduler(pid_t pid, int policy, const struct sched_param *param);
 - **原子性**：策略和参数的修改是原子的，不会出现中间状态。
 - **对运行任务的影响**：如果修改当前正在运行的任务（pid=0），调度器会立即重新评估任务优先级，可能导致任务被抢占。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 11、sched_getscheduler
+
+### sched_getscheduler
 
 ```c
 int sched_getscheduler(pid_t pid);
@@ -807,9 +670,123 @@ int sched_getscheduler(pid_t pid);
 - **修改策略**：如果需要修改调度策略，使用 `sched_setscheduler()`。
 - **策略名称映射**：可以使用 switch 或数组将返回的整数值映射为策略名称，提高可读性。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 12、sched_yield
+
+### sched_setparam
+
+```c
+int sched_setparam(pid_t pid, const struct sched_param *param);
+```
+
+修改指定任务的调度参数（主要是优先级），但不改变调度策略。这是调整任务优先级的标准接口，比 `sched_setscheduler()` 更轻量，语义更清晰。
+
+优先级是调度系统中最重要的参数，决定了任务在同一策略下的执行顺序。动态调整优先级是实时系统中常见的需求，例如实现优先级继承或优先级天花板协议。
+
+**参数**：
+
+- `pid` 目标任务的 PID。特殊值 0 表示修改调用任务自身的参数。必须是有效的任务 PID。
+- `param` 指向 `struct sched_param` 结构的指针，包含新的调度参数。主要字段：
+  - `sched_priority`：新的优先级值（必需），必须在当前调度策略的有效范围内
+  - 对于 SCHED_SPORADIC 策略，还包括 `sched_ss_low_priority`、`sched_ss_repl_period`、`sched_ss_init_budget`、`sched_ss_max_repl` 等零星服务器参数
+
+**返回值**：
+
+- 成功：返回 0
+- 失败：返回 -1 并设置 `errno`：
+  - `EINVAL`：`param` 中的优先级超出当前策略允许的范围，或 SCHED_SPORADIC 参数无效
+  - `ESRCH`：指定的任务不存在（PID 无效或任务已终止）
+  - `EPERM`：调用者没有权限修改目标任务的调度参数（通常需要超级用户权限或同一用户）
+  - `EFAULT`：`param` 指向无效内存
+
+**注意**：
+
+- **保持策略不变**：此函数只修改调度参数，不改变调度策略。如果需要同时修改策略和参数，使用 `sched_setscheduler()`。
+- **优先级范围**：每种调度策略有其有效的优先级范围，可以通过 `sched_get_priority_min()` 和 `sched_get_priority_max()` 查询。超出范围会导致 `EINVAL` 错误。
+- **立即生效**：优先级修改立即生效，调度器会重新评估任务优先级：
+  - 如果新优先级更高，任务可能立即抢占当前任务
+  - 如果新优先级更低，任务可能被其他高优先级任务抢占
+  - 对于阻塞任务，新优先级在任务恢复运行时生效
+- **优先级继承**：在实现互斥锁的优先级继承协议时，通常使用此函数临时提升低优先级任务的优先级，避免优先级反转。
+- **典型用法**：
+  ```c
+  struct sched_param param;
+  param.sched_priority = 100;  // 设置新优先级
+  
+  if (sched_setparam(0, &param) == 0) {
+      printf("Priority changed to %d\n", param.sched_priority);
+  } else {
+      perror("sched_setparam");
+  }
+  ```
+- **查询当前参数**：使用 `sched_getparam()` 获取任务当前的调度参数，然后修改需要改变的字段。
+- **实时系统调优**：在实时系统中，根据任务的实际执行情况动态调整优先级，可以优化系统响应性和吞吐量。
+- **权限要求**：修改其他任务的优先级通常需要特权。在嵌入式系统中，通常所有任务运行在同一权限级别，这一限制可能较宽松。
+- **对运行任务的影响**：修改当前运行任务（pid=0）的优先级可能立即触发重新调度，如果系统中有更高优先级的就绪任务。
+- **SCHED_SPORADIC 参数**：对于零星调度任务，`param` 中的其他字段（如 `sched_ss_low_priority`）也可以通过此函数修改，实现动态调整零星服务器行为。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sched_getparam
+
+```c
+int sched_getparam(pid_t pid, struct sched_param *param);
+```
+
+查询指定任务的当前调度参数（主要是优先级）。这是获取任务优先级和其他调度参数的标准接口，常用于监控、调试和动态调度决策。
+
+调度参数包括基本优先级以及特定策略相关的参数（如零星调度的补充周期），了解这些参数有助于理解任务的调度行为。
+
+**参数**：
+
+- `pid` 目标任务的 PID。特殊值 0 表示查询调用任务自身的参数。必须是有效的任务 PID。
+- `param` 指向 `struct sched_param` 结构的指针，用于接收查询结果。函数会填充此结构：
+  - `sched_priority`：任务的基本优先级（始终设置）
+  - 对于 SCHED_SPORADIC 策略，还包括 `sched_ss_low_priority`、`sched_ss_repl_period`、`sched_ss_init_budget`、`sched_ss_max_repl` 等零星服务器参数
+  - 其他策略（SCHED_FIFO、SCHED_RR、SCHED_OTHER）通常只设置 `sched_priority`
+
+**返回值**：
+
+- 成功：返回 0，并在 `param` 中填充任务的调度参数
+- 失败：返回 -1 并设置 `errno`：
+  - `ESRCH`：指定的任务不存在（PID 无效或任务已终止）
+  - `EINVAL`：参数 `pid` 为负值
+  - `EFAULT`：`param` 指向无效内存（NULL 或不可写）
+
+**注意**：
+
+- **只读查询**：此函数不修改任务状态，是纯查询操作，开销很小。
+- **完整调度信息**：通常与 `sched_getscheduler()` 配合使用，获取完整的调度信息（策略 + 参数）：
+  ```c
+  int policy = sched_getscheduler(0);
+  struct sched_param param;
+  sched_getparam(0, &param);
+  printf("Policy: %d, Priority: %d\n", policy, param.sched_priority);
+  ```
+- **典型用法**：
+  ```c
+  struct sched_param param;
+  if (sched_getparam(0, &param) == 0) {
+      printf("Current priority: %d\n", param.sched_priority);
+  } else {
+      perror("sched_getparam");
+  }
+  ```
+- **动态调整参考**：在动态调整优先级前，先用此函数获取当前参数，然后修改特定字段，最后用 `sched_setparam()` 应用更改。
+- **监控工具**：系统监控工具常用此函数显示任务的优先级，帮助分析调度行为和诊断优先级反转等问题。
+- **零星调度参数**：对于 SCHED_SPORADIC 策略的任务，此函数返回完整的零星服务器配置，包括预算、补充周期等。
+- **参数初始化**：在调用前无需初始化 `param` 结构，函数会完全覆盖其内容。但确保 `param` 指向有效内存。
+- **任务诊断**：在调试实时系统时，可以定期查询关键任务的优先级，验证优先级继承等机制是否正常工作。
+- **原子性**：查询操作是原子的，返回的参数是一致的快照，不会出现部分更新的情况。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+## 调度控制
+
+
+### sched_yield
 
 ```c
 int sched_yield(void);
@@ -862,9 +839,10 @@ int sched_yield(void);
 - **时间片重置**：对于 SCHED_RR 策略，`sched_yield()` 会重置时间片，相当于任务自愿放弃当前时间片。
 - **不可中断**：即使调用 `sched_yield()` 后立即返回，也会发生上下文切换检查，调度器会重新评估调度决策。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 13、sched_get_priority_max
+
+### sched_get_priority_max
 
 ```c
 int sched_get_priority_max(int policy);
@@ -923,9 +901,10 @@ int sched_get_priority_max(int policy);
 - **实时任务配置**：在配置关键实时任务时，通常使用接近最大值的优先级，以确保任务能抢占其他任务。
 - **优先级分层**：在复杂系统中，可以将优先级范围分为几个层次（如系统层、驱动层、应用层），每层使用不同的优先级子范围。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 14、sched_get_priority_min
+
+### sched_get_priority_min
 
 ```c
 int sched_get_priority_min(int policy);
@@ -984,15 +963,10 @@ int sched_get_priority_min(int policy);
 - **策略无关性**：在 openvela 中，通常所有实时策略共享相同的优先级空间，因此最小值也相同。
 - **调试工具**：使用这些函数可以编写通用的优先级检查工具，验证系统中所有任务的优先级配置是否合理。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-**返回值**：
 
-返回指定调度策略的最小优先级值，失败时返回 -1 并设置 `errno`。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 15、sched_rr_get_interval
+### sched_rr_get_interval
 
 ```c
 int sched_rr_get_interval(pid_t pid, struct timespec *interval);
@@ -1041,9 +1015,106 @@ int sched_rr_get_interval(pid_t pid, struct timespec *interval);
 - **调用 sched_yield()**：对于 SCHED_RR 任务，调用 `sched_yield()` 会重置时间片计数器。
 - **非 SCHED_RR 任务**：即使任务当前不是 SCHED_RR 策略，此函数通常也会成功返回系统默认的时间片值，但此值对非 SCHED_RR 任务无实际意义。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 16、sched_getcpu
+
+### sched_lock
+
+```c
+void sched_lock(void);
+```
+
+禁止任务调度（抢占）。调用后，当前任务不会被其他同优先级或更高优先级的任务抢占，直到调用 `sched_unlock()` 恢复调度。支持嵌套调用，每次 `sched_lock()` 必须对应一次 `sched_unlock()`。
+
+**参数**：
+
+无参数。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- **嵌套支持**：`sched_lock()` 维护一个锁计数器，每次调用递增，`sched_unlock()` 递减。只有计数器归零时才真正恢复调度。
+- **中断不受影响**：`sched_lock()` 只禁止任务级抢占，不禁止中断。中断处理程序仍然可以执行。
+- **与关中断的区别**：
+  - `sched_lock()`：禁止任务切换，中断仍可响应
+  - `enter_critical_section()`：禁止中断，更强的保护但延迟更大
+- **典型用法**：
+  ```c
+  sched_lock();
+  // 临界区：不会被其他任务抢占
+  update_shared_data();
+  sched_lock();  // 嵌套调用
+  do_more_work();
+  sched_unlock(); // 计数器减 1，仍然锁定
+  sched_unlock(); // 计数器归零，恢复调度
+  ```
+- **SMP 注意**：在多核系统中，`sched_lock()` 只保护当前 CPU 上的调度，其他 CPU 上的任务仍可运行。如需跨核保护，应使用自旋锁或其他 SMP 同步机制。
+- **避免长时间持有**：长时间禁止调度会影响系统实时性，应尽量缩短临界区。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口（非 POSIX 标准）。
+
+
+### sched_unlock
+
+```c
+void sched_unlock(void);
+```
+
+恢复任务调度（抢占）。递减调度锁计数器，当计数器归零时恢复正常调度。必须与 `sched_lock()` 配对使用。
+
+**参数**：
+
+无参数。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 每次 `sched_unlock()` 对应一次 `sched_lock()`，不能多调用。
+- 计数器归零时，如果有更高优先级的任务就绪，会立即发生任务切换。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口（非 POSIX 标准）。
+
+
+### sched_lockcount
+
+```c
+int sched_lockcount(void);
+```
+
+查询当前任务的调度锁嵌套计数。返回值表示 `sched_lock()` 被调用但尚未被 `sched_unlock()` 匹配的次数。
+
+**参数**：
+
+无参数。
+
+**返回值**：
+
+返回当前任务的调度锁计数（非负整数）。0 表示调度未被锁定。
+
+**注意**：
+
+- 主要用于调试，验证 `sched_lock()` / `sched_unlock()` 是否正确配对。
+- 典型用法：
+  ```c
+  int count = sched_lockcount();
+  if (count > 0) {
+      printf("Scheduler locked, count=%d\n", count);
+  }
+  ```
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口（非 POSIX 标准）。
+
+
+## CPU 亲和性
+
+
+### sched_getcpu
 
 ```c
 int sched_getcpu(void);
@@ -1099,7 +1170,8 @@ int sched_getcpu(void);
 
 **POSIX 兼容性**：兼容 Linux 扩展接口（非 POSIX 标准，但广泛支持）。
 
-## 17、sched_setaffinity
+
+### sched_setaffinity
 
 ```c
 int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
@@ -1175,7 +1247,8 @@ CPU 亲和性允许将任务绑定到特定的 CPU 核心，这在优化缓存�
 
 **POSIX 兼容性**：兼容 Linux 扩展接口（非 POSIX 标准，但广泛支持）。
 
-## 18、sched_getaffinity
+
+### sched_getaffinity
 
 ```c
 int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
@@ -1265,3 +1338,85 @@ int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 
 **POSIX 兼容性**：兼容 Linux 扩展接口（非 POSIX 标准，但广泛支持）。
 
+
+### sched_cpucount
+
+```c
+int sched_cpucount(const cpu_set_t *set);
+```
+
+统计 CPU 集合中包含的 CPU 数量。等价于 Linux 的 `CPU_COUNT()` 宏。
+
+**参数**：
+
+- `set` 指向 CPU 集合。
+
+**返回值**：
+
+返回集合中被设置的 CPU 数量。
+
+**注意**：
+
+- 在非 SMP 系统中，宏定义为始终返回 1。
+- 典型用法：
+  ```c
+  cpu_set_t set;
+  sched_getaffinity(0, sizeof(set), &set);
+  printf("Can run on %d CPUs\n", sched_cpucount(&set));
+  ```
+
+**POSIX 兼容性**：兼容 Linux 扩展接口（非 POSIX 标准）。
+
+
+## 调试与诊断
+
+
+### sched_backtrace
+
+```c
+int sched_backtrace(pid_t tid, void **buffer, int size, int skip);
+```
+
+获取指定任务的调用栈回溯信息。将栈帧地址存入 `buffer` 数组，用于调试和崩溃分析。
+
+**参数**：
+
+- `tid` 目标任务的 PID。0 表示当前任务。
+- `buffer` 指向指针数组，用于存储栈帧地址。
+- `size` `buffer` 数组的最大容量（元素个数）。
+- `skip` 跳过的栈帧数（从栈顶开始），用于过滤调试框架本身的栈帧。
+
+**返回值**：
+
+返回实际获取的栈帧数（非负整数）。如果返回值等于 `size`，可能还有更多栈帧未获取。
+
+**注意**：
+
+- 需要启用 `CONFIG_SCHED_BACKTRACE` 配置。未启用时，宏定义为返回 0。
+- 获取其他任务的调用栈时，目标任务应处于阻塞状态，否则结果可能不准确。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口（非 POSIX 标准）。
+
+
+### sched_dumpstack
+
+```c
+void sched_dumpstack(pid_t tid);
+```
+
+打印指定任务的调用栈到系统日志。内部调用 `sched_backtrace()` 获取栈帧，然后格式化输出。
+
+**参数**：
+
+- `tid` 目标任务的 PID。0 表示当前任务。
+
+**返回值**：
+
+无返回值。
+
+**注意**：
+
+- 主要用于调试和崩溃分析，输出到系统日志（syslog）。
+- 需要启用 `CONFIG_SCHED_BACKTRACE` 配置。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口（非 POSIX 标准）。

--- a/doxygen/api/kernel/signal.md
+++ b/doxygen/api/kernel/signal.md
@@ -1,72 +1,42 @@
-# 信号机制
+# 信号 API
 
-openvela 提供完整的 POSIX 信号机制，用于进程和线程间的异步通信和事件通知。信号是一种软件中断机制，允许内核或其他进程向目标进程发送异步通知，通知其发生了特定事件。
+openvela 提供完整的 POSIX 信号机制，用于进程和线程间的异步通信和事件通知。
 
-## 一、信号概述
+头文件：`#include <signal.h>`
 
-信号是 Unix/Linux 系统中最古老的进程间通信（IPC）机制之一。当信号被发送给进程时，进程的正常执行流程会被中断，转而执行信号处理函数（signal handler）。信号处理完成后，进程恢复到被中断的位置继续执行，除非信号的默认动作是终止进程。
+## openvela 实现说明
 
-### 1、信号类型
+- **信号范围**：标准信号 1~31，实时信号 `SIGRTMIN`(32) ~ `SIGRTMAX`(63)
+- **默认动作**：在 openvela 中，大多数信号的默认动作是忽略（与 Linux 不同），除非启用了相应配置
+- **实时信号特性**：支持排队、携带附加数据（`sigqueue`）、按 FIFO 顺序递送
+- **`SIGKILL`/`SIGSTOP`**：不可捕获、阻塞或忽略
+- **信号栈**：`sigaltstack()` 当前不支持 `SS_ONSTACK`，仅支持 `SS_DISABLE`
+- **已废弃接口**：`signal()`、`sighold()`、`sigrelse()`、`sigignore()`、`sigset()`、`sigpause()` 为旧式接口，建议使用 `sigaction()` 和 `sigprocmask()` 替代
 
-openvela 支持两类信号：
+## 信号概述
 
-1. **标准信号**（信号 1-31）：传统的 POSIX 信号，如 `SIGINT`、`SIGTERM`、`SIGKILL`、`SIGCHLD` 等。
-   - 不排队：同一信号发送多次，可能只递送一次
-   - 不携带额外数据
-   - 大多数有预定义的默认动作
+信号是一种软件中断机制，允许内核或其他进程向目标进程发送异步通知。
 
-2. **实时信号**（`SIGRTMIN`=32 到 `SIGRTMAX`=63）：POSIX.1b 实时扩展引入的信号。
-   - 支持排队：多次发送会排队等待递送
-   - 可携带附加数据（整数或指针）
-   - 按 FIFO 顺序递送
-   - 默认动作是忽略
+### 信号类型
 
-### 2、信号处理方式
+1. **标准信号**（1~31）：不排队，不携带额外数据，大多数有预定义默认动作
+2. **实时信号**（`SIGRTMIN`~`SIGRTMAX`）：支持排队，可携带附加数据，按 FIFO 递送
 
-进程对信号可以采取三种处理方式：
+### 信号处理方式
 
-1. **忽略信号**（`SIG_IGN`）：信号被丢弃，不产生任何影响。`SIGKILL` 和 `SIGSTOP` 不能被忽略。
-2. **默认处理**（`SIG_DFL`）：执行信号的默认动作，通常是终止进程、忽略或停止进程。在 openvela 中，大多数信号的默认动作是忽略（除非启用了相应的配置选项）。
-3. **自定义处理**：注册信号处理函数，在信号到达时执行用户定义的代码。
+1. **忽略**（`SIG_IGN`）：信号被丢弃
+2. **默认处理**（`SIG_DFL`）：执行默认动作
+3. **自定义处理**：注册信号处理函数
 
-### 3、信号掩码和阻塞
+### 信号掩码
 
-每个线程都有自己的信号掩码（signal mask），用于指定哪些信号当前被阻塞。被阻塞的信号不会被递送，而是保持挂起状态（pending），直到解除阻塞。这允许临界区代码暂时屏蔽信号，避免被中断。
+每个线程有独立的信号掩码，被阻塞的信号保持挂起状态直到解除阻塞。
 
-### 4、应用场景
 
-信号常用于以下场景：
+## 信号发送
 
-- **进程控制**：终止、暂停、继续进程（`SIGTERM`、`SIGKILL`、`SIGSTOP`、`SIGCONT`）
-- **错误通知**：硬件异常、非法操作（`SIGSEGV`、`SIGFPE`、`SIGILL`）
-- **定时器通知**：定时器到期（`SIGALRM`）
-- **异步 I/O 通知**：数据就绪通知（`SIGIO`、`SIGPOLL`）
-- **子进程状态变化**：子进程终止或停止（`SIGCHLD`）
-- **用户自定义事件**：应用程序特定的通知（`SIGUSR1`、`SIGUSR2`、实时信号）
 
-openvela 信号机制支持以下 API：
-
-- `kill()`
-- `raise()`
-- `sigaction()`
-- `sigprocmask()`
-- `sigpending()`
-- `sigsuspend()`
-- `sigwait()`
-- `sigwaitinfo()`
-- `sigtimedwait()`
-- `sigqueue()`
-- `sigemptyset()`
-- `sigfillset()`
-- `sigaddset()`
-- `sigdelset()`
-- `sigismember()`
-- `signal()`
-- `sigaltstack()`
-- `pthread_kill()`
-- `pthread_sigmask()`
-
-## 1、kill
+### kill
 
 ```c
 int kill(pid_t pid, int signo);
@@ -103,9 +73,10 @@ int kill(pid_t pid, int signo);
 - 向进程组发送信号时，如果进程组为空或所有进程都无权访问，会返回 `ESRCH` 错误。
 - 某些信号有特殊的语义，例如 `SIGCHLD` 通知父进程子进程状态变化，`SIGPIPE` 在向已关闭的管道写入时产生。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 2、killpg
+
+### killpg
 
 ```c
 int killpg(pid_t pgrp, int signo);
@@ -126,9 +97,10 @@ int killpg(pid_t pgrp, int signo);
 - `ESRCH` 指定的进程组不存在。
 - `EPERM` 没有权限向目标进程组发送信号。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 3、tgkill
+
+### tgkill
 
 ```c
 int tgkill(pid_t pid, pid_t tid, int signo);
@@ -157,7 +129,8 @@ int tgkill(pid_t pid, pid_t tid, int signo);
 
 **POSIX 兼容性**：兼容 Linux 扩展接口。
 
-## 4、raise
+
+### raise
 
 ```c
 int raise(int signo);
@@ -194,316 +167,10 @@ int raise(int signo);
   - `raise(SIGTERM)` - 自我终止
   - `raise(SIGUSR1)` - 触发用户定义的信号处理
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 5、sigaction
 
-```c
-int sigaction(int signo, const struct sigaction *act, struct sigaction *oact);
-```
-
-设置或查询信号的处理动作。这是设置信号处理器的首选方法，比 `signal()` 提供更多控制和更可预测的行为。`sigaction()` 是 POSIX 标准推荐的信号处理接口。
-
-`struct sigaction` 结构允许精确控制信号处理行为，包括处理函数、信号掩码、各种标志等。这比简单的 `signal()` 接口更强大和灵活。
-
-**参数**：
-
-- `signo` 要设置的信号编号（1-63）。不能是 `SIGKILL`（9）或 `SIGSTOP`（19），因为这两个信号的处理动作不能被修改。
-- `act` 指向新的信号处理动作结构。如果为 `NULL`，则不修改当前处理动作，仅通过 `oact` 查询。结构字段：
-  - `sa_handler` 或 `sa_sigaction`：信号处理函数
-    - `SIG_DFL`：恢复默认处理动作
-    - `SIG_IGN`：忽略该信号
-    - 函数指针：自定义处理函数
-  - `sa_mask`：信号掩码，指定在执行处理函数期间要额外阻塞的信号集。处理的信号本身会自动阻塞（除非设置 `SA_NODEFER`）。
-  - `sa_flags`：控制信号处理行为的标志（见下文）
-- `oact` 指向保存旧处理动作的结构。如果为 `NULL`，则不返回旧动作。可用于保存并稍后恢复原处理动作。
-
-**`sa_flags` 标志说明**：
-
-- `SA_SIGINFO` (0x02)：使用扩展的三参数处理函数 `sa_sigaction(int sig, siginfo_t *info, void *context)`，而不是简单的 `sa_handler(int sig)`。这允许获取信号的详细信息（发送者 PID、信号值等）。
-- `SA_RESTART` (0x10)：被信号中断的系统调用自动重启，而不是返回 `EINTR` 错误。这简化了错误处理，避免需要手动重试中断的系统调用。
-- `SA_NODEFER` (0x20)：不自动阻塞正在处理的信号。默认情况下，处理信号 X 时会阻塞信号 X，防止递归。设置此标志后允许信号处理函数递归调用。
-- `SA_RESETHAND` (0x40)：信号递送后自动重置处理动作为 `SIG_DFL`（一次性处理器）。类似于旧的不可靠信号语义。
-- `SA_ONSTACK` (0x08)：在备用信号栈上执行处理函数（需要先用 `sigaltstack()` 设置）。用于避免栈溢出信号处理器自身溢出栈。
-- `SA_NOCLDSTOP` (0x01)：如果 `signo` 是 `SIGCHLD`，则子进程停止（`SIGSTOP`）或继续（`SIGCONT`）时不产生信号，只在终止时产生。
-- `SA_NOCLDWAIT` (0x04)：如果 `signo` 是 `SIGCHLD`，子进程终止时自动回收，不产生僵尸进程，父进程无需调用 `wait()`。
-
-**返回值**：
-
-成功时返回 0，失败时返回 -1 并设置 `errno`：
-
-- `EINVAL` `signo` 无效，或尝试修改 `SIGKILL`/`SIGSTOP` 的处理动作。
-- `EFAULT` `act` 或 `oact` 指向无效内存地址（段错误）。
-
-**注意**：
-
-- 信号处理函数应尽量简短和高效，避免调用不可重入函数（如 `malloc()`、`printf()`）。只应调用异步信号安全（async-signal-safe）的函数。
-- `sa_mask` 在处理函数执行期间生效，处理函数返回后自动恢复原信号掩码。
-- 多次调用 `sigaction()` 修改同一信号的处理动作是安全的，新动作会覆盖旧动作。
-- 如果需要临时修改并恢复信号处理，模式为：
-  ```c
-  struct sigaction old_act;
-  sigaction(SIGINT, &new_act, &old_act);  // 设置新处理
-  // ... 做某些操作 ...
-  sigaction(SIGINT, &old_act, NULL);       // 恢复旧处理
-  ```
-- 在信号处理函数中修改全局变量时，应将其声明为 `volatile sig_atomic_t` 类型，确保原子性和可见性。
-- 使用 `SA_SIGINFO` 标志可以获取信号的详细信息，如发送者 PID、信号携带的数据等，这对于调试和高级信号处理很有用。
-- `sa_mask` 中应包含所有在处理函数执行期间需要阻塞的信号，防止信号处理函数被其他信号中断导致的竞态条件。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 6、signal
-
-```c
-sighandler_t signal(int signo, sighandler_t handler);
-```
-
-设置信号的处理函数。这是 `sigaction()` 的简化版本，但行为在不同系统上可能有差异，建议使用 `sigaction()`。
-
-**参数**：
-
-- `signo` 信号编号。不能是 `SIGKILL` 或 `SIGSTOP`。
-- `handler` 信号处理函数：
-  - `SIG_IGN` 忽略该信号。
-  - `SIG_DFL` 使用默认处理动作。
-  - 用户定义的函数指针，原型为 `void handler(int signo)`。
-
-**返回值**：
-
-成功时返回之前的信号处理函数，失败时返回 `SIG_ERR` 并设置 `errno`。
-
-**注意**：
-
-- 信号处理函数应尽量简短，只调用异步信号安全的函数。
-- 在 openvela 中，`signal()` 的行为与 BSD 语义一致：信号处理后不会重置为默认，系统调用会自动重启。
-- 对于需要精确控制信号行为的场景，建议使用 `sigaction()`。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 7、sigprocmask
-
-```c
-int sigprocmask(int how, const sigset_t *set, sigset_t *oset);
-```
-
-设置或查询调用线程的信号掩码（signal mask）。信号掩码决定哪些信号当前被阻塞。被阻塞的信号不会被递送给进程，而是保持挂起状态（pending），直到从信号掩码中移除（解除阻塞）。
-
-信号掩码是线程局部的，每个线程维护自己独立的信号掩码。新创建的线程继承创建者的信号掩码。阻塞信号可以保护临界区代码不被信号中断，是编写健壮信号处理代码的重要工具。
-
-**参数**：
-
-- `how` 指定如何修改信号掩码，必须是以下值之一：
-  - `SIG_BLOCK` (1)：将 `set` 中的信号添加到当前掩码。新掩码 = 旧掩码 ∪ `set`。用于阻塞更多信号。
-  - `SIG_UNBLOCK` (2)：从当前掩码中移除 `set` 中的信号。新掩码 = 旧掩码 - `set`。用于解除阻塞。
-  - `SIG_SETMASK` (3)：将当前掩码完全替换为 `set`。新掩码 = `set`。用于设置精确的信号掩码。
-- `set` 要操作的信号集。如果为 `NULL`，则不修改当前掩码，仅通过 `oset` 查询当前掩码（此时 `how` 参数被忽略）。信号集应先用 `sigemptyset()`、`sigfillset()`、`sigaddset()` 等函数初始化和设置。
-- `oset` 如果非 `NULL`，返回操作前的信号掩码（旧值）。可用于保存当前掩码以便稍后恢复。如果只想查询不修改，可设置 `set=NULL`。
-
-**返回值**：
-
-成功时返回 0，失败时返回 -1 并设置 `errno`：
-
-- `EINVAL` `how` 参数值无效（不是 `SIG_BLOCK`、`SIG_UNBLOCK` 或 `SIG_SETMASK`）。
-- `EFAULT` `set` 或 `oset` 指向无效内存地址。
-
-**注意**：
-
-- `SIGKILL`（9）和 `SIGSTOP`（19）无法被阻塞，尝试阻塞它们会被静默忽略（不返回错误）。这确保进程始终可以被终止或停止。
-- 在多线程程序中，每个线程有独立的信号掩码，`sigprocmask()` 只影响调用线程。对于多线程程序，POSIX 标准建议使用 `pthread_sigmask()`（功能完全相同，但返回错误码而非设置 `errno`）。
-- 解除阻塞信号后，如果该信号处于挂起状态，会立即递送（在 `sigprocmask()` 返回前）。
-- 阻塞信号期间，同一信号发送多次只会有一个实例挂起（标准信号不排队）。实时信号（`SIGRTMIN`-`SIGRTMAX`）支持排队。
-- 典型使用模式 - 临界区保护：
-  ```c
-  sigset_t new_mask, old_mask;
-  sigemptyset(&new_mask);
-  sigaddset(&new_mask, SIGINT);
-  sigaddset(&new_mask, SIGTERM);
-  
-  // 进入临界区，阻塞信号
-  sigprocmask(SIG_BLOCK, &new_mask, &old_mask);
-  
-  // 临界区代码，不会被 SIGINT/SIGTERM 中断
-  // ...
-  
-  // 离开临界区，恢复信号掩码
-  sigprocmask(SIG_SETMASK, &old_mask, NULL);
-  ```
-- 信号掩码在 `fork()` 后被子进程继承，但在 `exec()` 后重置为空（所有信号解除阻塞）。
-- 信号掩码不影响信号处理动作的设置，只影响信号的递送。即使信号被阻塞，仍可以用 `sigaction()` 修改其处理动作。
-- 可以通过 `sigpending()` 查询当前哪些信号被阻塞且正在挂起。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 8、sigpending
-
-```c
-int sigpending(sigset_t *set);
-```
-
-获取当前被阻塞且正在挂起（待处理）的信号集。这些信号已经被发送给进程，但因为被阻塞而尚未递送。
-
-**参数**：
-
-- `set` 用于返回挂起信号集的指针。
-
-**返回值**：
-
-成功时返回 0，失败时返回 -1 并设置 `errno`。
-
-**注意**：
-
-- 可用于检查在解除阻塞前是否有信号等待处理。
-- 配合 `sigismember()` 检查特定信号是否挂起。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 9、sigsuspend
-
-```c
-int sigsuspend(const sigset_t *mask);
-```
-
-临时替换信号掩码并挂起任务，直到收到未被阻塞的信号。这是一个原子操作，避免了分别调用 `sigprocmask()` 和 `pause()` 之间的竞态条件。
-
-**参数**：
-
-- `mask` 临时信号掩码。在等待期间，进程的信号掩码会被替换为此值。
-
-**返回值**：
-
-总是返回 -1，`errno` 设置为 `EINTR`（被信号中断）。
-
-**注意**：
-
-- 函数返回后，信号掩码会自动恢复为调用前的值。
-- 常用于等待特定信号，同时不阻塞该信号。
-- 示例：解除阻塞 `SIGUSR1` 并等待它：
-  ```c
-  sigset_t mask;
-  sigemptyset(&mask);  // 只解除阻塞 SIGUSR1
-  sigsuspend(&mask);   // 等待任意信号
-  ```
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 10、sigwait
-
-```c
-int sigwait(const sigset_t *set, int *sig);
-```
-
-同步等待信号集 `set` 中的任意信号到达。这是以同步方式处理信号的关键函数，允许将信号作为普通事件处理，而不是异步中断。
-
-与异步信号处理不同，`sigwait()` 将信号转换为同步事件：线程主动等待信号，信号到达时函数返回信号编号，而不是调用信号处理函数。这大大简化了信号处理，避免了异步信号处理的复杂性（如可重入性、竞态条件等）。
-
-典型用法是创建专门的信号处理线程，阻塞感兴趣的信号，然后循环调用 `sigwait()` 等待并处理信号。
-
-**参数**：
-
-- `set` 要等待的信号集。通常应先使用 `sigprocmask()` 或 `pthread_sigmask()` 阻塞这些信号，否则信号可能被异步处理函数捕获而不是 `sigwait()` 接收。必须包含至少一个有效信号。
-- `sig` 返回接收到的信号编号（输出参数）。如果等待多个信号，无法预测哪个信号先到达，需要根据返回的编号进行处理。
-
-**返回值**：
-
-成功时返回 0，失败时返回错误码（注意：不设置 `errno`，直接返回错误码）：
-
-- `EINVAL` `set` 包含无效的信号编号（<= 0 或 > `MAX_SIGNO`）。
-- `EINTR` 被未在 `set` 中的信号中断（某些实现，openvela 通常不会返回此错误）。
-
-**注意**：
-
-- **关键**：等待的信号必须被阻塞。否则信号可能在 `sigwait()` 调用前或期间被信号处理函数捕获，导致 `sigwait()` 错过信号。推荐模式：
-  ```c
-  sigset_t set;
-  sigemptyset(&set);
-  sigaddset(&set, SIGUSR1);
-  sigaddset(&set, SIGUSR2);
-  
-  // 先阻塞信号
-  pthread_sigmask(SIG_BLOCK, &set, NULL);
-  
-  // 然后等待
-  int sig;
-  while (1) {
-      sigwait(&set, &sig);
-      switch (sig) {
-          case SIGUSR1: /* 处理 SIGUSR1 */ break;
-          case SIGUSR2: /* 处理 SIGUSR2 */ break;
-      }
-  }
-  ```
-- `sigwait()` 从挂起信号队列中移除信号，不会触发信号处理函数。即使注册了信号处理函数，`sigwait()` 接收的信号也不会调用处理函数。
-- 如果多个线程同时等待同一信号，只有一个线程会接收到信号（由系统选择）。
-- 如果信号已经挂起（在调用 `sigwait()` 前到达），函数会立即返回，不会阻塞。
-- `sigwait()` 是取消点（cancellation point）：如果线程被取消（`pthread_cancel()`），函数会立即返回。
-- 相比异步信号处理，同步等待的优势：
-  - 不需要考虑函数可重入性
-  - 可以使用普通的 C 库函数（malloc、printf 等）
-  - 不需要使用 `volatile sig_atomic_t` 类型
-  - 更容易推理和调试
-- 常用于实现信号处理线程模式：主线程和工作线程阻塞所有信号，专门的信号线程循环调用 `sigwait()` 处理信号。
-- 标准信号不排队，如果同一信号发送多次，可能只有一个实例被 `sigwait()` 接收。实时信号支持排队。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 11、sigwaitinfo
-
-```c
-int sigwaitinfo(const sigset_t *set, siginfo_t *info);
-```
-
-等待 `set` 中的任意信号，并获取信号的详细信息。与 `sigwait()` 类似，但提供更多信号信息。
-
-**参数**：
-
-- `set` 要等待的信号集。
-- `info` 如果非 `NULL`，返回信号的详细信息，包括：
-  - `si_signo` 信号编号。
-  - `si_code` 信号来源代码（如 `SI_USER`、`SI_QUEUE`、`SI_TIMER`）。
-  - `si_pid` 发送进程的 PID。
-  - `si_value` 随信号传递的数据（用于 `sigqueue()` 发送的信号）。
-
-**返回值**：
-
-成功时返回信号编号，失败时返回 -1 并设置 `errno`。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 12、sigtimedwait
-
-```c
-int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout);
-```
-
-等待 `set` 中的任意信号，带超时限制。在指定时间内如果没有信号到达，函数返回错误。
-
-**参数**：
-
-- `set` 要等待的信号集。
-- `info` 如果非 `NULL`，返回信号的详细信息。
-- `timeout` 超时时间：
-  - `tv_sec` 秒数。
-  - `tv_nsec` 纳秒数。
-  - 如果为 `NULL`，则无限等待（等效于 `sigwaitinfo()`）。
-  - 如果为 `{0, 0}`，则立即返回（轮询模式）。
-
-**返回值**：
-
-成功时返回信号编号，失败时返回 -1 并设置 `errno`：
-
-- `EAGAIN` 超时时间内没有信号到达。
-- `EINTR` 被其他（未在 `set` 中的）信号中断。
-- `EINVAL` `timeout` 参数无效（如负值）。
-
-**注意**：
-
-- 常用于实现有超时的信号等待逻辑。
-- 结合实时信号使用，可以实现可靠的事件通知机制。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 13、sigqueue
+### sigqueue
 
 ```c
 int sigqueue(int pid, int signo, const union sigval value);
@@ -576,9 +243,172 @@ int sigqueue(int pid, int signo, const union sigval value);
   - 如果需要携带数据或使用实时信号，用 `sigqueue()`
 - `sigqueue()` 设置 `siginfo_t` 的 `si_code` 为 `SI_QUEUE`，可用于区分信号来源。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 14、sigemptyset
+
+## 信号处理设置
+
+
+### sigaction
+
+```c
+int sigaction(int signo, const struct sigaction *act, struct sigaction *oact);
+```
+
+设置或查询信号的处理动作。这是设置信号处理器的首选方法，比 `signal()` 提供更多控制和更可预测的行为。`sigaction()` 是 POSIX 标准推荐的信号处理接口。
+
+`struct sigaction` 结构允许精确控制信号处理行为，包括处理函数、信号掩码、各种标志等。这比简单的 `signal()` 接口更强大和灵活。
+
+**参数**：
+
+- `signo` 要设置的信号编号（1-63）。不能是 `SIGKILL`（9）或 `SIGSTOP`（19），因为这两个信号的处理动作不能被修改。
+- `act` 指向新的信号处理动作结构。如果为 `NULL`，则不修改当前处理动作，仅通过 `oact` 查询。结构字段：
+  - `sa_handler` 或 `sa_sigaction`：信号处理函数
+    - `SIG_DFL`：恢复默认处理动作
+    - `SIG_IGN`：忽略该信号
+    - 函数指针：自定义处理函数
+  - `sa_mask`：信号掩码，指定在执行处理函数期间要额外阻塞的信号集。处理的信号本身会自动阻塞（除非设置 `SA_NODEFER`）。
+  - `sa_flags`：控制信号处理行为的标志（见下文）
+- `oact` 指向保存旧处理动作的结构。如果为 `NULL`，则不返回旧动作。可用于保存并稍后恢复原处理动作。
+
+**`sa_flags` 标志说明**：
+
+- `SA_SIGINFO` (0x02)：使用扩展的三参数处理函数 `sa_sigaction(int sig, siginfo_t *info, void *context)`，而不是简单的 `sa_handler(int sig)`。这允许获取信号的详细信息（发送者 PID、信号值等）。
+- `SA_RESTART` (0x10)：被信号中断的系统调用自动重启，而不是返回 `EINTR` 错误。这简化了错误处理，避免需要手动重试中断的系统调用。
+- `SA_NODEFER` (0x20)：不自动阻塞正在处理的信号。默认情况下，处理信号 X 时会阻塞信号 X，防止递归。设置此标志后允许信号处理函数递归调用。
+- `SA_RESETHAND` (0x40)：信号递送后自动重置处理动作为 `SIG_DFL`（一次性处理器）。类似于旧的不可靠信号语义。
+- `SA_ONSTACK` (0x08)：在备用信号栈上执行处理函数（需要先用 `sigaltstack()` 设置）。用于避免栈溢出信号处理器自身溢出栈。
+- `SA_NOCLDSTOP` (0x01)：如果 `signo` 是 `SIGCHLD`，则子进程停止（`SIGSTOP`）或继续（`SIGCONT`）时不产生信号，只在终止时产生。
+- `SA_NOCLDWAIT` (0x04)：如果 `signo` 是 `SIGCHLD`，子进程终止时自动回收，不产生僵尸进程，父进程无需调用 `wait()`。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EINVAL` `signo` 无效，或尝试修改 `SIGKILL`/`SIGSTOP` 的处理动作。
+- `EFAULT` `act` 或 `oact` 指向无效内存地址（段错误）。
+
+**注意**：
+
+- 信号处理函数应尽量简短和高效，避免调用不可重入函数（如 `malloc()`、`printf()`）。只应调用异步信号安全（async-signal-safe）的函数。
+- `sa_mask` 在处理函数执行期间生效，处理函数返回后自动恢复原信号掩码。
+- 多次调用 `sigaction()` 修改同一信号的处理动作是安全的，新动作会覆盖旧动作。
+- 如果需要临时修改并恢复信号处理，模式为：
+  ```c
+  struct sigaction old_act;
+  sigaction(SIGINT, &new_act, &old_act);  // 设置新处理
+  // ... 做某些操作 ...
+  sigaction(SIGINT, &old_act, NULL);       // 恢复旧处理
+  ```
+- 在信号处理函数中修改全局变量时，应将其声明为 `volatile sig_atomic_t` 类型，确保原子性和可见性。
+- 使用 `SA_SIGINFO` 标志可以获取信号的详细信息，如发送者 PID、信号携带的数据等，这对于调试和高级信号处理很有用。
+- `sa_mask` 中应包含所有在处理函数执行期间需要阻塞的信号，防止信号处理函数被其他信号中断导致的竞态条件。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### signal
+
+```c
+sighandler_t signal(int signo, sighandler_t handler);
+```
+
+设置信号的处理函数。这是 `sigaction()` 的简化版本，但行为在不同系统上可能有差异，建议使用 `sigaction()`。
+
+**参数**：
+
+- `signo` 信号编号。不能是 `SIGKILL` 或 `SIGSTOP`。
+- `handler` 信号处理函数：
+  - `SIG_IGN` 忽略该信号。
+  - `SIG_DFL` 使用默认处理动作。
+  - 用户定义的函数指针，原型为 `void handler(int signo)`。
+
+**返回值**：
+
+成功时返回之前的信号处理函数，失败时返回 `SIG_ERR` 并设置 `errno`。
+
+**注意**：
+
+- 信号处理函数应尽量简短，只调用异步信号安全的函数。
+- 在 openvela 中，`signal()` 的行为与 BSD 语义一致：信号处理后不会重置为默认，系统调用会自动重启。
+- 对于需要精确控制信号行为的场景，建议使用 `sigaction()`。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigset
+
+```c
+sighandler_t sigset(int signo, sighandler_t handler);
+```
+
+设置信号处理函数（类似 `signal`，但支持 `SIG_HOLD`）。
+
+**参数**：
+
+- `signo` 信号编号。
+- `handler` 信号处理函数，可以是 `SIG_IGN`、`SIG_DFL`、`SIG_HOLD` 或用户定义的函数。
+
+**返回值**：
+
+成功时返回之前的信号处理函数，失败时返回 `SIG_ERR`。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+
+
+### sigignore
+
+```c
+int sigignore(int signo);
+```
+
+将指定信号的处理设置为忽略。
+
+**参数**：
+
+- `signo` 要忽略的信号编号。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1。
+
+
+**注意**：
+
+- 已废弃接口，等价于 `sigaction()` 设置 `SIG_IGN`。建议使用 `sigaction()`。
+- `SIGKILL` 和 `SIGSTOP` 不能被忽略。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+
+
+### siginterrupt
+
+```c
+int siginterrupt(int signo, int flag);
+```
+
+设置信号是否中断系统调用。
+
+**参数**：
+
+- `signo` 信号编号。
+- `flag` 如果非零，信号将中断系统调用；否则系统调用会自动重启。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1。
+
+
+**注意**：
+
+- `flag` 非零：清除 `SA_RESTART`，被信号中断的系统调用返回 `EINTR`。
+- `flag` 为零：设置 `SA_RESTART`，被信号中断的系统调用自动重启。
+**POSIX 兼容性**：兼容 BSD 扩展接口。
+
+
+## 信号集操作
+
+
+### sigemptyset
 
 ```c
 int sigemptyset(sigset_t *set);
@@ -612,9 +442,10 @@ int sigemptyset(sigset_t *set);
 - 即使信号集已经初始化，也可以再次调用 `sigemptyset()` 清空它。
 - 与 `sigfillset()` 配合：`sigemptyset()` + `sigaddset()` 用于构建稀疏信号集（包含少数信号），`sigfillset()` + `sigdelset()` 用于构建稠密信号集（排除少数信号）。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 15、sigfillset
+
+### sigfillset
 
 ```c
 int sigfillset(sigset_t *set);
@@ -653,9 +484,10 @@ int sigfillset(sigset_t *set);
   - 如果需要排除少数信号，用 `sigfillset()` + `sigdelset()`
 - 即使信号集已经初始化，也可以再次调用 `sigfillset()` 重新填充。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 16、sigaddset
+
+### sigaddset
 
 ```c
 int sigaddset(sigset_t *set, int signo);
@@ -696,9 +528,10 @@ int sigaddset(sigset_t *set, int signo);
 - 与 `sigdelset()` 配对使用可以灵活操作信号集。
 - 可以使用 `sigismember()` 检查信号是否在集合中。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 17、sigdelset
+
+### sigdelset
 
 ```c
 int sigdelset(sigset_t *set, int signo);
@@ -738,9 +571,10 @@ int sigdelset(sigset_t *set, int signo);
 - 与 `sigaddset()` 相反操作，两者可以组合使用灵活操作信号集。
 - 移除 `SIGKILL` 或 `SIGSTOP` 不会有实际效果，因为它们本身就无法被阻塞。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 18、sigismember
+
+### sigismember
 
 ```c
 int sigismember(const sigset_t *set, int signo);
@@ -792,9 +626,10 @@ int sigismember(const sigset_t *set, int signo);
   assert(sigismember(&set, SIGTERM) == 0);
   ```
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
-## 19、sigisemptyset
+
+### sigisemptyset
 
 ```c
 int sigisemptyset(sigset_t *set);
@@ -810,9 +645,14 @@ int sigisemptyset(sigset_t *set);
 
 如果信号集为空返回 1，否则返回 0。
 
+
+**注意**：
+
+- glibc 扩展接口，非 POSIX 标准，用于快速检查信号集是否为空。
 **POSIX 兼容性**：兼容 glibc 扩展接口。
 
-## 20、sigandset
+
+### sigandset
 
 ```c
 int sigandset(sigset_t *dest, const sigset_t *left, const sigset_t *right);
@@ -830,9 +670,14 @@ int sigandset(sigset_t *dest, const sigset_t *left, const sigset_t *right);
 
 成功时返回 0，失败时返回 -1。
 
+
+**注意**：
+
+- glibc 扩展接口，用于计算两个信号集的交集。`dest` 可以与 `left` 或 `right` 相同。
 **POSIX 兼容性**：兼容 glibc 扩展接口。
 
-## 21、sigorset
+
+### sigorset
 
 ```c
 int sigorset(sigset_t *dest, const sigset_t *left, const sigset_t *right);
@@ -850,82 +695,180 @@ int sigorset(sigset_t *dest, const sigset_t *left, const sigset_t *right);
 
 成功时返回 0，失败时返回 -1。
 
+
+**注意**：
+
+- glibc 扩展接口，用于计算两个信号集的并集。`dest` 可以与 `left` 或 `right` 相同。
 **POSIX 兼容性**：兼容 glibc 扩展接口。
 
-## 22、sighold
+
+## 信号等待
+
+
+### sigwait
 
 ```c
-int sighold(int signo);
+int sigwait(const sigset_t *set, int *sig);
 ```
 
-将指定信号添加到信号掩码中（阻塞该信号）。
+同步等待信号集 `set` 中的任意信号到达。这是以同步方式处理信号的关键函数，允许将信号作为普通事件处理，而不是异步中断。
+
+与异步信号处理不同，`sigwait()` 将信号转换为同步事件：线程主动等待信号，信号到达时函数返回信号编号，而不是调用信号处理函数。这大大简化了信号处理，避免了异步信号处理的复杂性（如可重入性、竞态条件等）。
+
+典型用法是创建专门的信号处理线程，阻塞感兴趣的信号，然后循环调用 `sigwait()` 等待并处理信号。
 
 **参数**：
 
-- `signo` 要阻塞的信号编号。
+- `set` 要等待的信号集。通常应先使用 `sigprocmask()` 或 `pthread_sigmask()` 阻塞这些信号，否则信号可能被异步处理函数捕获而不是 `sigwait()` 接收。必须包含至少一个有效信号。
+- `sig` 返回接收到的信号编号（输出参数）。如果等待多个信号，无法预测哪个信号先到达，需要根据返回的编号进行处理。
 
 **返回值**：
 
-成功时返回 0，失败时返回 -1。
+成功时返回 0，失败时返回错误码（注意：不设置 `errno`，直接返回错误码）：
 
-**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+- `EINVAL` `set` 包含无效的信号编号（<= 0 或 > `MAX_SIGNO`）。
+- `EINTR` 被未在 `set` 中的信号中断（某些实现，openvela 通常不会返回此错误）。
 
-## 23、sigrelse
+**注意**：
+
+- **关键**：等待的信号必须被阻塞。否则信号可能在 `sigwait()` 调用前或期间被信号处理函数捕获，导致 `sigwait()` 错过信号。推荐模式：
+  ```c
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGUSR1);
+  sigaddset(&set, SIGUSR2);
+  
+  // 先阻塞信号
+  pthread_sigmask(SIG_BLOCK, &set, NULL);
+  
+  // 然后等待
+  int sig;
+  while (1) {
+      sigwait(&set, &sig);
+      switch (sig) {
+          case SIGUSR1: /* 处理 SIGUSR1 */ break;
+          case SIGUSR2: /* 处理 SIGUSR2 */ break;
+      }
+  }
+  ```
+- `sigwait()` 从挂起信号队列中移除信号，不会触发信号处理函数。即使注册了信号处理函数，`sigwait()` 接收的信号也不会调用处理函数。
+- 如果多个线程同时等待同一信号，只有一个线程会接收到信号（由系统选择）。
+- 如果信号已经挂起（在调用 `sigwait()` 前到达），函数会立即返回，不会阻塞。
+- `sigwait()` 是取消点（cancellation point）：如果线程被取消（`pthread_cancel()`），函数会立即返回。
+- 相比异步信号处理，同步等待的优势：
+  - 不需要考虑函数可重入性
+  - 可以使用普通的 C 库函数（malloc、printf 等）
+  - 不需要使用 `volatile sig_atomic_t` 类型
+  - 更容易推理和调试
+- 常用于实现信号处理线程模式：主线程和工作线程阻塞所有信号，专门的信号线程循环调用 `sigwait()` 处理信号。
+- 标准信号不排队，如果同一信号发送多次，可能只有一个实例被 `sigwait()` 接收。实时信号支持排队。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigwaitinfo
 
 ```c
-int sigrelse(int signo);
+int sigwaitinfo(const sigset_t *set, siginfo_t *info);
 ```
 
-从信号掩码中移除指定信号（解除阻塞）。
+等待 `set` 中的任意信号，并获取信号的详细信息。与 `sigwait()` 类似，但提供更多信号信息。
 
 **参数**：
 
-- `signo` 要解除阻塞的信号编号。
+- `set` 要等待的信号集。
+- `info` 如果非 `NULL`，返回信号的详细信息，包括：
+  - `si_signo` 信号编号。
+  - `si_code` 信号来源代码（如 `SI_USER`、`SI_QUEUE`、`SI_TIMER`）。
+  - `si_pid` 发送进程的 PID。
+  - `si_value` 随信号传递的数据（用于 `sigqueue()` 发送的信号）。
 
 **返回值**：
 
-成功时返回 0，失败时返回 -1。
+成功时返回信号编号，失败时返回 -1 并设置 `errno`：
 
-**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+- `EINTR` 被其他信号中断。
+- `EINVAL` `set` 包含无效信号编号。
 
-## 24、sigignore
+**注意**：
+
+- 等价于 `sigtimedwait(set, info, NULL)`，即无超时的无限等待。
+- 与 `sigwait()` 的区别是返回更详细的 `siginfo_t` 信息。
+
+
+**注意**：
+
+- 等价于 `sigtimedwait(set, info, NULL)`，即无超时的无限等待。
+- 与 `sigwait()` 的区别是返回更详细的 `siginfo_t` 信息。
+- 失败时 `errno` 可能为 `EINTR`（被中断）或 `EINVAL`（无效信号集）。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigtimedwait
 
 ```c
-int sigignore(int signo);
+int sigtimedwait(const sigset_t *set, siginfo_t *info, const struct timespec *timeout);
 ```
 
-将指定信号的处理设置为忽略。
+等待 `set` 中的任意信号，带超时限制。在指定时间内如果没有信号到达，函数返回错误。
 
 **参数**：
 
-- `signo` 要忽略的信号编号。
+- `set` 要等待的信号集。
+- `info` 如果非 `NULL`，返回信号的详细信息。
+- `timeout` 超时时间：
+  - `tv_sec` 秒数。
+  - `tv_nsec` 纳秒数。
+  - 如果为 `NULL`，则无限等待（等效于 `sigwaitinfo()`）。
+  - 如果为 `{0, 0}`，则立即返回（轮询模式）。
 
 **返回值**：
 
-成功时返回 0，失败时返回 -1。
+成功时返回信号编号，失败时返回 -1 并设置 `errno`：
 
-**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+- `EAGAIN` 超时时间内没有信号到达。
+- `EINTR` 被其他（未在 `set` 中的）信号中断。
+- `EINVAL` `timeout` 参数无效（如负值）。
 
-## 25、sigset
+**注意**：
+
+- 常用于实现有超时的信号等待逻辑。
+- 结合实时信号使用，可以实现可靠的事件通知机制。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigsuspend
 
 ```c
-sighandler_t sigset(int signo, sighandler_t handler);
+int sigsuspend(const sigset_t *mask);
 ```
 
-设置信号处理函数（类似 `signal`，但支持 `SIG_HOLD`）。
+临时替换信号掩码并挂起任务，直到收到未被阻塞的信号。这是一个原子操作，避免了分别调用 `sigprocmask()` 和 `pause()` 之间的竞态条件。
 
 **参数**：
 
-- `signo` 信号编号。
-- `handler` 信号处理函数，可以是 `SIG_IGN`、`SIG_DFL`、`SIG_HOLD` 或用户定义的函数。
+- `mask` 临时信号掩码。在等待期间，进程的信号掩码会被替换为此值。
 
 **返回值**：
 
-成功时返回之前的信号处理函数，失败时返回 `SIG_ERR`。
+总是返回 -1，`errno` 设置为 `EINTR`（被信号中断）。
 
-**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+**注意**：
 
-## 26、sigpause
+- 函数返回后，信号掩码会自动恢复为调用前的值。
+- 常用于等待特定信号，同时不阻塞该信号。
+- 示例：解除阻塞 `SIGUSR1` 并等待它：
+  ```c
+  sigset_t mask;
+  sigemptyset(&mask);  // 只解除阻塞 SIGUSR1
+  sigsuspend(&mask);   // 等待任意信号
+  ```
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigpause
 
 ```c
 int sigpause(int signo);
@@ -943,136 +886,138 @@ int sigpause(int signo);
 
 **POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
 
-## 27、sigaltstack
+
+## 信号掩码
+
+
+### sigprocmask
 
 ```c
-int sigaltstack(const stack_t *ss, stack_t *oss);
+int sigprocmask(int how, const sigset_t *set, sigset_t *oset);
 ```
 
-设置或获取信号处理的备用栈。
+设置或查询调用线程的信号掩码（signal mask）。信号掩码决定哪些信号当前被阻塞。被阻塞的信号不会被递送给进程，而是保持挂起状态（pending），直到从信号掩码中移除（解除阻塞）。
+
+信号掩码是线程局部的，每个线程维护自己独立的信号掩码。新创建的线程继承创建者的信号掩码。阻塞信号可以保护临界区代码不被信号中断，是编写健壮信号处理代码的重要工具。
 
 **参数**：
 
-- `ss` 如果非 `NULL`，指向新的备用栈配置：
-  - `ss_sp` 栈内存指针。
-  - `ss_size` 栈大小。
-  - `ss_flags` 标志（`SS_DISABLE` 禁用备用栈）。
-- `oss` 如果非 `NULL`，返回之前的备用栈配置。
+- `how` 指定如何修改信号掩码，必须是以下值之一：
+  - `SIG_BLOCK` (1)：将 `set` 中的信号添加到当前掩码。新掩码 = 旧掩码 ∪ `set`。用于阻塞更多信号。
+  - `SIG_UNBLOCK` (2)：从当前掩码中移除 `set` 中的信号。新掩码 = 旧掩码 - `set`。用于解除阻塞。
+  - `SIG_SETMASK` (3)：将当前掩码完全替换为 `set`。新掩码 = `set`。用于设置精确的信号掩码。
+- `set` 要操作的信号集。如果为 `NULL`，则不修改当前掩码，仅通过 `oset` 查询当前掩码（此时 `how` 参数被忽略）。信号集应先用 `sigemptyset()`、`sigfillset()`、`sigaddset()` 等函数初始化和设置。
+- `oset` 如果非 `NULL`，返回操作前的信号掩码（旧值）。可用于保存当前掩码以便稍后恢复。如果只想查询不修改，可设置 `set=NULL`。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EINVAL` `how` 参数值无效（不是 `SIG_BLOCK`、`SIG_UNBLOCK` 或 `SIG_SETMASK`）。
+- `EFAULT` `set` 或 `oset` 指向无效内存地址。
+
+**注意**：
+
+- `SIGKILL`（9）和 `SIGSTOP`（19）无法被阻塞，尝试阻塞它们会被静默忽略（不返回错误）。这确保进程始终可以被终止或停止。
+- 在多线程程序中，每个线程有独立的信号掩码，`sigprocmask()` 只影响调用线程。对于多线程程序，POSIX 标准建议使用 `pthread_sigmask()`（功能完全相同，但返回错误码而非设置 `errno`）。
+- 解除阻塞信号后，如果该信号处于挂起状态，会立即递送（在 `sigprocmask()` 返回前）。
+- 阻塞信号期间，同一信号发送多次只会有一个实例挂起（标准信号不排队）。实时信号（`SIGRTMIN`-`SIGRTMAX`）支持排队。
+- 典型使用模式 - 临界区保护：
+  ```c
+  sigset_t new_mask, old_mask;
+  sigemptyset(&new_mask);
+  sigaddset(&new_mask, SIGINT);
+  sigaddset(&new_mask, SIGTERM);
+  
+  // 进入临界区，阻塞信号
+  sigprocmask(SIG_BLOCK, &new_mask, &old_mask);
+  
+  // 临界区代码，不会被 SIGINT/SIGTERM 中断
+  // ...
+  
+  // 离开临界区，恢复信号掩码
+  sigprocmask(SIG_SETMASK, &old_mask, NULL);
+  ```
+- 信号掩码在 `fork()` 后被子进程继承，但在 `exec()` 后重置为空（所有信号解除阻塞）。
+- 信号掩码不影响信号处理动作的设置，只影响信号的递送。即使信号被阻塞，仍可以用 `sigaction()` 修改其处理动作。
+- 可以通过 `sigpending()` 查询当前哪些信号被阻塞且正在挂起。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sigpending
+
+```c
+int sigpending(sigset_t *set);
+```
+
+获取当前被阻塞且正在挂起（待处理）的信号集。这些信号已经被发送给进程，但因为被阻塞而尚未递送。
+
+**参数**：
+
+- `set` 用于返回挂起信号集的指针。
 
 **返回值**：
 
 成功时返回 0，失败时返回 -1 并设置 `errno`。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**注意**：
 
-## 28、siginterrupt
+- 可用于检查在解除阻塞前是否有信号等待处理。
+- 配合 `sigismember()` 检查特定信号是否挂起。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+### sighold
 
 ```c
-int siginterrupt(int signo, int flag);
+int sighold(int signo);
 ```
 
-设置信号是否中断系统调用。
+将指定信号添加到信号掩码中（阻塞该信号）。
 
 **参数**：
 
-- `signo` 信号编号。
-- `flag` 如果非零，信号将中断系统调用；否则系统调用会自动重启。
+- `signo` 要阻塞的信号编号。
 
 **返回值**：
 
 成功时返回 0，失败时返回 -1。
 
-**POSIX 兼容性**：兼容 BSD 扩展接口。
-
-## 29、psignal
-
-```c
-void psignal(int signo, const char *message);
-```
-
-打印信号描述信息。
-
-**参数**：
-
-- `signo` 信号编号。
-- `message` 前缀消息。
-
-**返回值**：
-
-无返回值。
-
-**POSIX 兼容性**：兼容 BSD 扩展接口。
-
-## 30、psiginfo
-
-```c
-void psiginfo(const siginfo_t *info, const char *message);
-```
-
-打印信号信息结构的描述。
-
-**参数**：
-
-- `info` 信号信息结构。
-- `message` 前缀消息。
-
-**返回值**：
-
-无返回值。
-
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
-
-## 31、pthread_kill
-
-```c
-int pthread_kill(pthread_t thread, int signo);
-```
-
-向指定线程发送信号。这是多线程程序中向特定线程发送信号的标准方法，比 `kill()` 更精确，可以指定信号的接收线程。
-
-在多线程程序中，信号可以被递送给进程中的任意未阻塞该信号的线程。使用 `pthread_kill()` 可以明确指定接收线程，确保信号被期望的线程处理。
-
-**参数**：
-
-- `thread` 目标线程的线程 ID（通过 `pthread_create()` 返回或 `pthread_self()` 获取）。
-- `signo` 要发送的信号编号（1-63）。特殊值 0 是"空信号"，不发送实际信号，仅检查线程是否存在（用于存活性测试）。
-
-**返回值**：
-
-成功时返回 0，失败时返回错误码（注意：不设置 `errno`，直接返回错误码）：
-
-- `EINVAL` `signo` 无效（<= 0 或 > `MAX_SIGNO`）。
-- `ESRCH` 线程不存在或已终止。线程 ID 可能已被回收并指向新线程，导致信号发送给错误的线程。
 
 **注意**：
 
-- **线程特定性**：信号会被递送给指定线程，即使该线程阻塞了该信号，信号也会挂起在该线程上（而不是其他线程）。
-- **存活性测试**：使用 `pthread_kill(thread, 0)` 可以测试线程是否存在：
-  ```c
-  if (pthread_kill(thread, 0) == 0) {
-      // 线程存在
-  } else {
-      // 线程不存在（ESRCH）
-  }
-  ```
-- **信号处理**：即使向特定线程发送信号，信号处理函数仍然可能在其他线程中执行（取决于信号掩码）。如果只有目标线程未阻塞该信号，则一定在该线程中处理。
-- **线程 ID 重用**：线程终止后，其 ID 可能被重用。如果在线程终止后发送信号，可能发送给新线程。推荐使用 `tgkill()` 避免此问题（它会验证线程属于预期的进程）。
-- **与 `kill()` 的区别**：
-  - `kill()` 发送给整个进程，由任意线程处理
-  - `pthread_kill()` 发送给特定线程，更精确
-- **与 `raise()` 的关系**：`raise(sig)` 在多线程程序中等效于 `pthread_kill(pthread_self(), sig)`。
-- **信号掩码继承**：新线程继承创建者的信号掩码。如果需要不同的掩码，在线程启动时调用 `pthread_sigmask()`。
-- **典型用途**：
-  - 取消或终止特定线程（发送 `SIGTERM`、`SIGUSR1` 等）
-  - 向工作线程发送通知信号
-  - 向信号处理线程发送信号
-  - 测试线程是否存活
-- **线程安全**：`pthread_kill()` 本身是线程安全的，可以从多个线程并发调用。
-- **POSIX 一致性**：在 openvela 中，`pthread_t` 与 `pid_t` 相同，线程 ID 即任务 ID。
+- 已废弃接口，等价于 `sigprocmask(SIG_BLOCK, ...)`。建议使用 `sigprocmask()`。
+- 失败时设置 `errno` 为 `EINVAL`（信号编号无效）。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
 
-## 32、pthread_sigmask
+### sigrelse
+
+```c
+int sigrelse(int signo);
+```
+
+从信号掩码中移除指定信号（解除阻塞）。
+
+**参数**：
+
+- `signo` 要解除阻塞的信号编号。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1。
+
+
+**注意**：
+
+- 已废弃接口，等价于 `sigprocmask(SIG_UNBLOCK, ...)`。建议使用 `sigprocmask()`。
+- 失败时设置 `errno` 为 `EINVAL`（信号编号无效）。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口（已过时）。
+
+
+### pthread_sigmask
 
 ```c
 int pthread_sigmask(int how, const sigset_t *set, sigset_t *oset);
@@ -1149,5 +1094,140 @@ int pthread_sigmask(int how, const sigset_t *set, sigset_t *oset);
 - 与 `pthread_kill()` 配合使用可以实现线程间的精确信号通信。
 - 在单线程程序中，`pthread_sigmask()` 和 `sigprocmask()` 完全等效。
 
-**POSIX 兼容性**：完美兼容 `POSIX` 同名接口。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
 
+
+## 信号栈
+
+
+### sigaltstack
+
+```c
+int sigaltstack(const stack_t *ss, stack_t *oss);
+```
+
+设置或获取信号处理的备用栈。
+
+**参数**：
+
+- `ss` 如果非 `NULL`，指向新的备用栈配置：
+  - `ss_sp` 栈内存指针。
+  - `ss_size` 栈大小。
+  - `ss_flags` 标志（`SS_DISABLE` 禁用备用栈）。
+- `oss` 如果非 `NULL`，返回之前的备用栈配置。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`。
+
+
+**注意**：
+
+- openvela 当前不支持 `SS_ONSTACK`，设置非 `SS_DISABLE` 的栈返回 `EINVAL`。
+- `ss->ss_size` 小于 `MINSIGSTKSZ` 时返回 `ENOMEM`。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+## 线程信号
+
+
+### pthread_kill
+
+```c
+int pthread_kill(pthread_t thread, int signo);
+```
+
+向指定线程发送信号。这是多线程程序中向特定线程发送信号的标准方法，比 `kill()` 更精确，可以指定信号的接收线程。
+
+在多线程程序中，信号可以被递送给进程中的任意未阻塞该信号的线程。使用 `pthread_kill()` 可以明确指定接收线程，确保信号被期望的线程处理。
+
+**参数**：
+
+- `thread` 目标线程的线程 ID（通过 `pthread_create()` 返回或 `pthread_self()` 获取）。
+- `signo` 要发送的信号编号（1-63）。特殊值 0 是"空信号"，不发送实际信号，仅检查线程是否存在（用于存活性测试）。
+
+**返回值**：
+
+成功时返回 0，失败时返回错误码（注意：不设置 `errno`，直接返回错误码）：
+
+- `EINVAL` `signo` 无效（<= 0 或 > `MAX_SIGNO`）。
+- `ESRCH` 线程不存在或已终止。线程 ID 可能已被回收并指向新线程，导致信号发送给错误的线程。
+
+**注意**：
+
+- **线程特定性**：信号会被递送给指定线程，即使该线程阻塞了该信号，信号也会挂起在该线程上（而不是其他线程）。
+- **存活性测试**：使用 `pthread_kill(thread, 0)` 可以测试线程是否存在：
+  ```c
+  if (pthread_kill(thread, 0) == 0) {
+      // 线程存在
+  } else {
+      // 线程不存在（ESRCH）
+  }
+  ```
+- **信号处理**：即使向特定线程发送信号，信号处理函数仍然可能在其他线程中执行（取决于信号掩码）。如果只有目标线程未阻塞该信号，则一定在该线程中处理。
+- **线程 ID 重用**：线程终止后，其 ID 可能被重用。如果在线程终止后发送信号，可能发送给新线程。推荐使用 `tgkill()` 避免此问题（它会验证线程属于预期的进程）。
+- **与 `kill()` 的区别**：
+  - `kill()` 发送给整个进程，由任意线程处理
+  - `pthread_kill()` 发送给特定线程，更精确
+- **与 `raise()` 的关系**：`raise(sig)` 在多线程程序中等效于 `pthread_kill(pthread_self(), sig)`。
+- **信号掩码继承**：新线程继承创建者的信号掩码。如果需要不同的掩码，在线程启动时调用 `pthread_sigmask()`。
+- **典型用途**：
+  - 取消或终止特定线程（发送 `SIGTERM`、`SIGUSR1` 等）
+  - 向工作线程发送通知信号
+  - 向信号处理线程发送信号
+  - 测试线程是否存活
+- **线程安全**：`pthread_kill()` 本身是线程安全的，可以从多个线程并发调用。
+- **POSIX 一致性**：在 openvela 中，`pthread_t` 与 `pid_t` 相同，线程 ID 即任务 ID。
+
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。
+
+
+## 调试与诊断
+
+
+### psignal
+
+```c
+void psignal(int signo, const char *message);
+```
+
+打印信号描述信息。
+
+**参数**：
+
+- `signo` 信号编号。
+- `message` 前缀消息。
+
+**返回值**：
+
+无返回值。
+
+
+**注意**：
+
+- 输出格式为 `message: signal_description`，主要用于调试和错误日志。
+**POSIX 兼容性**：兼容 BSD 扩展接口。
+
+
+### psiginfo
+
+```c
+void psiginfo(const siginfo_t *info, const char *message);
+```
+
+打印信号信息结构的描述。
+
+**参数**：
+
+- `info` 信号信息结构。
+- `message` 前缀消息。
+
+**返回值**：
+
+无返回值。
+
+
+**注意**：
+
+- 比 `psignal()` 提供更详细的信息，包括信号来源代码。
+**POSIX 兼容性**：兼容 `POSIX` 同名接口。


### PR DESCRIPTION
- sched.md: add 6 missing APIs (sched_lock/unlock/lockcount/backtrace/dumpstack/cpucount), reorganize into 7 functional groups, add openvela implementation notes
- mem.md: add 16 missing APIs (delayfree/heapfree/mm_free/sbrk/notify_pressure etc.), reorganize into 8 functional groups, add build mode documentation
- signal.md: enhance 11 brief APIs with error codes and notes, reorganize into 10 functional groups, add openvela implementation notes
- msgqueue.md: fix mq_timedreceive signature (missing abstime param), add missing return values and error codes, reorganize into 6 groups
- All files: standardize POSIX compatibility wording, add header file references


