### PR TITLE
docs: replace Doxygen directives with class-level descriptions in services

### DIFF
--- a/doxygen/api/framework/services/ams.md
+++ b/doxygen/api/framework/services/ams.md
@@ -5,163 +5,159 @@ Activity Manager Service（AMS）是 openvela XMS 系统中的活动管理服务
 ## 功能特性
 
 - **Activity 生命周期管理**：AMS 负责管理应用内 Activity 的生命周期，包括创建、启动、暂停、恢复和销毁。
-
 - **任务管理**：AMS 管理应用任务和任务栈，包括任务切换和调度，确保流畅的用户体验。
-
 - **进程管理**：AMS 负责启动、停止和监控应用进程，确保系统资源的有效利用。
-
 - **Intent 处理**：AMS 处理应用间的 Intent 通信，允许不同应用启动 Activity 和 Service。
-
 - **权限管理**：AMS 参与权限检查，确保应用在启动 Activity 时满足系统安全要求。
-
 - **应用状态跟踪**：AMS 跟踪应用状态（如前台、后台、已停止），并据此分配资源。
-
 - **多窗口支持**：AMS 提供多窗口模式下的 Activity 管理，允许多个应用同时显示。
-
 - **后台任务限制**：AMS 对后台任务和服务施加限制，以优化系统性能和电池使用。
-
 - **Service 和 Broadcast 管理**：AMS 还负责管理 Service 和 BroadcastReceiver 的生命周期，确保系统的响应性和稳定性。
-
 
 ## 示例
 
-以下是使用 openvela AMS 模块的示例代码，通常通过 ActivityManager 类来管理 Activity 和控制任务：
+以下是使用 openvela AMS 模块的示例代码，通常通过 `ActivityManager` 类来管理 Activity 和控制任务。
 
-- **启动新 Activity**
+**启动新 Activity**
 
-    ```c++
-    Intent intent;
-    makeIntent(intent);
-    intent.setFlag(intent.mFlag | Intent::FLAG_ACTIVITY_NEW_TASK);
-    android::sp<android::IBinder> token = new android::BBinder();
-    ActivityManager am;
-    am.startActivity(token, intent, -1);
-    ```
-
-- **停止 Activity**
-
-    ```c++
-    Intent intent;
-    makeIntent(intent);
-    ActivityManager am;
-    am.stopActivity(intent, intent.mFlag);
-    ```
-
-## ActivityManagerService.h
-
-```eval_rst
-.. doxygenfile:: ActivityManagerService.h
-    :project: doxygen
+```cpp
+Intent intent;
+makeIntent(intent);
+intent.setFlag(intent.mFlag | Intent::FLAG_ACTIVITY_NEW_TASK);
+android::sp<android::IBinder> token = new android::BBinder();
+ActivityManager am;
+am.startActivity(token, intent, -1);
 ```
 
-## Activity.h
+**停止 Activity**
 
-```eval_rst
-.. doxygenfile:: Activity.h
-    :project: doxygen
+```cpp
+Intent intent;
+makeIntent(intent);
+ActivityManager am;
+am.stopActivity(intent, intent.mFlag);
 ```
 
-## ActivityManager.h
+## 核心类
 
-```eval_rst
-.. doxygenfile:: ActivityManager.h
-    :project: doxygen
-```
+### ActivityManager
 
-## Application.h
+头文件：`#include <app/ActivityManager.h>`
 
-```eval_rst
-.. doxygenfile:: Application.h
-    :project: doxygen
-```
+客户端侧访问 AMS 能力的门面类。提供的主要方法：
 
-## ApplicationThread.h
+- `startActivity()` / `stopActivity()` / `finishActivity()` — Activity 启停
+- `startService()` / `stopService()` / `stopServiceByToken()` / `bindService()` / `unbindService()` — Service 操作
+- `publishService()` / `getService()` — 服务发布与获取
+- `sendBroadcast()` / `registerReceiver()` / `unregisterReceiver()` — 广播与接收器
+- `attachApplication()` / `stopApplication()` — Application 绑定与终止
+- `moveActivityTaskToBackground()` — Activity 任务切换到后台
+- `reportActivityStatus()` / `reportServiceStatus()` — 状态上报（由应用向 AMS 回报生命周期状态）
+- `postIntent()` — 向指定组件投递 Intent
 
-```eval_rst
-.. doxygenfile:: ApplicationThread.h
-    :project: doxygen
-```
+### ActivityManagerService
 
-## AppMain.h
+头文件：`#include <am/ActivityManagerService.h>`
 
-```eval_rst
-.. doxygenfile:: AppMain.h
-    :project: doxygen
-```
+AMS 的服务端实现类，注册为系统服务，接收各应用通过 Binder 发来的调用并执行调度。开发者一般不直接使用该类。
 
-## BroadcastReceiver.h
+### Activity
 
-```eval_rst
-.. doxygenfile:: BroadcastReceiver.h
-    :project: doxygen
-```
+头文件：`#include <app/Activity.h>`
 
-## Context.h
+应用开发的 UI 单元基类。应用通过继承该类并重写 `onCreate` / `onStart` / `onResume` / `onPause` / `onStop` / `onDestroy` / `onRestart` 等生命周期回调来实现一个界面。还提供 `finish` / `setResult` / `getWindow` / `moveToBackground` / `onBackPressed` / `onActivityResult` / `onNewIntent` 等操作与扩展点。
 
-```eval_rst
-.. doxygenfile:: Context.h
-    :project: doxygen
-```
+### Application
 
-## ContextImpl.h
+头文件：`#include <app/Application.h>`
 
-```eval_rst
-.. doxygenfile:: ContextImpl.h
-    :project: doxygen
-```
+应用进程的全局单例基类。应用通常继承 `Application` 来放置进程级资源。主要方法包括：
 
-## Dialog.h
+- 生命周期：`onCreate` / `onDestroy` / `onForeground` / `onBackground` / `onReceiveIntent`
+- 组件管理：`createActivity` / `createService` / `addActivity` / `addService` / `findActivity` / `findService` / `deleteActivity` / `deleteService`
+- 元信息：`getPackageName` / `getUid` / `isSystemUI` / `getMainLoop` / `getWindowManager`
 
-```eval_rst
-.. doxygenfile:: Dialog.h
-    :project: doxygen
-```
+### ApplicationThread
 
-## Intent.h
+头文件：`#include <app/ApplicationThread.h>`
 
-```eval_rst
-.. doxygenfile:: Intent.h
-    :project: doxygen
-```
+Application 侧的调度线程抽象，承接来自 AMS 的调度请求并在应用进程内派发执行。属于框架内部协作类，应用开发者一般不直接调用。
 
-## Logger.h
+### AppMain
 
-```eval_rst
-.. doxygenfile:: Logger.h
-    :project: doxygen
-```
+头文件：`#include <app/AppMain.h>`
 
-## MessageService.h
+应用进程入口辅助类。定义应用进程从启动到接入 AMS 的基础流程，封装主事件循环与初始化步骤。
 
-```eval_rst
-.. doxygenfile:: MessageService.h
-    :project: doxygen
-```
+### Context
 
-## ServiceConnection.h
+头文件：`#include <app/Context.h>`
 
-```eval_rst
-.. doxygenfile:: ServiceConnection.h
-    :project: doxygen
-```
+最核心的上下文基类，提供系统能力访问入口。典型方法包括：
 
-## Service.h
+- `getPackageName()` / `getApplication()` / `getComponentName()` — 应用与组件信息
+- `startActivity()` / `startActivityForResult()` / `stopActivity()` — Activity 启停
+- `startService()` / `stopService()` / `bindService()` / `unbindService()` — Service 操作
+- `sendBroadcast()` / `registerReceiver()` / `unregisterReceiver()` — 广播与接收器
+- `getActivityManager()` / `getWindowManager()` — 系统服务访问
+- `getMainLoop()` / `getCurrentLoop()` — 事件循环获取
 
-```eval_rst
-.. doxygenfile:: Service.h
-    :project: doxygen
-```
+### ContextImpl
 
-## UvLoop.h
+头文件：`#include <app/ContextImpl.h>`
 
-```eval_rst
-.. doxygenfile:: UvLoop.h
-    :project: doxygen
-```
+`Context` 基类的默认实现，由框架在 Application / Activity / Service 创建时装配。应用开发者通常不直接构造 `ContextImpl`，而是通过 `Activity::getContext()` 等方式获取实例。
 
-## ActivityTrace.h
+### Intent
 
-```eval_rst
-.. doxygenfile:: ActivityTrace.h
-    :project: doxygen
-```
+头文件：`#include <app/Intent.h>`
+
+承载组件间通信意图的数据结构。包含 action、data、target、bundle、flag 等字段，以及 `FLAG_ACTIVITY_*` 等启动标志。提供 `setAction` / `setData` / `setTarget` / `setBundle` / `setFlag` / `readFromParcel` / `writeToParcel` 等读写方法。
+
+### Service
+
+头文件：`#include <app/Service.h>`
+
+无界面的长生命周期组件基类。开发者通过继承 `Service` 并重写 `onCreate` / `onStartCommand` / `onBind` / `onUnbind` / `onDestroy` / `onReceiveIntent` 来实现后台服务。
+
+### ServiceConnection
+
+头文件：`#include <app/ServiceConnection.h>`
+
+`bindService` 的连接回调接口。包含 `onServiceConnected` / `onServiceDisconnected` 两个回调方法，用于在绑定成功或断开时通知客户端。
+
+### BroadcastReceiver
+
+头文件：`#include <app/BroadcastReceiver.h>`
+
+广播接收器基类。应用通过继承该类并重写 `onReceive(Intent)` 来处理匹配到的系统或应用广播。
+
+### MessageService
+
+头文件：`#include <app/MessageService.h>`
+
+面向消息通信的服务辅助类，封装基于 Intent 的请求—响应模式，便于应用构建基于消息分发的后台服务。主要方法：`sendMessage` / `receiveMessage` / `receiveMessageAndReply` / `reply` / `onBind` / `onBindExt` / `onReply`。
+
+### Dialog
+
+头文件：`#include <app/Dialog.h>`
+
+对话框组件基类。提供 `show` / `hide` / `setLayout` / `setRect` / `getLayout` / `getRoot` / `createDialog` 等操作，应用可继承实现自定义对话框。
+
+### UvLoop
+
+头文件：`#include <app/UvLoop.h>`
+
+基于 libuv 的事件循环封装，供应用主线程以及其他框架组件复用。提供定时器、IO 事件、工作队列等能力。
+
+### Logger
+
+头文件：`#include <app/Logger.h>`
+
+AMS/应用侧通用日志宏定义，封装分级日志输出（`APP_LOGI` / `APP_LOGW` / `APP_LOGE` 等）。
+
+### ActivityTrace
+
+头文件：`#include <ActivityTrace.h>`
+
+Activity 生命周期的 trace 打点宏集合，配合 openvela trace 分析工具可视化应用启动与切换路径。

--- a/doxygen/api/framework/services/pms.md
+++ b/doxygen/api/framework/services/pms.md
@@ -10,76 +10,96 @@ Package Manager Service（PMS）是 openvela XMS 系统中的包管理模块。
 
 ## 示例
 
-- 通过命令行进行包管理
+**通过命令行进行包管理**
 
-    安装包：
+安装包：
 
-    ```
-    pm install [packagename]
-    ```
-
-    查询已安装的包：
-
-    ```
-    pm list
-    ```
-
-- 通过源码使用包管理工具
-
-    安装包：
-
-    ```c++
-    #include "pm/PackageManager.h"
-
-    PackageManager pm;
-    InstallParam parms;
-    pm.installPackage(parms);
-    ```
-
-    获取所有包信息：
-
-    ```c++
-    #include "pm/PackageManager.h"
-
-    PackageManager pm;
-    std::vector<PackageInfo> pgInfos;
-    pm.getAllPackageInfo(&pgInfos);
-    ```
-
-    卸载包：
-
-    ```c++
-    #include "pm/PackageManager.h"
-
-    PackageManager pm;
-    UninstallParam parms;
-    pm.uninstallPackage(parms);
-    ```
-
-## PackageInfo.h
-
-```eval_rst
-.. doxygenfile:: PackageInfo.h
-    :project: doxygen
+```
+pm install [packagename]
 ```
 
-## PackageManager.h
+查询已安装的包：
 
-```eval_rst
-.. doxygenfile:: PackageManager.h
-    :project: doxygen
+```
+pm list
 ```
 
-## PackageManagerService.h
+**通过源码使用包管理工具**
 
-```eval_rst
-.. doxygenfile:: PackageManagerService.h
-    :project: doxygen
+安装包：
+
+```cpp
+#include <pm/PackageManager.h>
+
+PackageManager pm;
+InstallParam parms;
+pm.installPackage(parms);
 ```
 
-## PackageTrace.h
+获取所有包信息：
 
-```eval_rst
-.. doxygenfile:: PackageTrace.h
-    :project: doxygen
+```cpp
+#include <pm/PackageManager.h>
+
+PackageManager pm;
+std::vector<PackageInfo> pgInfos;
+pm.getAllPackageInfo(&pgInfos);
 ```
+
+卸载包：
+
+```cpp
+#include <pm/PackageManager.h>
+
+PackageManager pm;
+UninstallParam parms;
+pm.uninstallPackage(parms);
+```
+
+## 核心类
+
+### PackageManager
+
+头文件：`#include <pm/PackageManager.h>`
+
+客户端侧访问 PMS 能力的门面类。提供的主要操作：
+
+- `installPackage(InstallParam)` — 安装应用包
+- `uninstallPackage(UninstallParam)` — 卸载应用包
+- `getAllPackageInfo(std::vector<PackageInfo>*)` — 查询所有已安装包信息
+- `getPackageInfo(packageName, PackageInfo*)` — 查询指定包信息
+- `getAllPackageName(std::vector<std::string>*)` — 查询所有已安装包名
+- `getPackageSizeInfo(packageName, ...)` — 查询包占用空间
+- `clearAppCache(packageName)` — 清理应用缓存
+- `isFirstBoot()` — 查询是否首次启动
+
+应用通常构造 `PackageManager` 实例后直接调用上述方法，内部通过 Binder 与 `PackageManagerService` 通信。
+
+### PackageManagerService
+
+头文件：`#include <pm/PackageManagerService.h>`
+
+PMS 的服务端实现类，注册为系统服务。负责维护已安装包的元数据、执行实际的安装/卸载动作、处理权限与签名校验。开发者一般不直接使用该类。
+
+### PackageInfo
+
+头文件：`#include <pm/PackageInfo.h>`
+
+描述单个安装包元数据的结构。主要字段包括：
+
+- `packageName` / `name` — 包名与应用名
+- `version` / `priority` / `appType` — 版本、优先级与应用类型
+- `installedPath` / `installTime` / `size` — 安装路径、安装时间与占用大小
+- `execfile` / `entry` / `manifest` — 可执行文件、入口与清单
+- `activitiesInfo` / `servicesInfo` — 内部 Activity 与 Service 列表
+- `shasum` — 签名摘要
+- `userId` / `isSystemUI` — 用户 ID 与是否系统 UI
+- `windowEnterAnim` / `windowExitAnim` — 窗口进入/退出动画配置
+
+`PackageManager` 的查询接口返回该类型的结果。
+
+### PackageTrace
+
+头文件：`#include <PackageTrace.h>`
+
+PMS 的 trace 打点宏集合，用于跟踪包管理操作路径，配合 openvela trace 工具分析性能。


### PR DESCRIPTION
## Overview

Replace all remaining `.. doxygenfile::` Sphinx/Breathe directives in the Services API documentation with hand-written, class-level Chinese descriptions that are accurate against the current source headers.

## Motivation

With Sphinx and Doxygen deprecated (PR #526), `services/ams.md` and `services/pms.md` were the last files in `doxygen/api/` still relying on `doxygenfile` directives, which now render as meaningless code blocks on GitHub. This PR removes that residual and makes the files self-contained Markdown.

## Changes

### `ams.md` — 17 class-level sections

Each class gets a short Chinese description naming its role, header file path and the main public methods actually found in the source:

ActivityManager, ActivityManagerService, Activity, Application, ApplicationThread, AppMain, Context, ContextImpl, Intent, Service, ServiceConnection, BroadcastReceiver, MessageService, Dialog, UvLoop, Logger, ActivityTrace.

### `pms.md` — 4 class-level sections

PackageManager, PackageManagerService, PackageInfo, PackageTrace.

### Other quality fixes

- Verified every method name cited in the docs against `frameworks/runtimes/services/{am,pm}/include/` — no hallucinated methods remain.
- Standardized code blocks to the `cpp` language tag.
- Standardized header includes to angle-bracket form, e.g. `#include <app/Context.h>`.

## Statistics

2 files changed, +212 / -196 lines

## Dependencies

Applies cleanly on top of current `dev`. No dependencies on other open PRs.