### PR TITLE
docs: refactor and enhance bluetooth API documentation

### DIFF
--- a/doxygen/api/framework/bluetooth/bt_a2dp.md
+++ b/doxygen/api/framework/bluetooth/bt_a2dp.md
@@ -1,106 +1,273 @@
-# 蓝牙 A2DP API 开发指南
+# 蓝牙 A2DP API
 
-## 1. 概述
+openvela 蓝牙 A2DP（高级音频分发）接口，支持音频流的发送（Source）和接收（Sink）。
 
-**高级音频分发规范 (A2DP)** 定义了在单声道、立体声或多声道模式下传输高质量音频内容的协议和过程。该规范为实现此功能的设备定义了 **源端 (Source/SRC)** 和 **接收端 (Sink/SNK)** 角色。
+头文件：#include "bt_a2dp.h"、#include "bt_a2dp_sink.h"、#include "bt_a2dp_source.h"
 
-- **源端 (SRC)**：当设备作为数字音频流的源头，将其传送给微微网 (Piconet) 中的接收端 (SNK) 时，该设备即为 SRC。
-- **接收端 (SNK)**：当设备作为数字音频流的接收方，接收同一微微网中源端 (SRC) 传送的数据时，该设备即为 SNK。
 
-常见的 A2DP 接收端设备包括蓝牙耳机、蓝牙音箱和车载蓝牙免提系统。音频流在传输前需要进行压缩和编码。目前，openvela 系统支持两种音频编解码器，包括 **SBC** 和 **AAC**。
+## openvela 实现说明
 
-### 1.1 音频传输模式
+- **双角色支持**：Source（音频发送端）和 Sink（音频接收端）
+- **编解码器**：支持 SBC 和 AAC
+- **传输模式**：支持硬件卸载（Offloading）和非卸载模式
 
-音频流的传输主要有两种截然不同的方式：**硬件卸载 (Offloading)** 和 **非卸载 (Non-offloading)**。这两种模式的主要区别在于蓝牙核心协议栈是否参与音频传输。
 
-- **非卸载模式**：音频流通过蓝牙核心协议栈传输至远端设备。
-- **硬件卸载模式**：音频流不经过蓝牙核心协议栈传输。
+## 同步接口
 
-### 1.2 远程控制说明
 
-需要注意的是，A2DP 仅负责传输音频流数据，不包含远程控制功能。然而，在某些情况下，设备可能会结合 A2DP 和控制规范来支持远程控制功能，例如音视频远程控制规范 (AVRCP) 中所使用的功能。
+### bt_a2dp_sink_unregister_callbacks
 
-## 2. A2DP 状态机与连接管理
-
-蓝牙服务通过状态机维护 A2DP 的生命周期。开发过程中需严格区分 **Profile 连接**（控制链路）和 **Audio 连接**（数据链路）。
-
-### 2.1 状态定义
-
-蓝牙服务负责维护 A2DP 的状态机，其中包含空闲 (Idle)、打开中 (Opening)、已打开 (Opened)、已启动 (Started) 和关闭中 (Closing) 等状态。这些状态可分为稳态和瞬态：
-
-- **稳态 (Stable States)**:
-
-    - **Idle (空闲)**：初始状态。
-    - **Opened (已打开)**：A2DP 连接已建立。
-    - **Started (已启动)**：正在传输音频流。
-
-- **瞬态 (Transient States)**:
-
-    - **Opening (打开中)**：正在建立 A2DP 连接。
-    - **Closing (关闭中)**：正在断开 A2DP 连接。
-
-状态变化如下图所示：
-
-![img](figures/a2dp.png)
-
-### 2.2 连接与流状态
-
-- **A2DP 连接状态**：包含四种不同状态，分别为 DISCONNECTED (已断开)、CONNECTING (连接中)、CONNECTED (已连接) 和 DISCONNECTING (断开中)。
-- **音频流状态**：涉及音频流的状态，包括 Started (已启动) 和 Stopped (已停止)。
-
-此外，A2DP 流仅在 Profile 连接建立后专用于传输音频数据。应用程序 (APP) 能够接收有关 A2DP 连接状态变化以及 A2DP 音频状态变化的通知。
-
-框架提供了一个名为 `bttool` 的测试工具。该工具通过调用 A2DP 接口，协助与远程设备建立 A2DP 连接。关于如何使用 `bttool` 命令的详细指南，请参阅 `bttool` 命令手册。
-
-## 3. 开发工具
-
-框架提供了命令行测试工具 `bttool`，用于验证 A2DP 功能。开发者可通过该工具调用底层接口，快速与远程设备建立连接并进行音频测试。
-
-- **参考文档**：请查阅 `bttool` 命令手册获取详细指令说明。
-
-## 4. API 参考
-
-### 4.1 通用接口 (Common)
-
-#### A2DP API
-
-```eval_rst
-
-.. doxygenfile:: bt_a2dp.h
-    :project: doxygen
+```c
+bool bt_a2dp_sink_unregister_callbacks(bt_instance_t* ins, void* cookie);
 ```
 
-### 4.2 A2DP 接收端 (Sink)
+取消注册回调函数，停止接收状态变更通知。
 
-A2DP Sink 设备负责接收音频流。A2DP Sink 定义了一些特定行为：
+**参数**：
 
-- **初始化**：初始化后，A2DP Sink 处于 Idle 状态并注册相关回调函数。
-- **状态通知**：当状态发生变化时，A2DP Sink 会将状态变更结果发送给 APP。
-- **连接管理**：A2DP Sink 可以主动连接 A2DP Source 设备，也可以主动断开连接。
-- **状态查询**：此外，APP 还可以检查 A2DP Sink 是否已连接、判断 A2DP Sink 是否正在播放，以及获取 A2DP Sink 当前的连接状态。
+- `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
 
-#### A2DP Sink API 详情
 
-```eval_rst
+**返回值**：
 
-.. doxygenfile:: bt_a2dp_sink.h
-    :project: doxygen
+成功时返回回调 cookie，失败或已注册时返回 NULL。
+
+
+### bt_a2dp_sink_is_connected
+
+```c
+bool bt_a2dp_sink_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-### 4.3 A2DP 源端 (Source)
+发起与远程设备的连接。
 
-A2DP Source 设备负责发送音频流。A2DP Source 定义了一些特定行为：
+**参数**：
 
-- **初始化**：初始化后，A2DP Source 处于 Idle 状态并注册相关回调函数。
-- **状态通知**：当状态发生变化时，A2DP Source 会将状态变更结果发送给 APP。
-- **连接管理**：A2DP Source 设备可以主动连接 A2DP Sink 设备，也可以主动断开连接。
-- **状态查询**：此外，APP 还可以调用 A2DP Source 提供的接口来检查是否已连接、判断是否正在播放，以及获取当前的连接状态。
-- **多设备支持**：当 A2DP Source 设备连接到多个 A2DP Sink 设备时，A2DP Source 可以设置静音 (Silence) 的 Sink 设备和活动 (Active) 的 Sink 设备。
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
 
-#### A2DP Source API 详情
+**返回值**：
 
-```eval_rst
+检查是否已连接。
 
-.. doxygenfile:: bt_a2dp_source.h
-    :project: doxygen
+
+### bt_a2dp_sink_is_playing
+
+```c
+bool bt_a2dp_sink_is_playing(bt_instance_t* ins, bt_address_t* addr);
 ```
+
+检查是否正在播放。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+检查是否正在播放。
+
+
+### bt_a2dp_sink_get_connection_state
+
+```c
+profile_connection_state_t bt_a2dp_sink_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+
+
+### bt_a2dp_sink_connect
+
+```c
+bt_status_t bt_a2dp_sink_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+建立连接。
+
+
+### bt_a2dp_sink_disconnect
+
+```c
+bt_status_t bt_a2dp_sink_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+断开连接。
+
+
+### bt_a2dp_source_unregister_callbacks
+
+```c
+bool bt_a2dp_source_unregister_callbacks(bt_instance_t* ins, void* cookie);
+```
+
+取消注册回调函数，停止接收状态变更通知。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
+
+
+**返回值**：
+
+成功时返回回调 cookie，失败或已注册时返回 NULL。
+
+
+### bt_a2dp_source_is_connected
+
+```c
+bool bt_a2dp_source_is_connected(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+检查是否已连接。
+
+
+### bt_a2dp_source_is_playing
+
+```c
+bool bt_a2dp_source_is_playing(bt_instance_t* ins, bt_address_t* addr);
+```
+
+检查是否正在播放。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+检查是否正在播放。
+
+
+### bt_a2dp_source_get_connection_state
+
+```c
+profile_connection_state_t bt_a2dp_source_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+
+
+### bt_a2dp_source_connect
+
+```c
+bt_status_t bt_a2dp_source_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+建立连接。
+
+
+### bt_a2dp_source_disconnect
+
+```c
+bt_status_t bt_a2dp_source_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_a2dp_source_set_silence_device
+
+```c
+bt_status_t bt_a2dp_source_set_silence_device(bt_instance_t* ins, bt_address_t* addr, bool silence);
+```
+
+设置静音设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `silence` 是否设为静音模式（true 为静音）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_a2dp_source_set_active_device
+
+```c
+bt_status_t bt_a2dp_source_set_active_device(bt_instance_t* ins, bt_address_t* addr);
+```
+
+设置活跃设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/doxygen/api/framework/bluetooth/bt_avrcp.md
+++ b/doxygen/api/framework/bluetooth/bt_avrcp.md
@@ -1,93 +1,191 @@
-# 蓝牙 AVRCP API 开发指南
+# 蓝牙 AVRCP API
 
-**音视频远程控制规范 (AVRCP)** 定义了在音视频分发场景中，具备音视频控制功能的蓝牙设备之间确保互操作性所需的特性和流程。
+openvela 蓝牙 AVRCP（音视频远程控制）接口，支持播放控制、曲目信息查询等。
 
-AVRCP 定义了两种设备角色：
+头文件：#include "bt_avrcp.h"、#include "bt_avrcp_control.h"、#include "bt_avrcp_target.h"
 
-- **控制端 (Controller, CT)**：发起事务的设备，负责向目标端发送命令帧。
-  
-    - *典型设备*：个人电脑、PDA、手机、遥控器，或车载系统、耳机等 AV 设备。
 
-- **目标端 (Target, TG)**：接收命令帧并生成相应响应帧的设备。
+## openvela 实现说明
 
-    - *典型设备*：音频/视频播放器、录音机、电视、调谐器、放大器或耳机。
+- **双角色支持**：Controller（控制端）和 Target（目标端）
+- **功能**：播放/暂停/切歌、音量控制、曲目信息获取
 
-### 连接与流媒体说明
 
-在 openvela 蓝牙系统中，AVRCP 的连接状态包括：
+## 同步接口
 
-- **DISCONNECTED** (已断开)
-- **CONNECTING** (连接中)
-- **CONNECTED** (已连接)
-- **DISCONNECTING** (断开中)
 
-> **注意**：AVRCP 仅负责控制信令，**不处理**音视频流数据的传输。支持此规范的设备通常需要同时实现**高级音频分发规范 (A2DP)** 和/或**视频分发规范 (VDP)** 以支持流媒体传输。
+### bt_avrcp_control_unregister_callbacks
 
-## 1. 通用接口 (Common)
-
-本节包含 AVRCP 通用的数据结构与定义。
-
-```eval_rst
-
-.. doxygenfile:: bt_avrcp.h
-    :project: doxygen
+```c
+bool bt_avrcp_control_unregister_callbacks(bt_instance_t* ins, void* cookie);
 ```
 
-## 2. AVRCP 控制端 (Controller)
+取消注册回调函数，停止接收状态变更通知。
 
-AVRCP Controller 应用程序主要用于向目标设备发送控制指令并获取信息。
+**参数**：
 
-**主要功能**：
+- `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
 
-- **属性获取**：应用程序可以从 AVRCP Target 设备检索当前播放歌曲的媒体元素属性信息（如歌名、艺术家等）。
-- **回调注册**：应用程序需向蓝牙服务注册连接状态回调和元素属性回调。
-- **事件通知**：当 AVRCP 连接状态发生变化，或收到 TG 返回的属性信息响应时，蓝牙服务将通过相应的回调函数通知应用程序。
+**返回值**：
 
-### AVRCP Controller API 详情
+取消注册回调函数。
 
-```eval_rst
 
-.. doxygenfile:: bt_avrcp_control.h
-    :project: doxygen
+### bt_avrcp_control_get_element_attributes
+
+```c
+bt_status_t bt_avrcp_control_get_element_attributes(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-## 3. AVRCP 目标端 (Target)
+获取媒体元素属性。
 
-AVRCP Target 应用程序主要用于响应控制指令并上报播放器状态。
+**参数**：
 
-**主要功能**：
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
 
-- **回调注册**：应用程序可向蓝牙服务注册多种回调函数，包括：
 
-    - 连接状态变更回调
-    - 播放器状态请求回调 (Player status request)
-    - 注册通知请求回调 (Register notification request)
-    - 面板操作回调 (Panel operation，如音量旋钮、按键操作)
+**返回值**：
 
-- **被动响应**：当相关事件发生时，蓝牙服务通过回调通知应用程序。
-- **主动通知**：如果 CT 注册了播放器状态通知，当 TG 设备的播放器状态发生变化时（例如暂停、切歌），TG 将主动向 CT 发送通知。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
-**支持的通知事件 (Notification Events)**：
 
-- `NOTIFICATION_EVT_PLAY_STATUS_CHANGED` (0x01): 播放状态变更
-- `NOTIFICATION_EVT_TRACK_CHANGED`: 曲目变更
-- `NOTIFICATION_EVT_TRACK_END`: 曲目结束
-- `NOTIFICATION_EVT_TRACK_START`: 曲目开始
-- `NOTIFICATION_EVT_PLAY_POS_CHANGED`: 播放位置变更
-- `NOTIFICATION_EVT_BATTERY_STATUS_CHANGED`: 电池状态变更
-- `NOTIFICATION_EVT_SYSTEM_STATUS_CHANGED`: 系统状态变更
-- `NOTIFICATION_EVT_APP_SETTING_CHANGED`: 应用设置变更
-- `NOTIFICATION_EVT_NOW_PLAYING_CONTENT_CHANGED`: 当前播放内容变更
-- `NOTIFICATION_EVT_AVAILABLE_PLAYERS_CHANGED`: 可用播放器变更
-- `NOTIFICATION_EVT_ADDRESSED_PLAYER_CHANGED`: 被控播放器变更
-- `NOTIFICATION_EVT_UIDS_CHANGED`: UID 变更
-- `NOTIFICATION_EVT_VOLUME_CHANGED`: 音量变更
-- `NOTIFICATION_EVT_FLAG_INTERIM`: 临时响应标志
+### bt_avrcp_control_send_passthrough_cmd
 
-### AVRCP Target API 详情
-
-```eval_rst
-
-.. doxygenfile:: bt_avrcp_target.h
-    :project: doxygen
+```c
+bt_status_t bt_avrcp_control_send_passthrough_cmd(bt_instance_t* ins, bt_address_t* addr, uint8_t cmd, uint8_t state);
 ```
+
+发送透传命令。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cmd` 命令。
+- `state` 状态。
+
+
+### bt_avrcp_control_get_unit_info
+
+```c
+bt_status_t bt_avrcp_control_get_unit_info(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程 AVRCP 设备的单元信息。
+
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址。
+
+
+### bt_avrcp_control_get_subunit_info
+
+```c
+bt_status_t bt_avrcp_control_get_subunit_info(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取子单元信息。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+### bt_avrcp_control_get_playback_state
+
+```c
+bt_status_t bt_avrcp_control_get_playback_state(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的当前播放状态。
+
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址。
+
+
+### bt_avrcp_control_register_notification
+
+```c
+bt_status_t bt_avrcp_control_register_notification(bt_instance_t* ins, bt_address_t* addr, uint8_t event, uint32_t interval);
+```
+
+注册事件通知。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `event` 事件类型。
+- `interval` 间隔。
+
+
+### bt_avrcp_target_unregister_callbacks
+
+```c
+bool bt_avrcp_target_unregister_callbacks(bt_instance_t* ins, void* cookie);
+```
+
+取消注册回调函数，停止接收状态变更通知。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
+
+
+
+- `cookie` 用户上下文。
+- `ins` 蓝牙客户端实例。
+
+**返回值**：
+
+成功时返回回调 cookie，失败或已注册时返回 NULL。
+
+
+### bt_avrcp_target_get_play_status_response
+
+```c
+bt_status_t bt_avrcp_target_get_play_status_response(bt_instance_t* ins, bt_address_t* addr, avrcp_play_status_t status, uint32_t song_len, uint32_t song_pos);
+```
+
+回复播放状态查询。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+- `status` 状态码。
+- `song_len` 歌曲长度（毫秒）。
+- `song_pos` 当前播放位置（毫秒）。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_avrcp_target_play_status_notify
+
+```c
+bt_status_t bt_avrcp_target_play_status_notify(bt_instance_t* ins, bt_address_t* addr, avrcp_play_status_t status);
+```
+
+通知播放状态变更。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `status` 状态码。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/doxygen/api/framework/bluetooth/bt_device.md
+++ b/doxygen/api/framework/bluetooth/bt_device.md
@@ -1,0 +1,1315 @@
+# 蓝牙设备管理 API
+
+openvela 蓝牙远程设备管理接口，提供设备配对、连接、属性查询和管理功能。
+
+头文件：`#include "bt_device.h"`
+
+
+## openvela 实现说明
+
+- **设备属性**：支持查询远程设备名称、地址、类型、配对状态、连接状态等
+- **配对管理**：支持发起配对、取消配对、确认配对请求
+- **连接管理**：支持建立和断开与远程设备的连接
+- **异步模式**：大部分 API 提供同步和异步两个版本
+
+
+## 同步接口
+
+
+### bt_device_get_identity_address
+
+```c
+bt_status_t bt_device_get_identity_address(bt_instance_t* ins, bt_address_t* bd_addr, bt_address_t* id_addr);
+```
+
+获取远程设备的身份地址（Identity Address），用于标识使用随机地址的 BLE 设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `bd_addr` 远程设备 BLE 地址。- `id_addr` 输出参数，存储身份地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_get_address_type
+
+```c
+ble_addr_type_t bt_device_get_address_type(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的 BLE 地址类型（Public/Static Random/RPA 等）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+
+**返回值**：
+
+返回设备的 BLE 地址类型，未找到时返回 `BLE_ADDR_TYPE_UNKNOWN`。
+
+
+### bt_device_get_device_type
+
+```c
+bt_device_type_t bt_device_get_device_type(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的类型（经典蓝牙/BLE/双模）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+
+
+### bt_device_get_name
+
+```c
+bool bt_device_get_name(bt_instance_t* ins, bt_address_t* addr, char* name, uint32_t length);
+```
+
+获取远程设备的蓝牙名称。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `name` 名称。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_get_device_class
+
+```c
+uint32_t bt_device_get_device_class(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的设备类型（Class of Device），包含主设备类、子设备类和服务类信息。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+
+**返回值**：
+
+
+
+### bt_device_get_uuids
+
+```c
+bt_status_t bt_device_get_uuids(bt_instance_t* ins, bt_address_t* addr, bt_uuid_t** uuids, uint16_t* size, bt_allocator_t allocator);
+```
+
+获取远程设备支持的服务 UUID 列表。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `allocator` 内存分配函数。- `uuids` UUID 数组（由 allocator 分配）。
+- `size` 返回 UUID 数量。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_get_appearance
+
+```c
+uint16_t bt_device_get_appearance(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的 BLE 外观特征值（Appearance），用于标识设备的物理外观。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+
+
+### bt_device_get_rssi
+
+```c
+int8_t bt_device_get_rssi(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取远程设备的接收信号强度指示（RSSI）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+
+
+### bt_device_get_alias
+
+```c
+bool bt_device_get_alias(bt_instance_t* ins, bt_address_t* addr, char* alias, uint32_t length);
+```
+
+获取远程设备的用户自定义别名，未设置时返回设备名称。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `length` 长度。- `alias` 输出参数，存储别名字符串。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_set_alias
+
+```c
+bt_status_t bt_device_set_alias(bt_instance_t* ins, bt_address_t* addr, const char* alias);
+```
+
+设置远程设备的用户自定义别名，长度不超过 BT_LOC_NAME_MAX_LEN。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `alias` 设备别名。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_is_connected
+
+```c
+bool bt_device_is_connected(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `transport` Transport type, 参见 bt_transport_t.
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_is_encrypted
+
+```c
+bool bt_device_is_encrypted(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+查询与远程设备的连接是否已加密。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `transport` Transport type, 参见 bt_transport_t.
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_is_bond_initiate_local
+
+```c
+bool bt_device_is_bond_initiate_local(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+查询与远程设备的配对是否由本地发起。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `transport` Transport type, 参见 bt_transport_t.
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_get_bond_state
+
+```c
+bond_state_t bt_device_get_bond_state(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+获取与远程设备的配对状态。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+返回当前配对状态，参见 bond_state_t。
+
+
+### bt_device_is_bonded
+
+```c
+bool bt_device_is_bonded(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+查询远程设备是否已配对。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_create_bond
+
+```c
+bt_status_t bt_device_create_bond(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+发起与远程设备的配对（Bonding），建立长期安全关系。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_set_security_level
+
+```c
+bt_status_t bt_device_set_security_level(bt_instance_t* ins, uint8_t level, bt_transport_t transport);
+```
+
+设置与远程设备的安全级别（0~4），级别越高安全性越强。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `level` 安全级别。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_set_bondable_le
+
+```c
+bt_status_t bt_device_set_bondable_le(bt_instance_t* ins, bool bondable);
+```
+
+设置远程设备是否允许 BLE 配对。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `bondable` 是否可配对。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_remove_bond
+
+```c
+bt_status_t bt_device_remove_bond(bt_instance_t* ins, bt_address_t* addr, uint8_t transport);
+```
+
+移除与远程设备的配对关系，删除存储的配对密钥。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_cancel_bond
+
+```c
+bt_status_t bt_device_cancel_bond(bt_instance_t* ins, bt_address_t* addr);
+```
+
+取消正在进行的配对过程。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_pair_request_reply
+
+```c
+bt_status_t bt_device_pair_request_reply(bt_instance_t* ins, bt_address_t* addr, bool accept);
+```
+
+回复远程设备的配对请求，接受或拒绝配对。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_set_pairing_confirmation
+
+```c
+bt_status_t bt_device_set_pairing_confirmation(bt_instance_t* ins, bt_address_t* addr, uint8_t transport, bool accept);
+```
+
+确认或拒绝 SSP 配对的数字比较请求。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `accept` 是否接受。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_set_pin_code
+
+```c
+bt_status_t bt_device_set_pin_code(bt_instance_t* ins, bt_address_t* addr, bool accept, char* pincode, int len);
+```
+
+设置 PIN 码用于传统配对认证。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+- `pincode` PIN 码字符串。
+- `len` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_set_pass_key
+
+```c
+bt_status_t bt_device_set_pass_key(bt_instance_t* ins, bt_address_t* addr, uint8_t transport, bool accept, uint32_t passkey);
+```
+
+设置数字密钥用于 SSP 配对认证。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `accept` 是否接受。
+- `passkey` 配对密钥。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_set_le_legacy_tk
+
+```c
+bt_status_t bt_device_set_le_legacy_tk(bt_instance_t* ins, bt_address_t* addr, bt_128key_t tk_val);
+```
+
+设置 BLE Legacy 配对 TK 值。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `tk_val` OOB TK 值。
+
+
+### bt_device_set_le_sc_remote_oob_data
+
+```c
+bt_status_t bt_device_set_le_sc_remote_oob_data(bt_instance_t* ins, bt_address_t* addr, bt_128key_t c_val, bt_128key_t r_val);
+```
+
+设置远程设备的 BLE Secure Connections OOB 数据，用于带外配对。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `c_val` SC 确认值（128 位）。
+- `r_val` SC 随机值（128 位）。
+
+
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `c_val` LE 安全连接确认值（128 位密钥）。
+- `r_val` LE 安全连接随机值（128 位密钥）。
+
+
+### bt_device_get_le_sc_local_oob_data
+
+```c
+bt_status_t bt_device_get_le_sc_local_oob_data(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取 BLE SC 本地 OOB 数据。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_connect
+
+```c
+bt_status_t bt_device_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_background_connect
+
+```c
+bt_status_t bt_device_background_connect(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_disconnect
+
+```c
+bt_status_t bt_device_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_device_background_disconnect
+
+```c
+bt_status_t bt_device_background_disconnect(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_device_connect_le
+
+```c
+bt_status_t bt_device_connect_le(bt_instance_t* ins, bt_address_t* addr, ble_addr_type_t type, ble_connect_params_t* param);
+```
+
+发起与远程设备的 BLE 连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 蓝牙地址。
+- `type` LE address type, 参见 ble_addr_type_t.
+- `param` 指向 connection parameters, 参见 ble_connect_params_t.
+
+
+### bt_device_disconnect_le
+
+```c
+bt_status_t bt_device_disconnect_le(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的 BLE 连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 蓝牙地址。
+
+
+### bt_device_connect_request_reply
+
+```c
+bt_status_t bt_device_connect_request_reply(bt_instance_t* ins, bt_address_t* addr, bool accept);
+```
+
+回复远程设备的连接请求，接受或拒绝连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+
+
+### bt_device_set_le_phy
+
+```c
+bt_status_t bt_device_set_le_phy(bt_instance_t* ins, bt_address_t* addr, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy);
+```
+
+设置与远程设备的 BLE PHY 配置（1M/2M/Coded）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `tx_phy` 发送 PHY。
+- `rx_phy` 接收 PHY。
+
+
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 蓝牙地址。
+- `tx_phy` Preferred TX PHY, 参见 ble_phy_type_t.
+- `rx_phy` Preferred RX PHY, 参见 ble_phy_type_t.
+
+
+### bt_device_connect_all_profile
+
+```c
+void bt_device_connect_all_profile(bt_instance_t* ins, bt_address_t* addr);
+```
+
+连接所有 Profile 连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+### bt_device_disconnect_all_profile
+
+```c
+void bt_device_disconnect_all_profile(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的所有 Profile 连接。
+
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+
+
+### bt_device_enable_enhanced_mode
+
+```c
+bt_status_t bt_device_enable_enhanced_mode(bt_instance_t* ins, bt_address_t* addr, bt_enhanced_mode_t mode);
+```
+
+启用与远程设备的增强模式。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `mode` 模式。
+
+
+### bt_device_disable_enhanced_mode
+
+```c
+bt_status_t bt_device_disable_enhanced_mode(bt_instance_t* ins, bt_address_t* addr, bt_enhanced_mode_t mode);
+```
+
+禁用与远程设备的增强模式。
+
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 远程设备地址.
+- `mode` Enhanced mode to disable, 参见 bt_enhanced_mode_t.
+
+
+## 异步接口
+
+
+### bt_device_get_identity_address_async
+
+```c
+bt_status_t bt_device_get_identity_address_async(bt_instance_t* ins, bt_address_t* bd_addr, bt_address_cb_t cb, void* userdata);
+```
+
+获取身份地址（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `bd_addr` BLE 地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_get_address_type_async
+
+```c
+bt_status_t bt_device_get_address_type_async(bt_instance_t* ins, bt_address_t* addr, bt_device_get_address_type_cb_t cb, void* userdata);
+```
+
+获取远程设备的 BLE 地址类型。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_get_device_type_async
+
+```c
+bt_status_t bt_device_get_device_type_async(bt_instance_t* ins, bt_address_t* addr, bt_device_type_cb_t cb, void* userdata);
+```
+
+获取设备类型（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_get_name_async
+
+```c
+bt_status_t bt_device_get_name_async(bt_instance_t* ins, bt_address_t* addr, bt_string_cb_t cb, void* userdata);
+```
+
+获取远程设备名称（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_get_device_class_async
+
+```c
+bt_status_t bt_device_get_device_class_async(bt_instance_t* ins, bt_address_t* addr, bt_u32_cb_t cb, void* userdata);
+```
+
+获取设备类型（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_get_uuids_async
+
+```c
+bt_status_t bt_device_get_uuids_async(bt_instance_t* ins, bt_address_t* addr, bt_uuids_cb_t cb, void* userdata);
+```
+
+获取远程设备支持的 UUID 列表。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_get_appearance_async
+
+```c
+bt_status_t bt_device_get_appearance_async(bt_instance_t* ins, bt_address_t* addr, bt_u16_cb_t cb, void* userdata);
+```
+
+获取外观特征值（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_get_rssi_async
+
+```c
+bt_status_t bt_device_get_rssi_async(bt_instance_t* ins, bt_address_t* addr, bt_s8_cb_t cb, void* userdata);
+```
+
+获取远程设备的 RSSI（接收信号强度）。（异步版本）
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_get_alias_async
+
+```c
+bt_status_t bt_device_get_alias_async(bt_instance_t* ins, bt_address_t* addr, bt_string_cb_t cb, void* userdata);
+```
+
+获取别名（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_set_alias_async
+
+```c
+bt_status_t bt_device_set_alias_async(bt_instance_t* ins, bt_address_t* addr, const char* alias, bt_status_cb_t cb, void* userdata);
+```
+
+设置远程设备的别名。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `alias` 别名。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_is_connected_async
+
+```c
+bt_status_t bt_device_is_connected_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_bool_cb_t cb, void* userdata);
+```
+
+检查是否已连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_is_encrypted_async
+
+```c
+bt_status_t bt_device_is_encrypted_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_bool_cb_t cb, void* userdata);
+```
+
+检查与远程设备的连接是否已加密。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_is_bond_initiate_local_async
+
+```c
+bt_status_t bt_device_is_bond_initiate_local_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_bool_cb_t cb, void* userdata);
+```
+
+查询配对是否由本地发起（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_get_bond_state_async
+
+```c
+bt_status_t bt_device_get_bond_state_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_device_get_bond_state_cb_t cb, void* userdata);
+```
+
+获取与远程设备的配对状态（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_is_bonded_async
+
+```c
+bt_status_t bt_device_is_bonded_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_bool_cb_t cb, void* userdata);
+```
+
+查询是否已配对（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_connect_async
+
+```c
+bt_status_t bt_device_connect_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+连接远程设备（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_disconnect_async
+
+```c
+bt_status_t bt_device_disconnect_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+断开连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_connect_le_async
+
+```c
+bt_status_t bt_device_connect_le_async(bt_instance_t* ins, bt_address_t* addr, ble_addr_type_t type, ble_connect_params_t* param, bt_status_cb_t cb, void* userdata);
+```
+
+连接远程 BLE 设备（异步版本，支持指定连接参数）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `type` 类型。
+- `param` 连接参数结构体。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_disconnect_le_async
+
+```c
+bt_status_t bt_device_disconnect_le_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+断开BLE 连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_connect_request_reply_async
+
+```c
+bt_status_t bt_device_connect_request_reply_async(bt_instance_t* ins, bt_address_t* addr, bool accept, bt_status_cb_t cb, void* userdata);
+```
+
+回复连接请求（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_connect_all_profile_async
+
+```c
+bt_status_t bt_device_connect_all_profile_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+连接所有 Profile 连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_disconnect_all_profile_async
+
+```c
+bt_status_t bt_device_disconnect_all_profile_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+断开所有 Profile 连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_set_le_phy_async
+
+```c
+bt_status_t bt_device_set_le_phy_async(bt_instance_t* ins, bt_address_t* addr, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy, bt_status_cb_t cb, void* userdata);
+```
+
+设置BLE PHY 配置（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `tx_phy` 发送 PHY。
+- `rx_phy` 接收 PHY。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_create_bond_async
+
+```c
+bt_status_t bt_device_create_bond_async(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport, bt_status_cb_t cb, void* userdata);
+```
+
+发起与远程设备的配对（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_remove_bond_async
+
+```c
+bt_status_t bt_device_remove_bond_async(bt_instance_t* ins, bt_address_t* addr, uint8_t transport, bt_status_cb_t cb, void* userdata);
+```
+
+取消配对（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_cancel_bond_async
+
+```c
+bt_status_t bt_device_cancel_bond_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+取消正在进行的配对（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_pair_request_reply_async
+
+```c
+bt_status_t bt_device_pair_request_reply_async(bt_instance_t* ins, bt_address_t* addr, bool accept, bt_status_cb_t cb, void* userdata);
+```
+
+配对配对请求回复（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_set_pairing_confirmation_async
+
+```c
+bt_status_t bt_device_set_pairing_confirmation_async(bt_instance_t* ins, bt_address_t* addr, uint8_t transport, bool accept, bt_status_cb_t cb, void* userdata);
+```
+
+设置安全配对确认（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `accept` 是否接受。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_set_pin_code_async
+
+```c
+bt_status_t bt_device_set_pin_code_async(bt_instance_t* ins, bt_address_t* addr, bool accept, char* pincode, int len, bt_status_cb_t cb, void* userdata);
+```
+
+设置 PIN 码（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `accept` 是否接受。
+- `pincode` PIN 码字符串。
+- `len` 长度。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_set_pass_key_async
+
+```c
+bt_status_t bt_device_set_pass_key_async(bt_instance_t* ins, bt_address_t* addr, uint8_t transport, bool accept, uint32_t passkey, bt_status_cb_t cb, void* userdata);
+```
+
+设置配对密钥（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `accept` 是否接受。
+- `passkey` 配对密钥。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_set_le_legacy_tk_async
+
+```c
+bt_status_t bt_device_set_le_legacy_tk_async(bt_instance_t* ins, bt_address_t* addr, bt_128key_t tk_val, bt_status_cb_t cb, void* userdata);
+```
+
+设置 BLE Legacy 配对 TK 值（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `tk_val` OOB TK 值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_device_set_le_sc_remote_oob_data_async
+
+```c
+bt_status_t bt_device_set_le_sc_remote_oob_data_async(bt_instance_t* ins, bt_address_t* addr, bt_128key_t c_val, bt_128key_t r_val, bt_status_cb_t cb, void* userdata);
+```
+
+设置 LE SC 配对的远程 OOB 数据（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `c_val` SC 确认值。
+- `r_val` SC 随机值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_device_get_le_sc_local_oob_data_async
+
+```c
+bt_status_t bt_device_get_le_sc_local_oob_data_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+获取 LE SC 配对的本地 OOB 数据（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+

--- a/doxygen/api/framework/bluetooth/bt_gap.md
+++ b/doxygen/api/framework/bluetooth/bt_gap.md
@@ -1,42 +1,1238 @@
-# 蓝牙 GAP API 开发指南
+# 蓝牙 GAP API
 
-**通用访问规范 (Generic Access Profile, GAP)** 是蓝牙协议栈的基础层，定义了蓝牙设备如何发现彼此、建立连接以及管理安全认证。它主要负责处理设备未连接时的行为（如广播、扫描）以及连接建立后的安全配置。
+openvela 蓝牙 GAP（通用访问规范）接口提供蓝牙适配器的管理功能，包括启用/禁用、设备发现、属性配置、配对管理等。
 
-在 openvela 系统中，GAP 接口主要围绕 **本地蓝牙适配器 (Local Bluetooth Adapter)** 的管理展开。
+头文件：`#include "bt_adapter.h"`
 
-## 1. 接口概览
+## openvela 实现说明
 
-`bt_adapter` 模块提供了蓝牙基础功能的控制入口。整体接口设计根据使用场景分为两类：
+- **双模支持**：支持经典蓝牙（BR/EDR）和低功耗蓝牙（BLE）独立控制
+- **异步模式**：大部分 API 提供同步和异步两个版本，异步版本以 `_async` 后缀命名，通过回调返回结果
+- **实例管理**：所有 API 的第一个参数为 `bt_instance_t* ins`（蓝牙客户端实例），通过 `bt_open()` 获取
+- **状态机**：适配器状态遵循 OFF → BLE_TURNING_ON → BLE_ON → TURNING_ON → ON 的转换流程
 
-### 1.1 应用开发接口 (Application APIs)
 
-这是面向最终应用开发者的核心接口，封装了标准的蓝牙业务逻辑。
+## 适配器控制
 
-- **功能范围**：
-  
-    - 蓝牙协议栈的初始化与去初始化 (Enable/Disable)。
-    - 设备属性配置（如设备名称、本地地址查询）。
-    - 扫描 (Scanning) 与广播 (Advertising) 参数设置。
-    - 配对与绑定管理 (Pairing & Bonding)。
 
-- **适用场景**：常规的蓝牙业务开发，如连接耳机、数据传输、HID 设备交互等。
+#### bt_adapter_get_state
 
-### 1.2 诊断与调试接口 (Debug & Test APIs)
-
-这是一组面向底层验证和系统调试的扩展接口。
-
-- **功能范围**：
-
-    - 强制模式切换。
-    - 射频 (RF) 测试模式控制。
-    - 底层状态转储 (State Dump)。
-
-- **适用场景**：工厂生产测试 (PTS)、硬件认证、故障排查。
-
-### API 详情
-
-```eval_rst
-
-.. doxygenfile:: bt_adapter.h
-    :project: doxygen
+```c
+bt_adapter_state_t bt_adapter_get_state(bt_instance_t* ins);
 ```
+
+获取适配器状态。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+**返回值**：
+
+bt_adapter_get_state 操作。
+
+
+#### bt_adapter_is_support_le
+
+```c
+bool bt_adapter_is_support_le(bt_instance_t* ins);
+```
+
+查询是否支持 BLE。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_adapter_is_support_le 操作。
+
+
+#### bt_adapter_is_support_leaudio
+
+```c
+bool bt_adapter_is_support_leaudio(bt_instance_t* ins);
+```
+
+查询是否支持 LE Audio。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_adapter_is_support_leaudio 操作。
+
+
+## 设备发现
+
+
+#### bt_adapter_set_discovery_filter
+
+```c
+bt_status_t bt_adapter_set_discovery_filter(bt_instance_t* ins);
+```
+
+设置设备发现过滤条件。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+
+#### bt_adapter_start_discovery
+
+```c
+bt_status_t bt_adapter_start_discovery(bt_instance_t* ins, uint32_t timeout);
+```
+
+开始设备发现。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `timeout` 超时时间。
+
+**返回值**：
+
+bt_adapter_start_discovery 操作。
+
+
+#### bt_adapter_cancel_discovery
+
+```c
+bt_status_t bt_adapter_cancel_discovery(bt_instance_t* ins);
+```
+
+取消设备发现。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+**返回值**：
+
+bt_adapter_cancel_discovery 操作。
+
+
+#### bt_adapter_is_discovering
+
+```c
+bool bt_adapter_is_discovering(bt_instance_t* ins);
+```
+
+查询是否正在发现设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_adapter_is_discovering 操作。
+
+
+## 属性管理
+
+
+#### bt_adapter_get_type
+
+```c
+bt_device_type_t bt_adapter_get_type(bt_instance_t* ins);
+```
+
+获取设备类型。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+
+#### bt_adapter_set_name
+
+```c
+bt_status_t bt_adapter_set_name(bt_instance_t* ins, const char* name);
+```
+
+设置设备名称。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `name` 名称。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。。
+
+
+#### bt_adapter_get_name
+
+```c
+void bt_adapter_get_name(bt_instance_t* ins, char* name, int length);
+```
+
+获取设备名称。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `name` 输出参数，存储适配器名称。
+- `length` 缓冲区长度。
+
+
+#### bt_adapter_set_scan_mode
+
+```c
+bt_status_t bt_adapter_set_scan_mode(bt_instance_t* ins, bt_scan_mode_t mode, bool bondable);
+```
+
+设置扫描模式。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `mode` 模式。
+- `bondable` 是否可配对。
+- `name` 输出参数，存储适配器名称。
+- `length` 缓冲区长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。。
+
+
+#### bt_adapter_get_scan_mode
+
+```c
+bt_scan_mode_t bt_adapter_get_scan_mode(bt_instance_t* ins);
+```
+
+获取扫描模式。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+
+
+#### bt_adapter_set_device_class
+
+```c
+bt_status_t bt_adapter_set_device_class(bt_instance_t* ins, uint32_t cod);
+```
+
+设置设备类型（CoD）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cod` 设备类型（CoD）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。。
+
+
+#### bt_adapter_get_device_class
+
+```c
+uint32_t bt_adapter_get_device_class(bt_instance_t* ins);
+```
+
+获取设备类型（CoD）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+
+
+#### bt_adapter_set_debug_mode
+
+```c
+bt_status_t bt_adapter_set_debug_mode(bt_instance_t* ins, bt_debug_mode_t mode, uint8_t operation);
+```
+
+设置蓝牙适配器的调试模式，用于工厂测试和射频认证。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `mode` 调试模式。
+- `operation` 调试操作。
+
+
+#### bt_adapter_set_le_address
+
+```c
+bt_status_t bt_adapter_set_le_address(bt_instance_t* ins, bt_address_t* addr);
+```
+
+设置本地 BLE 地址。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 指向 the BLE identity address.
+
+
+#### bt_adapter_set_le_appearance
+
+```c
+bt_status_t bt_adapter_set_le_appearance(bt_instance_t* ins, uint16_t appearance);
+```
+
+设置 BLE 外观值。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `appearance` BLE 外观值。
+
+
+#### bt_adapter_le_add_whitelist_with_type
+
+```c
+bt_status_t bt_adapter_le_add_whitelist_with_type(bt_instance_t* ins, bt_address_t* addr, ble_addr_type_t type);
+```
+
+BLE 连接添加BLE 白名单（指定类型）特征值（签名写入）type。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 设备地址。
+- `type` 地址类型。
+
+
+## 配对与安全
+
+
+#### bt_adapter_set_io_capability
+
+```c
+bt_status_t bt_adapter_set_io_capability(bt_instance_t* ins, bt_io_capability_t cap);
+```
+
+设置 IO 能力。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `cap` IO 能力值。
+
+
+#### bt_adapter_get_bonded_devices
+
+```c
+bt_status_t bt_adapter_get_bonded_devices(bt_instance_t* ins, bt_transport_t transport, bt_address_t** addr, int* num, bt_allocator_t allocator);
+```
+
+获取已配对设备列表。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `transport` Transport type, 参见 bt_transport_t.
+- `allocator` 内存分配函数。
+- `addr` 输出参数，存储已配对设备地址数组。
+- `num` 输出参数，存储设备数量。
+
+
+#### bt_adapter_disconnect_all_devices
+
+```c
+void bt_adapter_disconnect_all_devices(bt_instance_t* ins);
+```
+
+断开所有已连接设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+
+#### bt_adapter_get_le_io_capability
+
+```c
+uint32_t bt_adapter_get_le_io_capability(bt_instance_t* ins);
+```
+
+获取 BLE IO 能力。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.- `mode` 调试模式。
+- `operation` 调试操作。
+- `appearance` BLE 外观值。
+- `addr` 设备地址。
+- `type` 地址类型。
+- `cap` IO 能力值。
+- `num` 输出参数，存储设备数量。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+## BLE 管理
+
+
+#### bt_adapter_enable
+
+```c
+bt_status_t bt_adapter_enable(bt_instance_t* ins);
+```
+
+启用蓝牙适配器。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_adapter_enable 操作。
+
+
+#### bt_adapter_disable
+
+```c
+bt_status_t bt_adapter_disable(bt_instance_t* ins);
+```
+
+禁用蓝牙适配器。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+**返回值**：
+
+bt_adapter_disable 操作。
+
+
+#### bt_adapter_disable_safe
+
+```c
+bt_status_t bt_adapter_disable_safe(bt_instance_t* ins);
+```
+
+安全禁用蓝牙适配器，等待所有连接断开后再关闭。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+
+#### bt_adapter_disable_le
+
+```c
+bt_status_t bt_adapter_disable_le(bt_instance_t* ins);
+```
+
+禁用低功耗蓝牙（BLE）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+
+#### bt_adapter_is_le_enabled
+
+```c
+bool bt_adapter_is_le_enabled(bt_instance_t* ins);
+```
+
+查询 BLE 是否已启用。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_adapter_is_le_enabled 操作。
+
+
+#### bt_adapter_le_enable_key_derivation
+
+```c
+bt_status_t bt_adapter_le_enable_key_derivation(bt_instance_t* ins, bool brkey_to_lekey, bool lekey_to_brkey);
+```
+
+启用 BLE 密钥派生。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `brkey_to_lekey` 是否启用 BR→LE 密钥派生。
+- `lekey_to_brkey` 是否启用 LE→BR 密钥派生。
+
+
+#### bt_adapter_le_remove_whitelist
+
+```c
+bt_status_t bt_adapter_le_remove_whitelist(bt_instance_t* ins, bt_address_t* addr);
+```
+
+从 BLE 白名单移除设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` 要移除的设备地址。
+
+
+#### bt_adapter_set_page_scan_parameters
+
+```c
+bt_status_t bt_adapter_set_page_scan_parameters(bt_instance_t* ins, bt_scan_type_t type, uint16_t interval, uint16_t window);
+```
+
+设置页面扫描参数。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `type` 扫描类型。
+- `interval` 扫描间隔。
+- `window` 扫描窗口。
+
+
+## 异步接口
+
+
+#### bt_adapter_register_callback_async
+
+```c
+bt_status_t bt_adapter_register_callback_async(bt_instance_t* ins, const adapter_callbacks_t* adapter_cbs, bt_register_callback_cb_t cb, void* userdata);
+```
+
+异步版本。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `adapter_cbs` 适配器回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_unregister_callback_async
+
+```c
+bt_status_t bt_adapter_unregister_callback_async(bt_instance_t* ins, void* cookie, bt_bool_cb_t cb, void* userdata);
+```
+
+取消注册回调函数（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_enable_async
+
+```c
+bt_status_t bt_adapter_enable_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+适配器状态变更回调（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_disable_async
+
+```c
+bt_status_t bt_adapter_disable_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+禁用蓝牙适配器.（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_enable_le_async
+
+```c
+bt_status_t bt_adapter_enable_le_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+启用低功耗蓝牙（BLE）.（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_disable_le_async
+
+```c
+bt_status_t bt_adapter_disable_le_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+禁用低功耗蓝牙（BLE）.（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_state_async
+
+```c
+bt_status_t bt_adapter_get_state_async(bt_instance_t* ins, bt_adapter_get_state_cb_t get_state_cb, void* userdata);
+```
+
+获取当前适配器状态（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_state_cb` 获取状态的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_is_le_enabled_async
+
+```c
+bt_status_t bt_adapter_is_le_enabled_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+Check if BLE is enabled（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_type_async
+
+```c
+bt_status_t bt_adapter_get_type_async(bt_instance_t* ins, bt_device_type_cb_t get_dtype_cb, void* userdata);
+```
+
+获取适配器设备类型（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_dtype_cb` 获取设备类型的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_discovery_filter_async
+
+```c
+bt_status_t bt_adapter_set_discovery_filter_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+Set the discovery filter（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_start_discovery_async
+
+```c
+bt_status_t bt_adapter_start_discovery_async(bt_instance_t* ins, uint32_t timeout, bt_status_cb_t cb, void* userdata);
+```
+
+开始设备发现.（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `timeout` 超时时间。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_cancel_discovery_async
+
+```c
+bt_status_t bt_adapter_cancel_discovery_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+取消设备发现.（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_is_discovering_async
+
+```c
+bt_status_t bt_adapter_is_discovering_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+查询适配器是否正在发现设备（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_address_async
+
+```c
+bt_status_t bt_adapter_get_address_async(bt_instance_t* ins, bt_address_cb_t cb, void* userdata);
+```
+
+读取蓝牙控制器地址（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_name_async
+
+```c
+bt_status_t bt_adapter_set_name_async(bt_instance_t* ins, const char* name, bt_status_cb_t cb, void* userdata);
+```
+
+设置适配器本地名称（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `name` 名称。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_name_async
+
+```c
+bt_status_t bt_adapter_get_name_async(bt_instance_t* ins, bt_string_cb_t get_name_cb, void* userdata);
+```
+
+获取适配器本地名称（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_name_cb` 获取名称的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_uuids_async
+
+```c
+bt_status_t bt_adapter_get_uuids_async(bt_instance_t* ins, bt_uuids_cb_t get_uuids_cb, void* userdata);
+```
+
+获取适配器支持的 UUID 列表（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_uuids_cb` 获取 UUID 列表的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_scan_mode_async
+
+```c
+bt_status_t bt_adapter_set_scan_mode_async(bt_instance_t* ins, bt_scan_mode_t mode, bool bondable, bt_status_cb_t cb, void* userdata);
+```
+
+设置适配器扫描模式（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `mode` 模式。
+- `bondable` 是否可配对。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_scan_mode_async
+
+```c
+bt_status_t bt_adapter_get_scan_mode_async(bt_instance_t* ins, bt_adapter_get_scan_mode_cb_t get_scan_mode_cb, void* userdata);
+```
+
+获取适配器扫描模式（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_scan_mode_cb` 获取扫描模式的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_device_class_async
+
+```c
+bt_status_t bt_adapter_set_device_class_async(bt_instance_t* ins, uint32_t cod, bt_status_cb_t cb, void* userdata);
+```
+
+设置适配器设备类型（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cod` 设备类型（CoD）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_device_class_async
+
+```c
+bt_status_t bt_adapter_get_device_class_async(bt_instance_t* ins, bt_u32_cb_t get_cod_cb, void* userdata);
+```
+
+获取适配器设备类型（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_cod_cb` 获取设备类型的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_io_capability_async
+
+```c
+bt_status_t bt_adapter_set_io_capability_async(bt_instance_t* ins, bt_io_capability_t cap, bt_status_cb_t cb, void* userdata);
+```
+
+Set the BR/EDR adapter IO capability（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cap` IO 能力值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_io_capability_async
+
+```c
+bt_status_t bt_adapter_get_io_capability_async(bt_instance_t* ins, bt_adapter_get_io_capability_cb_t get_ioc_cb, void* userdata);
+```
+
+Get the BR/EDR adapter IO capability（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_ioc_cb` 获取 IO 能力的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_inquiry_scan_parameters_async
+
+```c
+bt_status_t bt_adapter_set_inquiry_scan_parameters_async(bt_instance_t* ins, bt_scan_type_t type, uint16_t interval, uint16_t window, bt_status_cb_t cb, void* userdata);
+```
+
+设置查询扫描参数（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `type` 类型。
+- `interval` 间隔。
+- `window` 扫描窗口（时间槽数）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_page_scan_parameters_async
+
+```c
+bt_status_t bt_adapter_set_page_scan_parameters_async(bt_instance_t* ins, bt_scan_type_t type, uint16_t interval, uint16_t window, bt_status_cb_t cb, void* userdata);
+```
+
+设置页面扫描参数（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `type` 类型。
+- `interval` 间隔。
+- `window` 扫描窗口（时间槽数）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_le_io_capability_async
+
+```c
+bt_status_t bt_adapter_set_le_io_capability_async(bt_instance_t* ins, uint32_t le_io_cap, bt_status_cb_t cb, void* userdata);
+```
+
+Set the BLE adapter IO capability（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `le_io_cap` BLE IO 能力值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_le_io_capability_async
+
+```c
+bt_status_t bt_adapter_get_le_io_capability_async(bt_instance_t* ins, bt_u32_cb_t get_le_ioc_cb, void* userdata);
+```
+
+Get the BLE adapter IO capability（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `get_le_ioc_cb` 获取 BLE IO 能力的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_le_address_async
+
+```c
+bt_status_t bt_adapter_get_le_address_async(bt_instance_t* ins, bt_adapter_get_le_address_cb_t cb, void* userdata);
+```
+
+Get the BLE adapter address（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_le_address_async
+
+```c
+bt_status_t bt_adapter_set_le_address_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+Set the BLE private address（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_le_identity_address_async
+
+```c
+bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool is_public, bt_status_cb_t cb, void* userdata);
+```
+
+Set the BLE identity address（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `is_public` 是否使用公共地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_le_appearance_async
+
+```c
+bt_status_t bt_adapter_set_le_appearance_async(bt_instance_t* ins, uint16_t appearance, bt_status_cb_t cb, void* userdata);
+```
+
+Set the BLE adapter appearance（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `appearance` 外观值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_le_appearance_async
+
+```c
+bt_status_t bt_adapter_get_le_appearance_async(bt_instance_t* ins, bt_u16_cb_t cb, void* userdata);
+```
+
+Get the BLE adapter appearance（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_le_enable_key_derivation_async
+
+```c
+bt_status_t bt_adapter_le_enable_key_derivation_async(bt_instance_t* ins, bool brkey_to_lekey, bool lekey_to_brkey, bt_status_cb_t cb, void* userdata);
+```
+
+启用或禁用跨传输密钥派生（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `brkey_to_lekey` 是否启用 BR 密钥派生 LE 密钥。
+- `lekey_to_brkey` 是否启用 LE 密钥派生 BR 密钥。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_le_add_whitelist_async
+
+```c
+bt_status_t bt_adapter_le_add_whitelist_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+Add a device to the BLE whitelist（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_le_remove_whitelist_async
+
+```c
+bt_status_t bt_adapter_le_remove_whitelist_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
+```
+
+从 BLE 白名单移除设备（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_bonded_devices_async
+
+```c
+bt_status_t bt_adapter_get_bonded_devices_async(bt_instance_t* ins, bt_transport_t transport, bt_adapter_get_devices_cb_t get_bonded_cb, void* userdata);
+```
+
+获取已配对设备列表（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `get_bonded_cb` 获取已配对设备列表的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_get_connected_devices_async
+
+```c
+bt_status_t bt_adapter_get_connected_devices_async(bt_instance_t* ins, bt_transport_t transport, bt_adapter_get_devices_cb_t get_connected_cb, void* userdata);
+```
+
+获取已连接设备列表（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `transport` 传输类型（BR/EDR 或 BLE）。
+- `get_connected_cb` 获取已连接设备列表的回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_afh_channel_classification_async
+
+```c
+bt_status_t bt_adapter_set_afh_channel_classification_async(bt_instance_t* ins, uint16_t central_frequency, uint16_t band_width, uint16_t number, bt_status_cb_t cb, void* userdata);
+```
+
+设置 AFH 自适应跳频信道分类（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `central_frequency` 中心频率（MHz）。
+- `band_width` 带宽（MHz）。
+- `number` 号码。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_set_auto_sniff_async
+
+```c
+bt_status_t bt_adapter_set_auto_sniff_async(bt_instance_t* ins, bt_auto_sniff_params_t* params, bt_status_cb_t cb, void* userdata);
+```
+
+设置自动 Sniff 模式参数（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `params` 参数结构体。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_disconnect_all_devices_async
+
+```c
+bt_status_t bt_adapter_disconnect_all_devices_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
+```
+
+断开所有已连接设备（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_is_support_bredr_async
+
+```c
+bt_status_t bt_adapter_is_support_bredr_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+Check if BR/EDR is supported（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_is_support_le_async
+
+```c
+bt_status_t bt_adapter_is_support_le_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+Check if BLE is supported（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+#### bt_adapter_is_support_leaudio_async
+
+```c
+bt_status_t bt_adapter_is_support_leaudio_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+查询是否支持 LE Audio（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+

--- a/doxygen/api/framework/bluetooth/bt_gatt.md
+++ b/doxygen/api/framework/bluetooth/bt_gatt.md
@@ -1,51 +1,946 @@
-# 蓝牙 GATT API 开发指南
+# 蓝牙 GATT API
 
-**通用属性规范 (Generic Attribute Profile, GATT)** 是蓝牙低功耗 (BLE) 数据通信的核心层。它基于 ATT (Attribute Protocol) 构建，定义了两个连接设备之间如何进行数据传输。
+openvela 蓝牙 GATT（通用属性规范）接口，支持 BLE 数据属性的读写与通知。
 
-GATT 使用层级结构来组织数据：
+头文件：#include "bt_gattc.h"、#include "bt_gatts.h"
 
-- **Service (服务)**：功能的逻辑集合（如“心率服务”）。
-- **Characteristic (特征)**：实际的数据点（如“心率测量值”）。
 
-## 1. 接口概览
+## openvela 实现说明
 
-`bt_gatt` 模块的接口设计遵循 GATT 的 C/S (Client/Server) 架构。开发者需根据设备在业务逻辑中扮演的角色，选择对应的接口集。
+- **双角色支持**：Client（GATTC，发起读写请求）和 Server（GATTS，提供服务和特征值）
+- **BLE 核心**：GATT 是 BLE 数据交换的基础协议
 
-> **注意**：一个设备可以同时作为 GATT Client 和 GATT Server。
 
-### 1.1 GATT Client 接口 (GATTC)
+## 同步接口
 
-`bt_gattc` (GATT Client) 模块面向**数据的使用者**。通常是手机 App 或网关设备，它们主动发起请求以获取或控制远程设备的数据。
 
-- **核心职责**：
+### bt_gattc_create_connect
 
-    - **发现 (Discovery)**：遍历远程设备的 Service 和 Characteristic (UUID)。
-    - **读写操作 (Read/Write)**：读取传感器数据或写入控制指令。
-    - **订阅 (Subscription)**：配置 CCCD 以接收远程设备的 Notification/Indication 推送。
-    - **MTU 协商**：调整最大传输单元以优化吞吐量。
-
-**API 参考：**
-
-```eval_rst
-
-.. doxygenfile:: bt_gattc.h
-    :project: doxygen
+```c
+bt_status_t bt_gattc_create_connect(bt_instance_t* ins, gattc_handle_t* phandle, gattc_callbacks_t* callbacks);
 ```
 
-### 1.2 GATT Server 接口 (GATTS)
+发起与远程设备的连接。
 
-`bt_gatts` (GATT Server) 模块面向**数据的持有者**。通常是传感器、手环或智能家居终端，它们存储数据并响应 Client 的请求。
+**参数**：
 
-- **核心职责**：
+- `ins` 蓝牙客户端实例。
+- `phandle` 输出参数，存储 GATT 客户端句柄。
+- `callbacks` 回调函数集合。
 
-    - **属性表构建**：注册本地 Service、Characteristic 及 Descriptor。
-    - **请求响应**：处理来自 Client 的 Read/Write 请求（支持回调鉴权）。
-    - **主动推送**：当本地数据变化时，通过 Notification 或 Indication 主动通知已订阅的 Client。
 
-**API 参考：**
+**返回值**：
 
-```eval_rst
+无返回值。
 
-.. doxygenfile:: bt_gatts.h
-    :project: doxygen
+
+### bt_gattc_delete_connect
+
+```c
+bt_status_t bt_gattc_delete_connect(gattc_handle_t conn_handle);
 ```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+
+
+**返回值**：
+
+建立连接。
+
+
+### bt_gattc_connect
+
+```c
+bt_status_t bt_gattc_connect(gattc_handle_t conn_handle, bt_address_t* addr, ble_addr_type_t addr_type);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `addr` 远程设备蓝牙地址。
+- `addr_type` BLE 地址类型。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_disconnect
+
+```c
+bt_status_t bt_gattc_disconnect(gattc_handle_t conn_handle);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+
+
+**返回值**：
+
+断开连接。
+
+
+### bt_gattc_discover_service
+
+```c
+bt_status_t bt_gattc_discover_service(gattc_handle_t conn_handle, bt_uuid_t* filter_uuid);
+```
+
+发现远程设备上的 GATT 服务，结果通过回调异步返回。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `filter_uuid` 服务 UUID 过滤条件（NULL 表示不过滤）。
+
+**返回值**：
+
+bt_gattc_discover_service 操作。
+
+
+### bt_gattc_get_attribute_by_handle
+
+```c
+bt_status_t bt_gattc_get_attribute_by_handle(gattc_handle_t conn_handle, uint16_t attr_handle, gatt_attr_desc_t* attr_desc);
+```
+
+通过属性句柄获取 GATT 属性信息。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `attr_desc` 输出参数，存储属性描述信息。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_get_attribute_by_uuid
+
+```c
+bt_status_t bt_gattc_get_attribute_by_uuid(gattc_handle_t conn_handle, uint16_t start_handle, uint16_t end_handle, bt_uuid_t* attr_uuid, gatt_attr_desc_t* attr_desc);
+```
+
+通过 UUID 获取 GATT 属性信息。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `start_handle` 起始句柄。
+- `end_handle` 结束句柄。
+- `attr_uuid` 属性 UUID。
+- `attr_desc` 输出参数，存储属性描述信息。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_read
+
+```c
+bt_status_t bt_gattc_read(gattc_handle_t conn_handle, uint16_t attr_handle);
+```
+
+读取远程设备的 GATT 特征值或描述符，结果通过回调异步返回。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_write
+
+```c
+bt_status_t bt_gattc_write(gattc_handle_t conn_handle, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+向远程设备写入 GATT 特征值或描述符，等待确认后通过回调返回结果。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_write_without_response
+
+```c
+bt_status_t bt_gattc_write_without_response(gattc_handle_t conn_handle, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+向远程设备写入 GATT 特征值（Write Without Response），不等待确认。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_write_with_signed
+
+```c
+bt_status_t bt_gattc_write_with_signed(gattc_handle_t conn_handle, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+向远程设备写入 GATT 特征值（Signed Write），使用签名认证。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_subscribe
+
+```c
+bt_status_t bt_gattc_subscribe(gattc_handle_t conn_handle, uint16_t attr_handle, uint16_t ccc_value);
+```
+
+订阅远程设备的 GATT 特征值通知或指示（Notification/Indication）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `ccc_value` CCCD 值（0 禁用，1 通知，2 指示）。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_unsubscribe
+
+```c
+bt_status_t bt_gattc_unsubscribe(gattc_handle_t conn_handle, uint16_t attr_handle);
+```
+
+取消订阅远程设备的 GATT 特征值通知或指示。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_exchange_mtu
+
+```c
+bt_status_t bt_gattc_exchange_mtu(gattc_handle_t conn_handle, uint32_t mtu);
+```
+
+与远程设备协商 ATT MTU 大小，影响单次数据传输的最大长度。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `mtu` MTU 值。
+
+**返回值**：
+
+bt_gattc_exchange_mtu 操作。
+
+
+### bt_gattc_update_connection_parameter
+
+```c
+bt_status_t bt_gattc_update_connection_parameter(gattc_handle_t conn_handle, uint32_t min_interval, uint32_t max_interval, uint32_t latency, uint32_t timeout, uint32_t min_connection_event_length, uint32_t max_connection_event_length);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `min_interval` 最小间隔。
+- `max_interval` 最大间隔。
+- `latency` 从设备延迟。
+- `timeout` 超时时间。
+- `min_connection_event_length` 最小连接事件长度。
+- `max_connection_event_length` 最大连接事件长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_read_phy
+
+```c
+bt_status_t bt_gattc_read_phy(gattc_handle_t conn_handle);
+```
+
+读取远程设备的 GATT 特征值或描述符，结果通过回调异步返回。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+
+
+**返回值**：
+
+bt_gattc_read_phy 操作。
+
+
+### bt_gattc_update_phy
+
+```c
+bt_status_t bt_gattc_update_phy(gattc_handle_t conn_handle, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy);
+```
+
+PHY 配置操作。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `tx_phy` 发送 PHY。
+- `rx_phy` 接收 PHY。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gattc_read_rssi
+
+```c
+bt_status_t bt_gattc_read_rssi(gattc_handle_t conn_handle);
+```
+
+读取远程设备的 GATT 特征值或描述符，结果通过回调异步返回。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+
+
+**返回值**：
+
+bt_gattc_read_rssi 操作。
+
+
+### bt_gatts_register_service
+
+```c
+bt_status_t bt_gatts_register_service(bt_instance_t* ins, gatts_handle_t* phandle, gatts_callbacks_t* callbacks);
+```
+
+注册GATT 服务。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `phandle` 输出参数，存储 GATT 客户端句柄。
+- `callbacks` 回调函数集合。
+
+
+**返回值**：
+
+
+
+### bt_gatts_unregister_service
+
+```c
+bt_status_t bt_gatts_unregister_service(gatts_handle_t srv_handle);
+```
+
+取消注册GATT 服务。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+
+
+**返回值**：
+
+bt_gatts_unregister_service 操作。
+
+
+### bt_gatts_connect
+
+```c
+bt_status_t bt_gatts_connect(gatts_handle_t srv_handle, bt_address_t* addr, ble_addr_type_t addr_type);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `addr_type` BLE 地址类型。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_connect_bear
+
+```c
+bt_status_t bt_gatts_connect_bear(gatts_handle_t srv_handle, bt_address_t* addr, ble_addr_type_t addr_type, uint8_t bear_type);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `addr_type` BLE 地址类型。
+- `bear_type` 承载类型。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_disconnect
+
+```c
+bt_status_t bt_gatts_disconnect(gatts_handle_t srv_handle, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_add_attr_table
+
+```c
+bt_status_t bt_gatts_add_attr_table(gatts_handle_t srv_handle, gatt_srv_db_t* srv_db);
+```
+
+向本地 GATT 服务器添加属性表（服务、特征值、描述符）。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `srv_db` GATT 服务属性表。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_remove_attr_table
+
+```c
+bt_status_t bt_gatts_remove_attr_table(gatts_handle_t srv_handle, uint16_t attr_handle);
+```
+
+从本地 GATT 服务器移除属性表。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `attr_handle` 属性句柄。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_set_attr_value
+
+```c
+bt_status_t bt_gatts_set_attr_value(gatts_handle_t srv_handle, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+设置本地 GATT 属性的值。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_get_attr_value
+
+```c
+bt_status_t bt_gatts_get_attr_value(gatts_handle_t srv_handle, uint16_t attr_handle, uint8_t* value, uint16_t* length);
+```
+
+获取本地 GATT 属性的值。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_response
+
+```c
+bt_status_t bt_gatts_response(gatts_handle_t srv_handle, bt_address_t* addr, uint32_t req_handle, uint8_t* value, uint16_t length);
+```
+
+回复远程设备的 GATT 读写请求。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `req_handle` 请求句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_notify
+
+```c
+bt_status_t bt_gatts_notify(gatts_handle_t srv_handle, bt_address_t* addr, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+向已订阅的远程设备发送 GATT 通知（Notification），不需要确认。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_indicate
+
+```c
+bt_status_t bt_gatts_indicate(gatts_handle_t srv_handle, bt_address_t* addr, uint16_t attr_handle, uint8_t* value, uint16_t length);
+```
+
+向已订阅的远程设备发送 GATT 指示（Indication），需要确认。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_read_phy
+
+```c
+bt_status_t bt_gatts_read_phy(gatts_handle_t srv_handle, bt_address_t* addr);
+```
+
+读取 PHY 配置。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_gatts_update_phy
+
+```c
+bt_status_t bt_gatts_update_phy(gatts_handle_t srv_handle, bt_address_t* addr, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy);
+```
+
+PHY 配置操作。
+
+**参数**：
+
+- `srv_handle` GATT 服务句柄。
+- `addr` 远程设备蓝牙地址。
+- `tx_phy` 发送 PHY。
+- `rx_phy` 接收 PHY。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+## 异步接口
+
+
+### bt_gattc_create_connect_async
+
+```c
+bt_status_t bt_gattc_create_connect_async(bt_instance_t* ins, gattc_handle_t* phandle, gattc_callbacks_t* callbacks, bt_gattc_create_connect_cb_t cb, void* userdata);
+```
+
+建立连接（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `phandle` 输出参数，存储 GATT 客户端句柄。
+- `callbacks` 回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_delete_connect_async
+
+```c
+bt_status_t bt_gattc_delete_connect_async(gattc_handle_t conn_handle, bt_status_cb_t bt_gattc_delete_connect_cb_t, void* userdata);
+```
+
+删除 GATT 客户端（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `bt_gattc_delete_connect_cb_t` 删除连接的回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_connect_async
+
+```c
+bt_status_t bt_gattc_connect_async(gattc_handle_t conn_handle, bt_address_t* addr, ble_addr_type_t addr_type, bt_status_cb_t cb, void* userdata);
+```
+
+建立连接（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `addr` 远程设备蓝牙地址。
+- `addr_type` BLE 地址类型。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_disconnect_async
+
+```c
+bt_status_t bt_gattc_disconnect_async(gattc_handle_t conn_handle, bt_status_cb_t cb, void* userdata);
+```
+
+断开 ATT 承载连接（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_discover_service_async
+
+```c
+bt_status_t bt_gattc_discover_service_async(gattc_handle_t conn_handle, bt_uuid_t* filter_uuid, bt_status_cb_t cb, void* userdata);
+```
+
+发现GATT 服务（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `filter_uuid` 服务 UUID 过滤条件（NULL 表示不过滤）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_get_attribute_by_handle_async
+
+```c
+bt_status_t bt_gattc_get_attribute_by_handle_async(gattc_handle_t conn_handle, uint16_t attr_handle, bt_gattc_get_attribute_cb_t cb, void* userdata);
+```
+
+通过属性句柄获取属性（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_get_attribute_by_uuid_async
+
+```c
+bt_status_t bt_gattc_get_attribute_by_uuid_async(gattc_handle_t conn_handle, uint16_t start_handle, uint16_t end_handle, bt_uuid_t* attr_uuid, bt_gattc_get_attribute_cb_t cb, void* userdata);
+```
+
+获取属性（按 UUID）（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `start_handle` 起始句柄。
+- `end_handle` 结束句柄。
+- `attr_uuid` 属性 UUID。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_read_async
+
+```c
+bt_status_t bt_gattc_read_async(gattc_handle_t conn_handle, uint16_t attr_handle, bt_status_cb_t cb, void* userdata);
+```
+
+通过句柄读取属性值（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_write_async
+
+```c
+bt_status_t bt_gattc_write_async(gattc_handle_t conn_handle, uint16_t attr_handle, uint8_t* value, uint16_t length, bt_status_cb_t cb, void* userdata);
+```
+
+写入操作（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_write_without_response_async
+
+```c
+bt_status_t bt_gattc_write_without_response_async(gattc_handle_t conn_handle, uint16_t attr_handle, uint8_t* value, uint16_t length, bt_gattc_write_cb_t cb, void* userdata);
+```
+
+向指定属性写入数据（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `value` 值。
+- `length` 长度。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_subscribe_async
+
+```c
+bt_status_t bt_gattc_subscribe_async(gattc_handle_t conn_handle, uint16_t attr_handle, uint16_t ccc_value, bt_status_cb_t cb, void* userdata);
+```
+
+订阅操作（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `ccc_value` CCCD 值（0 禁用，1 通知，2 指示）。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_unsubscribe_async
+
+```c
+bt_status_t bt_gattc_unsubscribe_async(gattc_handle_t conn_handle, uint16_t attr_handle, bt_status_cb_t cb, void* userdata);
+```
+
+禁用指定的 CCCD（客户端特征配置描述符）（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `attr_handle` 属性句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_exchange_mtu_async
+
+```c
+bt_status_t bt_gattc_exchange_mtu_async(gattc_handle_t conn_handle, uint32_t mtu, bt_status_cb_t cb, void* userdata);
+```
+
+交换 MTU 大小（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `mtu` MTU 值。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_update_connection_parameter_async
+
+```c
+bt_status_t bt_gattc_update_connection_parameter_async(gattc_handle_t conn_handle, uint32_t min_interval, uint32_t max_interval, uint32_t latency, uint32_t timeout, uint32_t min_connection_event_length, uint32_t max_connection_event_length, bt_status_cb_t cb, void* userdata);
+```
+
+修改 BLE 连接参数（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `min_interval` 最小间隔。
+- `max_interval` 最大间隔。
+- `latency` 从设备延迟。
+- `timeout` 超时时间。
+- `min_connection_event_length` 最小连接事件长度。
+- `max_connection_event_length` 最大连接事件长度。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_read_phy_async
+
+```c
+bt_status_t bt_gattc_read_phy_async(gattc_handle_t conn_handle, bt_status_cb_t cb, void* userdata);
+```
+
+读取PHY 配置（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_gattc_update_phy_async
+
+```c
+bt_status_t bt_gattc_update_phy_async(gattc_handle_t conn_handle, ble_phy_type_t tx_phy, ble_phy_type_t rx_phy, bt_status_cb_t cb, void* userdata);
+```
+
+更新 PHY 配置（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `tx_phy` 发送 PHY。
+- `rx_phy` 接收 PHY。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_gattc_read_rssi_async
+
+```c
+bt_status_t bt_gattc_read_rssi_async(gattc_handle_t conn_handle, bt_status_cb_t cb, void* userdata);
+```
+
+读取 RSSI 值（异步版本）。
+
+**参数**：
+
+- `conn_handle` 连接句柄。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+

--- a/doxygen/api/framework/bluetooth/bt_hfp.md
+++ b/doxygen/api/framework/bluetooth/bt_hfp.md
@@ -1,68 +1,898 @@
-# 蓝牙 HFP API 开发指南
+# 蓝牙 HFP API
 
-**免提规范 (Hands-Free Profile, HFP)** 是蓝牙协议栈中用于处理语音通话的核心规范。它允许车机、耳机等设备（HF）通过蓝牙控制移动电话（AG）进行接听、挂断、拒接、语音拨号及音量调节等操作。
+openvela 蓝牙 HFP（免提规范）接口，支持蓝牙通话功能。
 
-在 HFP 架构中，设备被定义为以下两种角色：
+头文件：#include "bt_hfp.h"、#include "bt_hfp_hf.h"、#include "bt_hfp_ag.h"
 
-- **Audio Gateway (AG)**：音频网关。通常指连接蜂窝网络的设备（如：手机），负责音频的输入/输出及通话逻辑处理。
-- **Hands-Free Unit (HF)**：免提单元。通常指远程音频输入/输出机制的设备（如：蓝牙耳机、车载套件），作为 AG 的音频扩展和控制器。
 
-## 1. API 接口概览
+## openvela 实现说明
 
-本模块接口依据 HFP 协议的公共定义及角色职责进行划分。
+- **双角色支持**：HF（Hands-Free，免提端）和 AG（Audio Gateway，音频网关端）
+- **功能**：接听/挂断电话、音量控制、语音识别、电话簿访问
 
-### 1.1 HFP 通用 API (Common)
 
-`bt_hfp.h` 包含了 HFP 协议中 AG 和 HF 角色通用的数据结构、枚举定义及事件类型。
+## 同步接口
 
-- **主要内容**：
 
-    - **编解码器定义**：CVSD (窄带) 和 mSBC (宽带/HD Voice) 的相关定义。
-    - **状态定义**：通话状态、连接状态等通用枚举。
-    - **公共宏**：各个角色共用的配置参数。
+### bt_hfp_hf_unregister_callbacks
 
-**API 详情：**
-
-```eval_rst
-
-.. doxygenfile:: bt_hfp.h
-    :project: doxygen
+```c
+bool bt_hfp_hf_unregister_callbacks(bt_instance_t* ins, void* cookie);
 ```
 
-### 1.2 HFP HF 角色 API (Hands-Free)
+取消注册回调函数，停止接收状态变更通知。
 
-`bt_hfp_hf.h` 模块面向 **免提单元 (HF)** 开发（即开发蓝牙耳机或车机端功能）。
+**参数**：
 
-- **核心功能**：
+- `cookie` 用户上下文。
+- `ins` 蓝牙客户端实例。
 
-    - **通话控制**：发起接听 (Answer)、挂断 (Hangup)、拒接 (Reject) 及号码重拨。
-    - **音频管理**：在耳机与手机之间切换音频通道、调节通话音量。
-    - **功能交互**：查询运营商名称、信号强度、电池电量以及发送 DTMF 音。
-    - **SIRI/语音助手**：激活 AG 端的语音识别功能。
+**返回值**：
 
-**API 详情：**
+取消注册回调函数。
 
-```eval_rst
 
-.. doxygenfile:: bt_hfp_hf.h
-    :project: doxygen
+### bt_hfp_hf_is_connected
+
+```c
+bool bt_hfp_hf_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-### 1.3 HFP AG 角色 API (Audio Gateway)
+发起与远程设备的连接。
 
-`bt_hfp_ag.h` 模块面向 **音频网关 (AG)** 开发（即开发手机侧或拥有通话能力的网关设备功能）。
+**参数**：
 
-- **核心功能**：
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
 
-    - **状态同步**：向 HF 端发送当前通话状态（振铃、通话中、保持中）。
-    - **音频路由**：建立或断开与 HF 端的同步定向连接 (SCO/eSCO) 链路。
-    - **能力协商**：响应 HF 端发起的编解码器协商请求及功能查询。
-    - **带内铃声**：配置是否将铃声传输至 HF 端。
 
-**API 详情：**
+**返回值**：
 
-```eval_rst
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
-.. doxygenfile:: bt_hfp_ag.h
-    :project: doxygen
+
+### bt_hfp_hf_is_audio_connected
+
+```c
+bool bt_hfp_hf_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_get_connection_state
+
+```c
+profile_connection_state_t bt_hfp_hf_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+
+
+### bt_hfp_hf_connect
+
+```c
+bt_status_t bt_hfp_hf_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+建立连接。
+
+
+### bt_hfp_hf_disconnect
+
+```c
+bt_status_t bt_hfp_hf_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_set_connection_policy
+
+```c
+bt_status_t bt_hfp_hf_set_connection_policy(bt_instance_t* ins, bt_address_t* addr, connection_policy_t policy);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `policy` 策略值。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_connect_audio
+
+```c
+bt_status_t bt_hfp_hf_connect_audio(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_disconnect_audio
+
+```c
+bt_status_t bt_hfp_hf_disconnect_audio(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_start_voice_recognition
+
+```c
+bt_status_t bt_hfp_hf_start_voice_recognition(bt_instance_t* ins, bt_address_t* addr);
+```
+
+启动远程设备的语音识别功能。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_stop_voice_recognition
+
+```c
+bt_status_t bt_hfp_hf_stop_voice_recognition(bt_instance_t* ins, bt_address_t* addr);
+```
+
+停止远程设备的语音识别功能。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_dial
+
+```c
+bt_status_t bt_hfp_hf_dial(bt_instance_t* ins, bt_address_t* addr, const char* number);
+```
+
+发起通话。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `number` 号码。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_dial_memory
+
+```c
+bt_status_t bt_hfp_hf_dial_memory(bt_instance_t* ins, bt_address_t* addr, uint32_t memory);
+```
+
+通过 HFP 拨打内存中存储的号码。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `memory` 内存位置编号。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_redial
+
+```c
+bt_status_t bt_hfp_hf_redial(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起通话。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_accept_call
+
+```c
+bt_status_t bt_hfp_hf_accept_call(bt_instance_t* ins, bt_address_t* addr, hfp_call_accept_t flag);
+```
+
+通过 HFP 接听来电。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `flag` 标志位。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_reject_call
+
+```c
+bt_status_t bt_hfp_hf_reject_call(bt_instance_t* ins, bt_address_t* addr);
+```
+
+通过 HFP 拒绝来电。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_hold_call
+
+```c
+bt_status_t bt_hfp_hf_hold_call(bt_instance_t* ins, bt_address_t* addr);
+```
+
+通过 HFP 保持当前通话。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_terminate_call
+
+```c
+bt_status_t bt_hfp_hf_terminate_call(bt_instance_t* ins, bt_address_t* addr);
+```
+
+通过 HFP 挂断当前通话。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_control_call
+
+```c
+bt_status_t bt_hfp_hf_control_call(bt_instance_t* ins, bt_address_t* addr, hfp_call_control_t chld, uint8_t index);
+```
+
+control通话状态。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `chld` CHLD 命令类型。
+- `index` 索引。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_query_current_calls
+
+```c
+bt_status_t bt_hfp_hf_query_current_calls(bt_instance_t* ins, bt_address_t* addr, hfp_current_call_t** calls, int* num, bt_allocator_t allocator);
+```
+
+查询当前所有通话的状态信息（CLCC）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+- `allocator` 内存分配函数。- `calls` 输出参数，存储通话信息数组。
+- `num` 输出参数，存储通话数量。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_send_at_cmd
+
+```c
+bt_status_t bt_hfp_hf_send_at_cmd(bt_instance_t* ins, bt_address_t* addr, const char* cmd);
+```
+
+发送自定义 AT 命令到远程设备。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `cmd` 命令。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_update_battery_level
+
+```c
+bt_status_t bt_hfp_hf_update_battery_level(bt_instance_t* ins, bt_address_t* addr, uint8_t level);
+```
+
+向远程设备更新本地电池电量信息。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `level` 安全级别。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_volume_control
+
+```c
+bt_status_t bt_hfp_hf_volume_control(bt_instance_t* ins, bt_address_t* addr, hfp_volume_type_t type, uint8_t volume);
+```
+
+通过 HFP 控制远程设备的音量。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `type` 类型。
+- `volume` 音量值。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_send_dtmf
+
+```c
+bt_status_t bt_hfp_hf_send_dtmf(bt_instance_t* ins, bt_address_t* addr, char dtmf);
+```
+
+通过 HFP 发送 DTMF 按键音。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `dtmf` DTMF 按键字符。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_hf_get_subscriber_number
+
+```c
+bt_status_t bt_hfp_hf_get_subscriber_number(bt_instance_t* ins, bt_address_t* addr);
+```
+
+获取用户号码。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+### bt_hfp_hf_query_current_calls_with_callback
+
+```c
+bt_status_t bt_hfp_hf_query_current_calls_with_callback(bt_instance_t* ins, bt_address_t* addr);
+```
+
+查询当前所有通话的状态信息（CLCC）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+
+- `ins` 蓝牙客户端实例。
+
+
+### bt_hfp_ag_unregister_callbacks
+
+```c
+bool bt_hfp_ag_unregister_callbacks(bt_instance_t* ins, void* cookie);
+```
+
+取消注册回调函数，停止接收状态变更通知。
+
+**参数**：
+
+- `cookie` 用户上下文。
+- `ins` 蓝牙客户端实例。
+
+**返回值**：
+
+取消注册回调函数。
+
+
+### bt_hfp_ag_is_connected
+
+```c
+bool bt_hfp_ag_is_connected(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_is_audio_connected
+
+```c
+bool bt_hfp_ag_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_get_connection_state
+
+```c
+profile_connection_state_t bt_hfp_ag_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+
+
+### bt_hfp_ag_connect
+
+```c
+bt_status_t bt_hfp_ag_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址 of the peer device.
+
+**返回值**：
+
+建立连接。
+
+
+### bt_hfp_ag_disconnect
+
+```c
+bt_status_t bt_hfp_ag_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_connect_audio
+
+```c
+bt_status_t bt_hfp_ag_connect_audio(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_disconnect_audio
+
+```c
+bt_status_t bt_hfp_ag_disconnect_audio(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_start_virtual_call
+
+```c
+bt_status_t bt_hfp_ag_start_virtual_call(bt_instance_t* ins, bt_address_t* addr);
+```
+
+开始操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_stop_virtual_call
+
+```c
+bt_status_t bt_hfp_ag_stop_virtual_call(bt_instance_t* ins, bt_address_t* addr);
+```
+
+停止操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_start_voice_recognition
+
+```c
+bt_status_t bt_hfp_ag_start_voice_recognition(bt_instance_t* ins, bt_address_t* addr);
+```
+
+启动远程设备的语音识别功能。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_stop_voice_recognition
+
+```c
+bt_status_t bt_hfp_ag_stop_voice_recognition(bt_instance_t* ins, bt_address_t* addr);
+```
+
+停止远程设备的语音识别功能。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_phone_state_change
+
+```c
+bt_status_t bt_hfp_ag_phone_state_change(bt_instance_t* ins, bt_address_t* addr, uint8_t num_active, uint8_t num_held, hfp_ag_call_state_t call_state, hfp_call_addrtype_t type, const char* number, const char* name);
+```
+
+通知远程设备电话状态变更（来电/通话/挂断等）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `num_active` 活跃通话数量。
+- `num_held` 保持中通话数量。
+- `call_state` 通话状态。
+- `type` 类型。
+- `number` 号码。
+- `name` 名称。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_notify_device_status
+
+```c
+bt_status_t bt_hfp_ag_notify_device_status(bt_instance_t* ins, bt_address_t* addr, hfp_network_state_t network, hfp_roaming_state_t roam, uint8_t signal, uint8_t battery);
+```
+
+notify设备类型status。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `network` 网络信息。
+- `roam` 漫游状态。
+- `signal` 信号强度。
+- `battery` 电池电量。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_volume_control
+
+```c
+bt_status_t bt_hfp_ag_volume_control(bt_instance_t* ins, bt_address_t* addr, hfp_volume_type_t type, uint8_t volume);
+```
+
+通过 HFP 控制远程设备的音量。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `type` 类型。
+- `volume` 音量值。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_send_at_command
+
+```c
+bt_status_t bt_hfp_ag_send_at_command(bt_instance_t* ins, bt_address_t* addr, const char* at_command);
+```
+
+发送操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `at_command` AT 命令字符串。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_send_vendor_specific_at_command
+
+```c
+bt_status_t bt_hfp_ag_send_vendor_specific_at_command(bt_instance_t* ins, bt_address_t* addr, const char* command, const char* value);
+```
+
+发送操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `command` 命令。
+- `value` 值。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_send_clcc_response
+
+```c
+bt_status_t bt_hfp_ag_send_clcc_response(bt_instance_t* ins, bt_address_t* addr, uint32_t index, hfp_call_direction_t dir, hfp_ag_call_state_t state, hfp_call_mode_t mode, hfp_call_mpty_type_t mpty, hfp_call_addrtype_t type, const char* number);
+```
+
+发送操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 蓝牙地址。
+- `index` 索引。
+- `dir` 方向（呼入/呼出）。
+- `state` 状态。
+- `mode` 模式。
+- `mpty` 是否 the call is multi party.
+- `type` 类型。
+- `number` phone 数量 the call.
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_hfp_ag_send_cind_response
+
+```c
+bt_status_t bt_hfp_ag_send_cind_response(bt_instance_t* ins, bt_address_t* addr, hfp_network_state_t network, hfp_call_t call, hfp_callheld_t call_held, hfp_callsetup_t call_setup, uint8_t signal, hfp_roaming_state_t roam, uint8_t battery);
+```
+
+发送操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `network` 网络信息。
+- `call` 通话信息。
+- `call_held` 保持中通话数量。
+- `call_setup` 通话建立状态。
+- `signal` 信号强度。
+- `roam` 漫游状态。
+- `battery` 电池电量。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/doxygen/api/framework/bluetooth/bt_hid.md
+++ b/doxygen/api/framework/bluetooth/bt_hid.md
@@ -1,27 +1,181 @@
-# 蓝牙 HID API 开发指南
+# 蓝牙 HID API
 
-**人机接口设备规范 (Human Interface Device Profile, HID)** 定义了蓝牙设备如何与主机进行低延迟的人机交互。它允许鼠标、键盘、游戏手柄等设备（HID Device）通过蓝牙无线控制计算机、平板或手机（HID Host）。
+openvela 蓝牙 HID（人机接口设备）接口，支持键盘、鼠标、游戏手柄等输入设备。
 
-## 1. API 接口概览
+头文件：#include "bt_hid_device.h"
 
-本模块接口主要针对 **HID Device (设备端)** 角色设计。
 
-`bt_hid_device.h` 模块面向**外设开发**。开发者利用此接口将设备模拟为标准的输入/输出设备。
+## openvela 实现说明
 
-- **适用场景**：蓝牙键盘、鼠标、游戏控制器、遥控器等。
+- **设备角色**：HID Device（输入设备端）
 
-- **核心功能**：
 
-    - **连接管理**：注册 HID 服务记录 (SDP)，管理与主机的连接与断开。
-    - **发送报告 (Send Input Report)**：向主机发送按键点击、鼠标移动或传感器数据。
-    - **接收报告 (Receive Output Report)**：处理来自主机的反馈数据（如键盘的大小写锁定 LED 灯指令、手柄震动指令）。
-    - **协议模式切换**：支持 Boot Protocol（引导模式，用于BIOS等简单环境）与 Report Protocol（报告模式，用于操作系统）的切换。
-    - **虚拟拔插 (Virtual Cable Unplug)**：发送控制指令以断开并移除配对关系。
+## 同步接口
 
-**API 详情：**
 
-```eval_rst
+### bt_hid_device_unregister_callbacks
 
-.. doxygenfile:: bt_hid_device.h
-    :project: doxygen
+```c
+bool bt_hid_device_unregister_callbacks(bt_instance_t* ins, void* cookie);
 ```
+
+取消注册回调函数，停止接收状态变更通知。
+
+**参数**：
+
+- `cookie` 用户上下文。
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+**返回值**：
+
+取消注册回调函数。
+
+
+### bt_hid_device_register_app
+
+```c
+bt_status_t bt_hid_device_register_app(bt_instance_t* ins, hid_device_sdp_settings_t* sdp_setting, bool le_hid);
+```
+
+注册操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `sdp_setting` SDP 设置。
+- `le_hid` LE HID 实例。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_hid_device_unregister_app
+
+```c
+bt_status_t bt_hid_device_unregister_app(bt_instance_t* ins);
+```
+
+取消注册操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_hid_device_unregister_app 操作。
+
+
+### bt_hid_device_connect
+
+```c
+bt_status_t bt_hid_device_connect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_hid_device_disconnect
+
+```c
+bt_status_t bt_hid_device_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_hid_device_send_report
+
+```c
+bt_status_t bt_hid_device_send_report(bt_instance_t* ins, bt_address_t* addr, uint8_t rpt_id, uint8_t* rpt_data, int rpt_size);
+```
+
+向已连接的主机发送 HID 输入报告。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `rpt_id` HID 报告 ID。
+- `rpt_data` HID 报告数据。
+- `rpt_size` 报告数据大小（字节）。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。
+
+
+### bt_hid_device_response_report
+
+```c
+bt_status_t bt_hid_device_response_report(bt_instance_t* ins, bt_address_t* addr, uint8_t rpt_type, uint8_t* rpt_data, int rpt_size);
+```
+
+回复主机的 HID 报告请求。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `rpt_type` HID 报告类型（输入/输出/特性）。
+- `rpt_data` HID 报告数据。
+- `rpt_size` 报告数据大小（字节）。
+
+
+### bt_hid_device_report_error
+
+```c
+bt_status_t bt_hid_device_report_error(bt_instance_t* ins, bt_address_t* addr, hid_status_error_t error);
+```
+
+向主机报告 HID 错误。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `error` 错误码。
+
+
+
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `addr` Address of the peer device, 参见 bt_address_t.
+- `error` Error code, 参见 hid_status_error_t.
+
+
+### bt_hid_device_virtual_unplug
+
+```c
+bt_status_t bt_hid_device_virtual_unplug(bt_instance_t* ins, bt_address_t* addr);
+```
+
+发送虚拟拔出请求，断开 HID 连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。

--- a/doxygen/api/framework/bluetooth/bt_le_advertiser.md
+++ b/doxygen/api/framework/bluetooth/bt_le_advertiser.md
@@ -1,0 +1,139 @@
+# 蓝牙 BLE 广播 API
+
+openvela 蓝牙 BLE 广播接口，用于发送 BLE 广播数据和管理广播实例。
+
+头文件：`#include "bt_le_advertiser.h"`
+
+
+## openvela 实现说明
+
+- **广播类型**：支持可连接广播、不可连接广播、扫描响应等
+- **广播数据**：支持自定义广播数据和扫描响应数据
+- **多实例**：支持同时运行多个广播实例
+
+
+## 同步接口
+
+
+### bt_le_stop_advertising
+
+```c
+void bt_le_stop_advertising(bt_instance_t* ins, bt_advertiser_t* adver);
+```
+
+停止 BLE 广播。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `adver` 广播器实例。
+
+**返回值**：
+
+
+
+### bt_le_stop_advertising_id
+
+```c
+void bt_le_stop_advertising_id(bt_instance_t* ins, uint8_t adv_id);
+```
+
+停止指定 ID 的 BLE 广播实例。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `adv_id` 广播实例 ID。
+
+
+### bt_le_advertising_is_supported
+
+```c
+bool bt_le_advertising_is_supported(bt_instance_t* ins);
+```
+
+广播数据查询supported。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_le_advertising_is_supported 操作。
+
+
+## 异步接口
+
+
+### bt_le_start_advertising_async
+
+```c
+bt_status_t bt_le_start_advertising_async(bt_instance_t* ins, ble_adv_params_t* params, uint8_t* adv_data, uint16_t adv_len, uint8_t* scan_rsp_data, uint16_t scan_rsp_len, advertiser_callback_t* adv_cbs, bt_le_start_adv_callback_cb_t cb, void* userdata);
+```
+
+开始 BLE 广播（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `params` 参数结构体。
+- `adv_data` 广播数据。
+- `adv_len` 广播数据长度。
+- `scan_rsp_data` 扫描响应数据。
+- `scan_rsp_len` 扫描响应数据长度。
+- `adv_cbs` 广播回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_le_stop_advertising_async
+
+```c
+bt_status_t bt_le_stop_advertising_async(bt_instance_t* ins, bt_advertiser_t* adver, bt_status_cb_t cb, void* userdata);
+```
+
+
+
+
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `adver` 广播器实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_le_stop_advertising_id_async
+
+```c
+bt_status_t bt_le_stop_advertising_id_async(bt_instance_t* ins, uint8_t adv_id, bt_status_cb_t cb, void* userdata);
+```
+
+停止BLE 广播（指定 ID）（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `adv_id` 广播实例 ID。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_le_advertising_is_supported_async
+
+```c
+bt_status_t bt_le_advertising_is_supported_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+查询是否支持 BLE 广播（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+

--- a/doxygen/api/framework/bluetooth/bt_le_scan.md
+++ b/doxygen/api/framework/bluetooth/bt_le_scan.md
@@ -1,0 +1,139 @@
+# 蓝牙 BLE 扫描 API
+
+openvela 蓝牙 BLE 扫描接口，用于发现周围的 BLE 设备和广播数据。
+
+头文件：`#include "bt_le_scan.h"`
+
+
+## openvela 实现说明
+
+- **扫描模式**：支持被动扫描和主动扫描
+- **过滤器**：支持按名称、地址、UUID 等条件过滤扫描结果
+- **回调通知**：通过回调函数异步返回扫描结果
+
+
+## 同步接口
+
+
+### bt_le_stop_scan
+
+```c
+void bt_le_stop_scan(bt_instance_t* ins, bt_scanner_t* scanner);
+```
+
+停止 BLE 扫描。
+
+**参数**：
+
+- `scanner` 扫描器实例。
+- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+
+**返回值**：
+
+
+
+### bt_le_scan_is_supported
+
+```c
+bool bt_le_scan_is_supported(bt_instance_t* ins);
+```
+
+查询操作。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+
+
+**返回值**：
+
+bt_le_scan_is_supported 操作。
+
+
+## 异步接口
+
+
+### bt_le_start_scan_async
+
+```c
+bt_status_t bt_le_start_scan_async(bt_instance_t* ins, const scanner_callbacks_t* scan_cbs, bt_le_start_scan_cb_t cb, void* userdata);
+```
+
+开始BLE 扫描（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `scan_cbs` 扫描回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_le_start_scan_settings_async
+
+```c
+bt_status_t bt_le_start_scan_settings_async(bt_instance_t* ins, ble_scan_settings_t* settings, const scanner_callbacks_t* scan_cbs, bt_le_start_scan_cb_t cb, void* userdata);
+```
+
+异步版本。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `settings` 设置。
+- `scan_cbs` 扫描回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+### bt_le_start_scan_with_filters_async
+
+```c
+bt_status_t bt_le_start_scan_with_filters_async(bt_instance_t* ins, ble_scan_settings_t* settings, ble_scan_filter_t* filter, const scanner_callbacks_t* scan_cbs, bt_le_start_scan_cb_t cb, void* userdata);
+```
+
+开始操作（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `settings` 设置。
+- `filter` 过滤条件。
+- `scan_cbs` 扫描回调函数集合。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+### bt_le_stop_scan_async
+
+```c
+bt_status_t bt_le_stop_scan_async(bt_instance_t* ins, bt_scanner_t* scanner, bt_le_stop_scan_cb_t cb, void* userdata);
+```
+
+停止扫描（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `scanner` 扫描器实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+
+
+
+
+### bt_le_scan_is_supported_async
+
+```c
+bt_status_t bt_le_scan_is_supported_async(bt_instance_t* ins, bt_bool_cb_t cb, void* userdata);
+```
+
+查询是否支持 BLE 扫描（异步版本）。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `cb` 回调函数。
+- `userdata` 用户数据。
+

--- a/doxygen/api/framework/bluetooth/bt_pan.md
+++ b/doxygen/api/framework/bluetooth/bt_pan.md
@@ -1,36 +1,71 @@
-# 蓝牙 PAN API 开发指南
+# 蓝牙 PAN API
 
-**个人局域网规范 (Personal Area Network Profile, PAN)** 允许蓝牙设备通过 BNEP (Bluetooth Network Encapsulation Protocol) 封装网络协议包（如 IPv4/IPv6），从而构建无线局域网。
+openvela 蓝牙 PAN（个人局域网）接口，支持通过蓝牙实现网络共享。
 
-该协议主要用于以下场景：
+头文件：#include "bt_pan.h"
 
-- **蓝牙网络共享 (Tethering)**：手机作为网关，让其他设备通过蓝牙共享其移动网络连接。
-- **本地组网**：多个设备在没有外部网络的情况下组成临时的 Ad-hoc 网络进行通信。
 
-在 PAN 架构中，主要涉及以下角色：
+## openvela 实现说明
 
-- **PANU (PAN User)**：PAN 用户端。通常指连接到网关以获取网络服务的设备（如：连接手机热点的平板电脑）。
-- **NAP (Network Access Point)**：网络接入点。提供网络连接服务的网关设备（如：开启蓝牙热点的手机）。
+- **功能**：网络共享（Tethering）、蓝牙组网
 
-## 1. API 接口概览
 
-`bt_pan` 模块提供了管理蓝牙网络连接及数据传输的接口。
+## 同步接口
 
-### 1.1 PAN 协议接口
 
-`bt_pan.h` 定义了 PAN Profile 的通用操作，支持设备作为 PANU 或 NAP 进行连接和数据交互。
+### bt_pan_unregister_callbacks
 
-- **核心功能**：
-
-    - **服务注册**：注册 PANU 或 NAP 服务记录 (SDP)，声明设备支持的网络角色。
-    - **连接管理**：建立或断开基于 BNEP 的网络连接。
-    - **数据传输**：在蓝牙链路与上层 TCP/IP 协议栈之间转发以太网帧。
-    - **多路复用**：支持同时处理多个设备的网络连接（通常针对 NAP 角色）。
-
-**API 详情：**
-
-```eval_rst
-
-.. doxygenfile:: bt_pan.h
-    :project: doxygen
+```c
+bool bt_pan_unregister_callbacks(bt_instance_t* ins, void* cookie);
 ```
+
+取消注册回调函数，停止接收状态变更通知。
+
+**参数**：
+
+- `cookie` 用户上下文。
+- `ins` 蓝牙客户端实例。
+
+**返回值**：
+
+取消注册回调函数。
+
+
+### bt_pan_connect
+
+```c
+bt_status_t bt_pan_connect(bt_instance_t* ins, bt_address_t* addr, uint8_t dst_role, uint8_t src_role);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+- `dst_role` 目标设备角色。
+- `src_role` 本地设备角色。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_pan_disconnect
+
+```c
+bt_status_t bt_pan_disconnect(bt_instance_t* ins, bt_address_t* addr);
+```
+
+断开与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `addr` 远程设备蓝牙地址。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/doxygen/api/framework/bluetooth/bt_spp.md
+++ b/doxygen/api/framework/bluetooth/bt_spp.md
@@ -1,37 +1,132 @@
-# 蓝牙 SPP API 开发指南
+# 蓝牙 SPP API
 
-**串口规范 (Serial Port Profile, SPP)** 是蓝牙协议栈中用于模拟串行电缆连接的规范。它基于 ETSI TS 07.10 标准（RFCOMM 协议），允许两个蓝牙设备之间建立虚拟的串行端口，进行透明的数据流传输。
+openvela 蓝牙 SPP（串口仿真）接口，用于替代物理串口进行数据透传。
 
-SPP 是传统蓝牙（Classic Bluetooth）中最常用的数据传输方式，广泛应用于以下场景：
+头文件：#include "bt_spp.h"
 
-- **数据透传**：在两个设备间（如手机与打印机、扫描仪与PC）建立数据管道。
-- **传统设备控制**：控制支持串口通信的工业设备或嵌入式模块。
-- **替代线缆**：无线替代原有的 RS-232 物理连接。
 
-在 SPP 架构中，通信双方通常分为：
+## openvela 实现说明
 
-- **SPP Server (服务端)**：在 SDP (服务发现协议) 中注册特定的服务 UUID，并等待连接。
-- **SPP Client (客户端)**：搜索指定 UUID 的服务，并主动发起连接请求。
+- **功能**：虚拟串口通信，适用于传统串口设备的蓝牙化
 
-## 1. API 接口概览
 
-`bt_spp` 模块提供了建立串口连接及进行读写操作的接口。
+## 同步接口
 
-### 1.1 SPP 协议接口
 
-`bt_spp.h` 定义了 SPP 的通用操作，支持设备作为 Server 或 Client 进行配置和通信。
+### bt_spp_unregister_app
 
-- **核心功能**：
-
-    - **服务注册 (Server)**：配置服务 UUID（标准 UUID 或自定义 128-bit UUID）并注册到 SDP 数据库，声明设备支持串口服务。
-    - **连接建立 (Client)**：通过搜索对方的 UUID 发起 RFCOMM 连接。
-    - **数据读写**：提供类似标准串口的 `read` 和 `write` 接口，实现数据的双向透明传输。
-    - **流控管理**：处理底层 RFCOMM 的流控信号，确保数据传输的稳定性。
-
-**API 详情：**
-
-```eval_rst
-
-.. doxygenfile:: bt_spp.h
-    :project: doxygen
+```c
+bt_status_t bt_spp_unregister_app(bt_instance_t* ins, void* handle);
 ```
+
+取消注册操作。
+
+**参数**：
+
+- `handle` 句柄。
+- `ins` 蓝牙客户端实例。
+
+**返回值**：
+
+bt_spp_unregister_app 操作。
+
+
+### bt_spp_server_start
+
+```c
+bt_status_t bt_spp_server_start(bt_instance_t* ins, void* handle, uint16_t scn, bt_uuid_t* uuid, uint8_t max_connection);
+```
+
+启动 SPP 服务器，监听远程设备的连接请求。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `handle` 句柄。
+- `scn` 服务器通道号。
+- `uuid` 服务 UUID。
+- `max_connection` 最大连接数。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_spp_server_stop
+
+```c
+bt_status_t bt_spp_server_stop(bt_instance_t* ins, void* handle, uint16_t scn);
+```
+
+停止 SPP 服务器，不再接受新连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `handle` 句柄。
+- `scn` 服务器通道号。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_spp_connect
+
+```c
+bt_status_t bt_spp_connect(bt_instance_t* ins, void* handle, bt_address_t* addr, int16_t scn, bt_uuid_t* uuid, uint16_t* port);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `handle` 句柄。
+- `addr` 远程设备蓝牙地址。
+- `scn` 服务器通道号。
+- `uuid` 服务 UUID。
+- `port` 端口号。
+
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
+
+### bt_spp_insecure_connect
+
+```c
+bt_status_t bt_spp_insecure_connect(bt_instance_t* ins, void* handle, bt_address_t* addr, int16_t scn, bt_uuid_t* uuid, uint16_t* port);
+```
+
+发起与远程设备的连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `handle` 句柄。
+- `addr` 远程设备蓝牙地址。
+- `scn` 服务器通道号。
+- `uuid` 服务 UUID。
+- `port` 端口号。
+
+
+### bt_spp_disconnect
+
+```c
+bt_status_t bt_spp_disconnect(bt_instance_t* ins, void* handle, bt_address_t* addr, uint16_t port);
+```
+
+断开连接。
+
+**参数**：
+
+- `ins` 蓝牙客户端实例。
+- `handle` 句柄。
+- `addr` 蓝牙地址 of the peer device.
+- `port` 端口号。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/doxygen/api/framework/bluetooth/index.md
+++ b/doxygen/api/framework/bluetooth/index.md
@@ -1,47 +1,42 @@
-# 蓝牙 API 开发指南
+# 蓝牙 API
 
-本手册旨在指导开发者在 openvela 系统上进行蓝牙协议栈的配置与应用开发。文档体系涵盖了从底层的连接管理（GAP/GATT）到经典蓝牙的上层应用规范（Profiles），支持构建音频流传输、语音通话、人机交互及数据透传等多种应用场景。
+openvela 蓝牙框架提供完整的蓝牙协议栈接口，支持经典蓝牙（BR/EDR）和低功耗蓝牙（BLE），涵盖从底层连接管理到上层应用规范。
 
-## 1. 协议栈模块索引
+## 核心协议
 
-开发者可根据具体的应用需求，参考以下分类文档：
+- **[GAP](bt_gap.md)**（通用访问规范）— 设备发现、连接管理、配对与安全
+- **[GATT](bt_gatt.md)**（通用属性规范）— BLE 数据属性读写与通知
+- **[设备管理](bt_device.md)** — 远程设备配对、连接、属性查询
 
-### 1.1 基础核心 (Core)
+## BLE 接口
 
-构建蓝牙应用的基石，涉及设备发现、连接建立及通用数据交换。
+- **[BLE 扫描](bt_le_scan.md)** — BLE 设备发现与广播数据接收
+- **[BLE 广播](bt_le_advertiser.md)** — BLE 广播数据发送与管理
 
-- **GAP (Generic Access Profile)**：通用访问规范。负责广播、扫描、配对及链路安全管理。
-- **GATT (Generic Attribute Profile)**：通用属性规范。负责低功耗蓝牙 (BLE) 及部分经典蓝牙的数据属性读写与通知。
+## 音频与媒体
 
-### 1.2 音频与媒体 (Audio & Media)
+- **[A2DP](bt_a2dp.md)**（高级音频分发）— 高质量立体声音乐传输
+- **[AVRCP](bt_avrcp.md)**（音视频远程控制）— 播放控制、切歌、音量调节
+- **[HFP](bt_hfp.md)**（免提规范）— 蓝牙通话功能
 
-面向蓝牙耳机、音箱及车载系统的多媒体功能。
+## 数据与外设
 
-- **A2DP (Advanced Audio Distribution Profile)**：高级音频分发。用于传输高质量的立体声音乐。
-- **AVRCP (Audio/Video Remote Control Profile)**：音视频远程控制。用于控制播放暂停、切歌及音量调节。
-- **HFP (Hands-Free Profile)**：免提规范。用于实现蓝牙通话功能。
-
-### 1.3 数据与外设 (Data & Peripherals)
-
-面向数据传输、网络共享及人机交互设备。
-
-- **HID (Human Interface Device Profile)**：人机接口设备。用于开发键盘、鼠标、游戏手柄等输入设备。
-- **SPP (Serial Port Profile)**：串口仿真。用于替代物理串口进行数据透传。
-- **PAN (Personal Area Network Profile)**：个人局域网。用于通过蓝牙实现网络共享 (Tethering) 或组网。
-
-## 2. 文档列表
-
-详细 API 说明请参阅下表：
+- **[HID](bt_hid.md)**（人机接口设备）— 键盘、鼠标、游戏手柄
+- **[SPP](bt_spp.md)**（串口仿真）— 数据透传
+- **[PAN](bt_pan.md)**（个人局域网）— 网络共享与蓝牙组网
 
 ```eval_rst
 
 .. toctree::
     :maxdepth: 2
 
+    bt_gap
+    bt_device
+    bt_gatt
+    bt_le_scan
+    bt_le_advertiser
     bt_a2dp
     bt_avrcp
-    bt_gap
-    bt_gatt
     bt_hfp
     bt_hid
     bt_spp


### PR DESCRIPTION
- Hand-write all 222 bluetooth APIs across 11 files, replacing 15 Doxygen directives
- Add 3 new files: bt_device.md (72 APIs), bt_le_scan.md (7 APIs), bt_le_advertiser.md (7 APIs)
- Generate briefs from source code context, not header comments
- Translate all descriptions to Chinese, keep technical terms in English
- Ensure all params match function signatures exactly
- Add openvela implementation notes for each sub-module
- Reorganize index.md with functional grouping
