### PR TITLE
docs: refactor and enhance telephony framework API documentation

### DIFF
--- a/doxygen/api/framework/telephony/index.md
+++ b/doxygen/api/framework/telephony/index.md
@@ -1,118 +1,111 @@
-# Telephony
+# Telephony API
 
-Telephony 提供蜂窝通信能力，framework/telephony 是 openvela 蜂窝通信对应用层提供的接口层，又称为 TAPI（Telephony API）。封装的接口涵盖了蜂窝通信业务：网络服务、通话、短信、数据、SIM 双卡和 modem 配置管理等。
+Telephony 提供蜂窝通信能力，`framework/telephony` 是 openvela 蜂窝通信对应用层提供的接口层，又称为 TAPI（Telephony API）。封装的接口涵盖了蜂窝通信业务：网络服务、通话、短信、数据、SIM 双卡和 modem 配置管理等。
 
-TAPI 独立于 openvela telephony core stack，内部逻辑基于 DBUS LIB 对 Core Stack 进行业务逻辑封装，屏蔽掉 D-BUS 的复杂操作，对外以标准 C 的方式提供标准化统一的 Telephony API 接口定义，方便 openvela 应用层 APP 的使用，让 openvela APP 实现 openvela 系统版本间复用。
+TAPI 独立于 openvela telephony core stack，内部逻辑基于 DBUS LIB 对 Core Stack 进行业务逻辑封装，屏蔽掉 D-Bus 的复杂操作，对外以标准 C 的方式提供标准化统一的 Telephony API 接口定义，方便 openvela 应用层 APP 的使用，让 openvela APP 实现 openvela 系统版本间复用。
 
-## 一、模块代码介绍
+## openvela 实现说明
 
-| 模块           | 文件                      | 说明                  |
-| :------------- | :------------------------ | :-------------------- |
-| 对外统一头文件 | tapi.h                    | 公共与 utils 接口定义 |
-| Radio 接口     | tapi_manager.c/h          | Telephony 公共接口    |
-| Call 接口      | tapi_call.c/h tapi_ss.c/h | 通话管理接口          |
-| Network 接口   | tapi_network.c/h          | 网络注册接口          |
-| Data 接口      | tapi_data.c/h             | 数据服务接口          |
-| SIM 接口       | tapi_sim.c/h tapi_stk.c/h | 卡和 STK 接口         |
-| SMS 接口       | tapi_sms.c/h              | 短信管理接口          |
-| IMS 接口       | tapi_ims.c/h              | IMS 服务接口          |
+- **架构**：TAPI 基于 D-Bus 对 Telephony Core Stack（oFono）进行封装，以标准 C 接口对外提供
+- **多卡支持**：通过 `slot_id` 参数区分不同 SIM 卡槽
+- **异步模型**：大部分操作通过回调函数异步返回结果
 
-## 二、TAPI 配置
+## 模块代码介绍
 
-完整的 Telephony 业务涉及模块众多，需要所有模块开启完整使用 Telephony 业务：
+| 模块 | 源码 | API 文档 | 说明 |
+| :--- | :--- | :--- | :--- |
+| 对外统一头文件 | `tapi.h` | [公共工具](telephony.md) | 公共类型定义、字符串/枚举转换 utils |
+| Radio 接口 | `tapi_manager.c/h` | [管理](telephony_manager.md) | Telephony 初始化、状态查询、事件注册 |
+| Call 接口 | `tapi_call.c/h` | [通话](telephony_call.md) | 语音通话控制 |
+| 补充业务 | `tapi_ss.c/h` | [补充业务 SS](telephony_ss.md) | 呼叫转移/呼叫限制/呼叫等待/CLIR/USSD |
+| 简化电话服务 | `tapi_phone.c/h` | [简化电话服务](telephony_phone.md) | 轻量客户端封装 |
+| Network 接口 | `tapi_network.c/h` | [网络](telephony_network.md) | 网络注册、信号、运营商 |
+| Data 接口 | `tapi_data.c/h` | [数据](telephony_data.md) | 蜂窝数据连接 |
+| SIM 接口 | `tapi_sim.c/h` | [SIM 卡](telephony_sim.md) | SIM 卡管理 |
+| SIM Toolkit | `tapi_stk.c/h` | [SIM Toolkit](telephony_stk.md) | STK Agent 与 SIM 卡主动命令 |
+| 电话簿 | `tapi_phonebook.c/h` | [电话簿](telephony_phonebook.md) | ADN/FDN 电话簿管理 |
+| SMS 接口 | `tapi_sms.c/h` | [短信](telephony_sms.md) | 短信收发 |
+| Cell Broadcast | `tapi_cbs.c/h` | [小区广播 CBS](telephony_cbs.md) | 小区广播消息 |
+| IMS 接口 | `tapi_ims.c/h` | [IMS](telephony_ims.md) | VoLTE/VoWiFi |
 
-- DBUS 配置
+## TAPI 配置
 
-    ```
-    CONFIG_DBUS_DAEMON=y
-    CONFIG_DBUS_MONITOR=y
-    CONFIG_DBUS_SEND=y
-    CONFIG_LIB_DBUS=y
-    ```
+完整的 Telephony 业务涉及模块众多，需要所有模块开启完整使用 Telephony 业务。
 
-- GLIB 配置
+**DBUS 配置**
 
-    ```
-    CONFIG_LIB_GLIB=y
-    ```
+```kconfig
+CONFIG_DBUS_DAEMON=y
+CONFIG_DBUS_MONITOR=y
+CONFIG_DBUS_SEND=y
+CONFIG_LIB_DBUS=y
+```
 
-- OFONO 配置
+**GLIB 配置**
 
-    ```
-    CONFIG_LIB_ELL=y
-    CONFIG_OFONO=y
-    CONFIG_OFONO_RILMODEM=y //modem类型选择，支持rild的选择rilmodem
-    CONFIG_OFONO_ATMODEM=y //支持串口、USB的选择atmodem
-    ```
+```kconfig
+CONFIG_LIB_GLIB=y
+```
 
-- GDBUS 配置
+**OFONO 配置**
 
-    ```
-    CONFIG_LIB_DBUS=y
-    ```
+```kconfig
+CONFIG_LIB_ELL=y
+CONFIG_OFONO=y
+CONFIG_OFONO_RILMODEM=y  # modem 类型选择，支持 rild 的选择 rilmodem
+CONFIG_OFONO_ATMODEM=y   # 支持串口、USB 的选择 atmodem
+```
 
-- Telephony API 配置
+**GDBUS 配置**
 
-    ```
-    CONFIG_TELEPHONY=y
-    CONFIG_TELEPHONY_TOOL=y  //debug工具，可选
-    ```
+```kconfig
+CONFIG_LIB_DBUS=y
+```
 
-## 三、TAPI 工作使用模型
+**Telephony API 配置**
+
+```kconfig
+CONFIG_TELEPHONY=y
+CONFIG_TELEPHONY_TOOL=y  # debug 工具，可选
+```
+
+## TAPI 工作使用模型
 
 ![TAPIWork](figures/TapiWork.png)
 
+## TAPI 函数使用举例
 
-## 四、TAPI 函数使用举例
+### 获取 TAPI 工作上下文
 
-1. 获取 TAPI 工作上下文
+先声明一个 callback 函数：
 
-    先声明一个 callback 函数：
+```c
+static void on_tapi_client_ready(const char* client_name, void* user_data)
+{
+    if (client_name != NULL)
+        syslog(LOG_DEBUG, "tapi is ready for %s\n", client_name);
+    ...
+}
+```
 
-    ```c
-    static void on_tapi_client_ready(const char* client_name, void* user_data)
-    {
-        if (client_name != NULL)
-            syslog(LOG_DEBUG, "tapi is ready for %s\n", client_name);
-        ...
-    }
-    ```
+再调用 `tapi_open` 函数获取上下文。获取成功需要 oFono、D-Bus 等服务启动成功，当 ready 后会调用 callback 函数。
 
-    再调用 tapi_open 函数获取上下文。获取成功需要 oFono、DBus 等服务启动成功，当 ready 后会调用 callback 函数。
+```c
+tapi_context context;
+char* dbus_name = "vela.telephony.tool";
+context = tapi_open(dbus_name, on_tapi_client_ready, NULL);
+```
 
-    ```c
-    tapi_context context;
-    char* dbus_name = "vela.telephony.tool";
-    context = tapi_open(dbus_name, on_tapi_client_ready, NULL);
-    ```
+### 释放 TAPI 工作上下文
 
-2. 释放 TAPI 工作上下文
+```c
+tapi_close(context);
+```
 
-    ```c
-    tapi_close(context);
-    ```
+### 查询当前的 radio power 状态
 
-3. 查询当前的 radio power 状态
-
-    ```c
-    int slot_id = 0;
-    bool value = false;
-    tapi_get_radio_power(context, slot_id, &value);
-    ```
-
-## 五、TAPI 列表
-
-```eval_rst
-
-.. toctree::
-    :maxdepth: 2
-
-    telephony_manager
-    telephony_call
-    telephony_data
-    telephony_ims
-    telephony_network
-    telephony_sim
-    telephony_sms
-
+```c
+int slot_id = 0;
+bool value = false;
+tapi_get_radio_power(context, slot_id, &value);
 ```

--- a/doxygen/api/framework/telephony/telephony.md
+++ b/doxygen/api/framework/telephony/telephony.md
@@ -1,0 +1,360 @@
+# Telephony 公共工具 API
+
+TAPI 提供的通用工具函数，涵盖状态字符串转换、modem 路径解析、运营商状态解析等辅助能力。
+
+头文件：`#include <tapi.h>`
+
+## openvela 实现说明
+
+- **字符串↔枚举转换**：`*_from_string` / `*_to_string` 系列把 oFono D-Bus 字符串与 TAPI 枚举互转，便于状态解析
+- **Modem 路径**：`tapi_utils_get_modem_path` 将 `slot_id` 转成 oFono 的 modem 对象路径
+- **工具性质**：本组接口不依赖 tapi_context，可在任意位置直接调用
+- **适用场景**：实现自定义事件处理、打印调试日志、或扩展 TAPI 能力时使用
+
+## SIM 状态
+
+### tapi_sim_state_to_string
+
+```c
+const char* tapi_sim_state_to_string(tapi_sim_state state);
+```
+
+将 SIM 状态枚举转为可读字符串。
+
+**参数**：
+
+- `state` SIM 状态枚举值。
+
+**返回值**：
+
+返回状态的字符串表示，失败时返回 `NULL` 或占位字符串。
+
+## APN 工具
+
+### tapi_utils_apn_auth_from_string
+
+```c
+int tapi_utils_apn_auth_from_string(const char* str);
+```
+
+将认证类型字符串转为 APN 认证枚举值。
+
+**参数**：
+
+- `str` 认证类型字符串（如 `"pap"`、`"chap"`）。
+
+**返回值**：
+
+返回认证枚举值；无效字符串时返回错误值。
+
+### tapi_utils_apn_auth_to_string
+
+```c
+const char* tapi_utils_apn_auth_to_string(int auth);
+```
+
+将 APN 认证枚举值转为字符串。
+
+**参数**：
+
+- `auth` 认证枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+### tapi_utils_apn_proto_from_string
+
+```c
+int tapi_utils_apn_proto_from_string(const char* str);
+```
+
+将协议字符串转为 APN 协议枚举值。
+
+**参数**：
+
+- `str` 协议字符串（如 `"ip"`、`"ipv6"`、`"dual"`）。
+
+**返回值**：
+
+返回协议枚举值。
+
+### tapi_utils_apn_proto_to_string
+
+```c
+const char* tapi_utils_apn_proto_to_string(int proto);
+```
+
+将 APN 协议枚举值转为字符串。
+
+**参数**：
+
+- `proto` 协议枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+### tapi_utils_apn_type_from_string
+
+```c
+int tapi_utils_apn_type_from_string(const char* str);
+```
+
+将 APN 类型字符串转为类型枚举值。
+
+**参数**：
+
+- `str` APN 类型字符串（如 `"default"`、`"mms"`、`"ims"`）。
+
+**返回值**：
+
+返回类型枚举值。
+
+### tapi_utils_apn_type_to_string
+
+```c
+const char* tapi_utils_apn_type_to_string(int type);
+```
+
+将 APN 类型枚举值转为字符串。
+
+**参数**：
+
+- `type` APN 类型枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+## 通话工具
+
+### tapi_utils_call_disconnected_reason
+
+```c
+int tapi_utils_call_disconnected_reason(const char* reason);
+```
+
+将通话断开原因字符串转为 TAPI 断开原因枚举值。
+
+**参数**：
+
+- `reason` 断开原因字符串。
+
+**返回值**：
+
+返回断开原因枚举值。
+
+### tapi_utils_call_status_from_string
+
+```c
+int tapi_utils_call_status_from_string(const char* status);
+```
+
+将通话状态字符串转为状态枚举值。
+
+**参数**：
+
+- `status` 状态字符串（如 `"active"`、`"held"`、`"dialing"`）。
+
+**返回值**：
+
+返回状态枚举值。
+
+## 小区与网络工具
+
+### tapi_utils_cell_type_from_string
+
+```c
+int tapi_utils_cell_type_from_string(const char* str);
+```
+
+将小区类型字符串转为枚举值。
+
+**参数**：
+
+- `str` 小区类型字符串。
+
+**返回值**：
+
+返回小区类型枚举值。
+
+### tapi_utils_cell_type_to_string
+
+```c
+const char* tapi_utils_cell_type_to_string(int type);
+```
+
+将小区类型枚举值转为字符串。
+
+**参数**：
+
+- `type` 小区类型枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+### tapi_utils_network_mode_from_string
+
+```c
+int tapi_utils_network_mode_from_string(const char* str);
+```
+
+将网络模式字符串转为枚举值。
+
+**参数**：
+
+- `str` 网络模式字符串（如 `"gsm"`、`"lte"`）。
+
+**返回值**：
+
+返回网络模式枚举值。
+
+### tapi_utils_network_mode_to_string
+
+```c
+const char* tapi_utils_network_mode_to_string(int mode);
+```
+
+将网络模式枚举值转为字符串。
+
+**参数**：
+
+- `mode` 网络模式枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+### tapi_utils_network_type_from_ril_tech
+
+```c
+int tapi_utils_network_type_from_ril_tech(int tech);
+```
+
+将 RIL 层传来的网络技术值转为 TAPI 网络类型枚举。
+
+**参数**：
+
+- `tech` RIL 网络技术值。
+
+**返回值**：
+
+返回 TAPI 网络类型枚举值。
+
+### tapi_utils_network_operator_status_from_string
+
+```c
+int tapi_utils_network_operator_status_from_string(const char* str);
+```
+
+将运营商状态字符串转为枚举值。
+
+**参数**：
+
+- `str` 运营商状态字符串。
+
+**返回值**：
+
+返回运营商状态枚举值。
+
+### tapi_utils_operator_status_from_string
+
+```c
+int tapi_utils_operator_status_from_string(const char* str);
+```
+
+`tapi_utils_network_operator_status_from_string` 的简写版本，等价功能。
+
+**参数**：
+
+- `str` 运营商状态字符串。
+
+**返回值**：
+
+返回运营商状态枚举值。
+
+## 注册状态工具
+
+### tapi_utils_registration_mode_from_string
+
+```c
+int tapi_utils_registration_mode_from_string(const char* str);
+```
+
+将注册模式字符串转为枚举值。
+
+**参数**：
+
+- `str` 注册模式字符串（如 `"auto"`、`"manual"`）。
+
+**返回值**：
+
+返回注册模式枚举值。
+
+### tapi_utils_registration_status_from_string
+
+```c
+int tapi_utils_registration_status_from_string(const char* str);
+```
+
+将注册状态字符串转为枚举值。
+
+**参数**：
+
+- `str` 注册状态字符串。
+
+**返回值**：
+
+返回注册状态枚举值。
+
+### tapi_utils_get_registration_status_string
+
+```c
+const char* tapi_utils_get_registration_status_string(int status);
+```
+
+将注册状态枚举值转为可读字符串。
+
+**参数**：
+
+- `status` 注册状态枚举值。
+
+**返回值**：
+
+返回对应字符串。
+
+## Modem 路径与 Slot
+
+### tapi_utils_get_modem_path
+
+```c
+const char* tapi_utils_get_modem_path(int slot_id);
+```
+
+根据 SIM 卡槽 ID 获取 oFono 的 modem 对象路径。
+
+**参数**：
+
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+返回 modem 对象路径字符串（如 `/ril_0`、`/ril_1`）。
+
+### tapi_utils_get_slot_id
+
+```c
+int tapi_utils_get_slot_id(const char* path);
+```
+
+从 oFono modem 对象路径解析 SIM 卡槽 ID。
+
+**参数**：
+
+- `path` modem 对象路径。
+
+**返回值**：
+
+返回对应的卡槽 ID（0 或 1），无效路径时返回负值。

--- a/doxygen/api/framework/telephony/telephony_call.md
+++ b/doxygen/api/framework/telephony/telephony_call.md
@@ -1,19 +1,692 @@
-# Telephony Call API
+# 通话管理 API
 
-Telephony Call TAPI 提供 openvela Telephony 处理通话相关业务，以及补充业务相关业务能力，包括会议通话、呼叫转移、呼叫等待、呼叫限制等。APP 无需关心 CALL 模块的内部业务细节，仅需调用 API 获取 CALL 信息或者监听 CALL 相关消息即可完成 APP 开发。
+语音通话控制，包括拨号、接听、挂断、保持等。
 
-## tapi_call.h
+头文件：`#include <tapi_call.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_call.h
-    :project: doxygen
+- **多卡支持**：部分接口不带 `slot_id`，使用默认卡；需要指定卡时通过 `tapi_call_set_default_slot` 切换
+- **同步/异步**：拨号、应答等耗时操作同时提供同步版本和 `_async` 版本（回调风格）
+- **按 ID 操作**：长生命周期通话通过返回的 call ID（字符串）唯一标识，`*_by_id` 接口据此执行操作
+- **DTMF**：拨号盘按键通过 `tapi_call_send_tones`（批量）或 `tapi_call_start_dtmf` / `tapi_call_stop_dtmf`（持续按键）触发
+- **会议通话**：通过 `tapi_call_dial_conferece` 和 `tapi_call_merge_call` 组织，`tapi_call_separate_call` 拆分
+
+## 拨打与应答
+
+### tapi_call_dial
+
+```c
+int tapi_call_dial(tapi_context context, int slot_id, char* number, int hide_callerid, int event_id, tapi_async_function p_handle);
 ```
 
-## tapi_ss.h
+发起语音通话。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: tapi_ss.h
-    :project: doxygen
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `number` 电话号码。
+- `hide_callerid` 是否隐藏主叫号码。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_dial_async
+
+```c
+int tapi_call_dial_async(tapi_context context, int slot_id, char* number, int hide_callerid, int event_id, void* user_data, tapi_async_function p_handle);
 ```
+
+发起语音通话（异步版本）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `number` 电话号码。
+- `hide_callerid` 是否隐藏主叫号码。
+- `event_id` 事件 ID，用于回调匹配。
+- `user_data` 用户数据，传递给回调函数。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 挂断控制
+
+### tapi_call_hangup_all_calls
+
+```c
+int tapi_call_hangup_all_calls(tapi_context context, int slot_id);
+```
+
+挂断所有通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 保持与切换
+
+### tapi_call_release_and_answer
+
+```c
+int tapi_call_release_and_answer(tapi_context context, int slot_id);
+```
+
+挂断当前通话并接听等待中的来电。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_hold_and_answer
+
+```c
+int tapi_call_hold_and_answer(tapi_context context, int slot_id);
+```
+
+保持当前通话并接听等待中的来电。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_release_and_swap
+
+```c
+int tapi_call_release_and_swap(tapi_context context, int slot_id);
+```
+
+挂断当前通话并切换到保持中的通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_hold_call
+
+```c
+int tapi_call_hold_call(tapi_context context, int slot_id);
+```
+
+保持当前通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_unhold_call
+
+```c
+int tapi_call_unhold_call(tapi_context context, int slot_id);
+```
+
+恢复保持中的通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 转移与会议
+
+### tapi_call_transfer
+
+```c
+int tapi_call_transfer(tapi_context context, int slot_id);
+```
+
+转接通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_merge_call
+
+```c
+int tapi_call_merge_call(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+合并通话（多方通话）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_merge_call_async
+
+```c
+int tapi_call_merge_call_async(tapi_context context, int slot_id, int event_id, void* user_data, tapi_async_function p_handle);
+```
+
+合并通话（多方通话）（异步版本）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `user_data` 用户数据，传递给回调函数。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_separate_call
+
+```c
+int tapi_call_separate_call(tapi_context context, int slot_id, int event_id, char* call_id, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `call_id` 通话 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_hangup_multiparty
+
+```c
+int tapi_call_hangup_multiparty(tapi_context context, int slot_id);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## DTMF 与拨号音
+
+### tapi_call_send_tones
+
+```c
+int tapi_call_send_tones(void* context, int slot_id, char* tones);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `tones` DTMF 按键序列。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 通话查询
+
+### tapi_call_get_all_calls
+
+```c
+int tapi_call_get_all_calls(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_get_call_by_state
+
+```c
+int tapi_call_get_call_by_state(tapi_context context, int slot_id, int state, tapi_call_info* call_list, int size, tapi_call_info* out_list);
+```
+
+获取指定通话的信息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `state` 状态。
+- `call_list` 通话列表。
+- `size` 大小。
+- `out_list` 输出列表。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 紧急号码
+
+### tapi_call_get_ecc_list
+
+```c
+int tapi_call_get_ecc_list(tapi_context context, int slot_id, ecc_info* out);
+```
+
+获取紧急呼叫号码列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_is_emergency_number
+
+```c
+int tapi_call_is_emergency_number(tapi_context context, char* number);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `number` 电话号码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 事件订阅
+
+### tapi_call_register_emergency_list_change
+
+```c
+int tapi_call_register_emergency_list_change(tapi_context context, int slot_id, void* user_obj, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_register_ringback_tone_change
+
+```c
+int tapi_call_register_ringback_tone_change(tapi_context context, int slot_id, void* user_obj, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_register_default_voicecall_slot_change
+
+```c
+int tapi_call_register_default_voicecall_slot_change(tapi_context context, void* user_obj, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 会议通话
+
+### tapi_call_dial_conferece
+
+```c
+int tapi_call_dial_conferece(tapi_context context, int slot_id, char* participants[], int size);
+```
+
+发起语音通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `participants` 参与者列表。
+- `size` 大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_invite_participants
+
+```c
+int tapi_call_invite_participants(tapi_context context, int slot_id, char* participants[], int size);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `participants` 参与者列表。
+- `size` 大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_register_call_state_change
+
+```c
+int tapi_call_register_call_state_change(tapi_context context, int slot_id, void* user_obj, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 按 ID 操作
+
+### tapi_call_answer_by_id
+
+```c
+int tapi_call_answer_by_id(tapi_context context, int slot_id, char* call_id);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `call_id` 通话 ID。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_answer_by_id_async
+
+```c
+int tapi_call_answer_by_id_async(tapi_context context, int slot_id, char* call_id, void* user_obj, tapi_async_function p_handle);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `call_id` 通话 ID。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_hangup_by_id
+
+```c
+int tapi_call_hangup_by_id(tapi_context context, int slot_id, char* call_id);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `call_id` 通话 ID。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_deflect_by_id
+
+```c
+int tapi_call_deflect_by_id(tapi_context context, int slot_id, char* call_id, char* number);
+```
+
+转移来电到指定号码。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `call_id` 通话 ID。
+- `number` 电话号码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 连续 DTMF
+
+### tapi_call_start_dtmf
+
+```c
+int tapi_call_start_dtmf(tapi_context context, int slot_id, unsigned char digit, int event_id, tapi_async_function p_handle);
+```
+
+开始发送 DTMF 按键音。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `digit` DTMF 按键字符。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_stop_dtmf
+
+```c
+int tapi_call_stop_dtmf(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+停止发送 DTMF 按键音。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 默认卡槽
+
+### tapi_call_set_default_slot
+
+```c
+int tapi_call_set_default_slot(tapi_context context, int slot_id);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_call_get_default_slot
+
+```c
+int tapi_call_get_default_slot(tapi_context context, int* out);
+```
+
+从多方通话中分离指定通话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_cbs.md
+++ b/doxygen/api/framework/telephony/telephony_cbs.md
@@ -1,0 +1,112 @@
+# Telephony 小区广播 API
+
+Cell Broadcast Service（CBS）是蜂窝网络的小区广播能力，常用于接收政府紧急警报（地震、海啸）和运营商公告。
+
+头文件：`#include <tapi_cbs.h>`
+
+## openvela 实现说明
+
+- **开关控制**：通过 `set_cell_broadcast_power_on` 启用/禁用小区广播接收
+- **主题订阅**：通过 `set_cell_broadcast_topics` 配置要接收的广播主题范围（按频道 ID）
+- **事件回调**：通过 `tapi_cbs_register` 注册事件回调，接收到的广播消息
+- **多卡支持**：所有接口带 `slot_id`，支持多 SIM 卡设备
+- **相关协议**：底层对应 3GPP TS 23.041 定义的 Cell Broadcast 流程
+
+## 开关控制
+
+### tapi_sms_set_cell_broadcast_power_on
+
+```c
+int tapi_sms_set_cell_broadcast_power_on(tapi_context context, int slot_id, bool enabled);
+```
+
+启用或禁用小区广播接收。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `enabled` `true` 表示启用，`false` 表示禁用。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_sms_get_cell_broadcast_power_on
+
+```c
+int tapi_sms_get_cell_broadcast_power_on(tapi_context context, int slot_id, bool* enabled);
+```
+
+查询小区广播接收开关状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `enabled` 输出参数，返回当前开关状态。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 主题订阅
+
+### tapi_sms_set_cell_broadcast_topics
+
+```c
+int tapi_sms_set_cell_broadcast_topics(tapi_context context, int slot_id, char* topics);
+```
+
+配置小区广播的主题范围（频道 ID 列表）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `topics` 主题字符串，典型格式为逗号分隔的频道 ID 或范围（如 `"4352-4356,919"`）。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_sms_get_cell_broadcast_topics
+
+```c
+int tapi_sms_get_cell_broadcast_topics(tapi_context context, int slot_id, char** topics);
+```
+
+查询当前配置的小区广播主题。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `topics` 输出参数，返回主题字符串（调用方负责释放）。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 事件订阅
+
+### tapi_cbs_register
+
+```c
+int tapi_cbs_register(tapi_context context, int slot_id, tapi_indication_msg msg,
+                      void* user_obj, tapi_async_function p_handle);
+```
+
+注册小区广播事件回调。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `msg` 要监听的事件类型。
+- `user_obj` 用户数据，将回传给回调函数。
+- `p_handle` 事件回调函数。
+
+**返回值**：
+
+成功时返回事件订阅 watch ID，失败时返回负的错误码。

--- a/doxygen/api/framework/telephony/telephony_data.md
+++ b/doxygen/api/framework/telephony/telephony_data.md
@@ -1,15 +1,494 @@
-# Telephony Data API
+# 数据连接 API
 
-Telephony Data TAPI 提供 openvela Telephony 蜂窝数据的相关功能：
+蜂窝数据连接管理。
 
-- 对外提供蜂窝数据相关功能接口，包括开关蜂窝数据、开关数据漫游、获取当前使用数据的 SLOT ID 和当前蜂窝数据链路是否激活等接口。
-- 对内根据客户端的需求进行蜂窝数据链路的激活、去激活和相应的状态维护，并将当前数据链路连接状态上报给客户端。
-- 在开启蜂窝数据且网络状态满足的情况下，始终保持一路 Internet 类型 APN 链路存在。当客户端对 APN 特定参数（iptype、username、password 和 apn）进行修改或新建一路默认上网的 Internet 类型 APN 时，会进行 reattach 操作，去激活掉原有的 Internet 类型 APN 链路，用更新后的 APN 参数重新进行激活。
+头文件：`#include <tapi_data.h>`
 
-## tapi_data.h
+## openvela 实现说明
 
-```eval_rst
+- **APN 上下文**：通过 `tapi_data_*_apn_context` 系列接口管理 APN 配置（增删改查）
+- **按需连接**：`tapi_data_request_network` / `tapi_data_release_network` 控制数据网络的建立与释放
+- **漫游控制**：通过 `tapi_data_enable_roaming` 显式开关数据漫游
+- **多卡支持**：涉及特定卡的操作使用 `slot_id` 参数；数据默认卡通过 `tapi_data_set_default_slot` 设置
+- **状态订阅**：`tapi_data_register` / `tapi_data_unregister` 用于注册/取消状态变化事件
 
-.. doxygenfile:: tapi_data.h
-    :project: doxygen
+## APN 配置管理
+
+### tapi_data_load_apn_contexts
+
+```c
+int tapi_data_load_apn_contexts(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
 ```
+
+加载 APN 配置。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_add_apn_context
+
+```c
+int tapi_data_add_apn_context(tapi_context context, int slot_id, int event_id, tapi_data_context* apn, tapi_async_function p_handle);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `apn` 接入点名称（APN）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_remove_apn_context
+
+```c
+int tapi_data_remove_apn_context(tapi_context context, int slot_id, int event_id, tapi_data_context* apn, tapi_async_function p_handle);
+```
+
+删除 APN 配置。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `apn` 接入点名称（APN）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_edit_apn_context
+
+```c
+int tapi_data_edit_apn_context(tapi_context context, int slot_id, int event_id, tapi_data_context* apn, tapi_async_function p_handle);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `apn` 接入点名称（APN）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_reset_apn_contexts
+
+```c
+int tapi_data_reset_apn_contexts(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+重置 APN 配置为默认值。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 数据网络状态
+
+### tapi_data_is_registered
+
+```c
+int tapi_data_is_registered(tapi_context context, int slot_id, bool* out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_is_data_emergency_only
+
+```c
+int tapi_data_is_data_emergency_only(tapi_context context, int slot_id, bool* out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_network_type
+
+```c
+int tapi_data_get_network_type(tapi_context context, int slot_id, tapi_network_type* out);
+```
+
+获取当前网络类型。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_is_data_roaming
+
+```c
+int tapi_data_is_data_roaming(tapi_context context, int slot_id, bool* out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 数据连接控制
+
+### tapi_data_request_network
+
+```c
+int tapi_data_request_network(tapi_context context, int slot_id, const char* type);
+```
+
+请求建立数据连接。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `type` 类型。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_release_network
+
+```c
+int tapi_data_release_network(tapi_context context, int slot_id, const char* type);
+```
+
+释放数据连接。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `type` 类型。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_data_connection_list
+
+```c
+int tapi_data_get_data_connection_list(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 首选 APN
+
+### tapi_data_set_preferred_apn
+
+```c
+int tapi_data_set_preferred_apn(tapi_context context, int slot_id, tapi_data_context* apn);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `apn` 接入点名称（APN）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_preferred_apn
+
+```c
+int tapi_data_get_preferred_apn(tapi_context context, int slot_id, char** out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 数据开关
+
+### tapi_data_enable_data
+
+```c
+int tapi_data_enable_data(tapi_context context, bool enabled);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `enabled` 是否启用。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_enabled
+
+```c
+int tapi_data_get_enabled(tapi_context context, bool* out);
+```
+
+查询 IMS 是否启用。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 漫游控制
+
+### tapi_data_enable_roaming
+
+```c
+int tapi_data_enable_roaming(tapi_context context, bool enabled);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `enabled` 是否启用。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_roaming_enabled
+
+```c
+int tapi_data_get_roaming_enabled(tapi_context context, bool* out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 默认卡槽与授权
+
+### tapi_data_set_default_slot
+
+```c
+int tapi_data_set_default_slot(tapi_context context, int slot_id);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_get_default_slot
+
+```c
+int tapi_data_get_default_slot(tapi_context context, int* out);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_set_data_allow
+
+```c
+int tapi_data_set_data_allow(tapi_context context, int slot_id, int event_id, bool allowed, tapi_async_function p_handle);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `allowed` 是否允许。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 事件订阅
+
+### tapi_data_register
+
+```c
+int tapi_data_register(tapi_context context, int slot_id, tapi_indication_msg msg, void* user_obj, tapi_async_function p_handle);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `msg` 消息内容。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_data_unregister
+
+```c
+int tapi_data_unregister(tapi_context context, int watch_id);
+```
+
+加载 APN 配置列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 监听 ID（用于取消监听）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_ims.md
+++ b/doxygen/api/framework/telephony/telephony_ims.md
@@ -1,11 +1,199 @@
-# Telephony IMS API
+# IMS 服务 API
 
-Telephony IMS TAPI 提供 openvela Telephony 处理 IMS 相关业务。APP 无需关心 IMS 内部实现逻辑，仅需调用 TAPI 接口获取或者监听 IMS 注册相关接口。
+IP 多媒体子系统（VoLTE/VoWiFi）管理。
 
-## tapi_ims.h
+头文件：`#include <tapi_ims.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_ims.h
-    :project: doxygen
+- **IMS 开关**：通过 `turn_on` / `turn_off` 控制 IMS 服务的启用状态
+- **注册状态**：查询 IMS 是否已注册到网络，订阅注册状态变化事件
+- **业务开关**：`set_service_status` 控制具体业务（如语音、视频）的启用
+- **VoLTE 支持**：通过 `is_volte_available` 查询当前网络是否支持 VoLTE
+- **多卡支持**：所有接口带 `slot_id`
+
+## IMS 开关
+
+### tapi_ims_turn_on
+
+```c
+int tapi_ims_turn_on(tapi_context context, int slot_id);
 ```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_ims_turn_off
+
+```c
+int tapi_ims_turn_off(tapi_context context, int slot_id);
+```
+
+关闭 IMS 服务。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 服务状态配置
+
+### tapi_ims_set_service_status
+
+```c
+int tapi_ims_set_service_status(tapi_context context, int slot_id, int capability);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `capability` 能力值。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 注册状态与事件
+
+### tapi_ims_get_registration
+
+```c
+int tapi_ims_get_registration(tapi_context context, int slot_id, tapi_ims_registration_info* ims_reg);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `ims_reg` IMS 注册状态。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_ims_register_registration_change
+
+```c
+int tapi_ims_register_registration_change(tapi_context context, int slot_id, void* user_obj, tapi_async_function p_handle);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_ims_is_registered
+
+```c
+int tapi_ims_is_registered(tapi_context context, int slot_id, bool* out);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## VoLTE 与业务查询
+
+### tapi_ims_is_volte_available
+
+```c
+int tapi_ims_is_volte_available(tapi_context context, int slot_id, bool* out);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_ims_get_subscriber_uri_number
+
+```c
+int tapi_ims_get_subscriber_uri_number(tapi_context context, int slot_id, char** out);
+```
+
+开启 IMS 服务（VoLTE/VoWiFi）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_ims_get_enabled
+
+```c
+int tapi_ims_get_enabled(tapi_context context, int slot_id, bool* out);
+```
+
+查询 IMS 是否启用。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_manager.md
+++ b/doxygen/api/framework/telephony/telephony_manager.md
@@ -1,12 +1,723 @@
-# Telephony Manager API
+# Telephony 管理 API
 
-Telephony Manage API 提供 Telephony 服务的总控接口，负责通信功能的初始化与启停。这是使用所有其他 Telephony 业务的前提。
+蜂窝通信管理接口，包括初始化、状态查询和事件注册。
 
-## tapi_manager.h
+头文件：`#include <tapi_manager.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_manager.h
-  :project: doxygen
+- **基于 D-Bus**：TAPI Manager 通过 D-Bus 与 Telephony Core Stack（oFono）通信，对外以标准 C 接口封装
+- **多卡支持**：管理器层面不直接涉及 SIM 卡槽选择，涉及特定卡槽的操作在 `tapi_sim` 等子模块中使用 `slot_id` 参数
+- **客户端句柄**：通过 `tapi_open` 获取 `tapi_context`，所有后续调用均以该 context 作为第一个参数
+- **事件订阅**：通过 `tapi_register` 注册事件回调，`tapi_unregister` 取消订阅
+- **同步 vs 异步**：多数接口是异步的（带回调），部分提供 `*_sync` 变体用于简单场景
 
+## 客户端连接管理
+
+### tapi_open
+
+```c
+tapi_context tapi_open(const char* client_name, tapi_client_ready_function callback, void* user_data);
 ```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `client_name` 客户端名称。
+- `callback` 回调函数。
+- `user_data` 用户数据，传递给回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_open_service
+
+```c
+tapi_context tapi_open_service(const char* client_name, tapi_client_ready_function callback, void* user_data, unsigned int tapi_service);
+```
+
+打开 Telephony 连接。
+
+**参数**：
+
+- `client_name` 客户端名称。
+- `callback` 回调函数。
+- `user_data` 用户数据，传递给回调函数。
+- `tapi_service` Telephony 服务类型。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_close
+
+```c
+int tapi_close(tapi_context context);
+```
+
+关闭 Telephony 连接。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 能力查询
+
+### tapi_is_feature_supported
+
+```c
+bool tapi_is_feature_supported(tapi_feature_type feature);
+```
+
+查询是否支持指定功能。
+
+**参数**：
+
+- `feature` 功能名称。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 无线电控制
+
+### tapi_set_radio_power
+
+```c
+int tapi_set_radio_power(tapi_context context, int slot_id, int event_id, bool state, tapi_async_function p_handle);
+```
+
+设置射频功率。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `state` 状态。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_set_radio_power_async
+
+```c
+int tapi_set_radio_power_async(tapi_context context, int slot_id, int event_id, bool state, void* user_data, tapi_async_function p_handle);
+```
+
+设置射频功率（异步版本）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `state` 状态。
+- `user_data` 用户数据，传递给回调函数。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_radio_power
+
+```c
+int tapi_get_radio_power(tapi_context context, int slot_id, bool* out);
+```
+
+获取射频功率状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 网络模式
+
+### tapi_set_pref_net_mode
+
+```c
+int tapi_set_pref_net_mode(tapi_context context, int slot_id, int event_id, tapi_pref_net_mode mode, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `mode` 模式。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_pref_net_mode
+
+```c
+int tapi_get_pref_net_mode(tapi_context context, int slot_id, tapi_pref_net_mode* out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_radio_state
+
+```c
+int tapi_get_radio_state(tapi_context context, int slot_id, tapi_radio_state* out);
+```
+
+获取射频状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## Modem 信息
+
+### tapi_get_imei
+
+```c
+int tapi_get_imei(tapi_context context, int slot_id, char** out);
+```
+
+获取设备 IMEI。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_imeisv
+
+```c
+int tapi_get_imeisv(tapi_context context, int slot_id, char** out);
+```
+
+获取设备 IMEI。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_modem_revision
+
+```c
+int tapi_get_modem_revision(tapi_context context, int slot_id, char** out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_phone_state
+
+```c
+int tapi_get_phone_state(tapi_context context, int slot_id, tapi_phone_state* state);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `state` 状态。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 手机号码
+
+### tapi_get_msisdn_number
+
+```c
+int tapi_get_msisdn_number(tapi_context context, int slot_id, char** out);
+```
+
+获取 SIM 卡电话号码（MSISDN）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## Modem 状态与控制
+
+### tapi_get_modem_activity_info
+
+```c
+int tapi_get_modem_activity_info(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+获取 Modem 活动信息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_invoke_oem_ril_request_raw
+
+```c
+int tapi_invoke_oem_ril_request_raw(tapi_context context, int slot_id, int event_id, unsigned char oem_req[], int length, tapi_async_function p_handle);
+```
+
+发送 OEM RIL 请求。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `oem_req` OEM 请求数据。
+- `length` 数据长度。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_invoke_oem_ril_request_strings
+
+```c
+int tapi_invoke_oem_ril_request_strings(tapi_context context, int slot_id, int event_id, char* oem_req[], int length, tapi_async_function p_handle);
+```
+
+发送 OEM RIL 请求。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `oem_req` OEM 请求数据。
+- `length` 数据长度。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_enable_modem
+
+```c
+int tapi_enable_modem(tapi_context context, int slot_id, int event_id, bool enable, tapi_async_function p_handle);
+```
+
+启用 Modem。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `enable` 是否启用。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_enable_modem_abnormal_event
+
+```c
+int tapi_enable_modem_abnormal_event(tapi_context context, int slot_id, bool enable, int event_id, int module_mask, int from_event_id, int to_event_id, tapi_async_function p_handle);
+```
+
+启用 Modem。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `enable` 是否启用。
+- `event_id` 事件 ID，用于回调匹配。
+- `module_mask` 模块掩码。
+- `from_event_id` 源事件 ID。
+- `to_event_id` 目标事件 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_set_signal_report_threshold
+
+```c
+int tapi_set_signal_report_threshold(tapi_context context, int slot_id, int event_id, int type, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `type` 类型。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_suppress_message_report
+
+```c
+int tapi_suppress_message_report(tapi_context context, int slot_id, int event_id, bool enable, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `enable` 是否启用。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_enable_modem_stationary
+
+```c
+int tapi_enable_modem_stationary(tapi_context context, int slot_id, int event_id, bool enable, tapi_async_function p_handle);
+```
+
+启用 Modem。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `enable` 是否启用。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_set_modem_stationary_threshold
+
+```c
+int tapi_set_modem_stationary_threshold(tapi_context context, int slot_id, int event_id, int value, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `value` 值。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_modem_status
+
+```c
+int tapi_get_modem_status(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_modem_status_sync
+
+```c
+int tapi_get_modem_status_sync(tapi_context context, int slot_id, tapi_modem_state* out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_set_fast_dormancy
+
+```c
+int tapi_set_fast_dormancy(tapi_context context, int slot_id, int event_id, bool state, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `state` 状态。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_phone_number
+
+```c
+int tapi_get_phone_number(tapi_context context, int slot_id, char** out);
+```
+
+获取本机号码。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 事件订阅
+
+### tapi_register
+
+```c
+int tapi_register(tapi_context context, int slot_id, tapi_indication_msg msg, void* user_obj, tapi_async_function p_handle);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `msg` 消息内容。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_unregister
+
+```c
+int tapi_unregister(tapi_context context, int watch_id);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 监听 ID（用于取消监听）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 运营商配置
+
+### tapi_get_carrier_config_bool
+
+```c
+int tapi_get_carrier_config_bool(tapi_context context, int slot_id, char* key, bool* out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `key` 键名。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_carrier_config_int
+
+```c
+int tapi_get_carrier_config_int(tapi_context context, int slot_id, char* key, int* out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `key` 键名。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_get_carrier_config_string
+
+```c
+int tapi_get_carrier_config_string(tapi_context context, int slot_id, char* key, char** out);
+```
+
+打开 Telephony 连接，获取上下文句柄。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `key` 键名。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_network.md
+++ b/doxygen/api/framework/telephony/telephony_network.md
@@ -1,11 +1,438 @@
-# Telephony Network API
+# 网络服务 API
 
-Telephony Network TAPI 提供 openvela Telephony 网络服务相关能力，主要针对驻网以及相关功能业务，包括但不限于开关飞行模式、搜索网络、信号强度、小区信息等等。
+蜂窝网络注册、信号强度、运营商信息等。
 
-## tapi_network.h
+头文件：`#include <tapi_network.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_network.h
-    :project: doxygen
+- **选网模式**：支持自动选网（`select_auto`）和手动选网（`select_manual`）
+- **扫描**：`tapi_network_scan` 扫描可用的网络运营商
+- **小区信息**：`get_serving_cellinfos` 获取当前服务小区，`get_neighbouring_cellinfos` 获取相邻小区
+- **多卡支持**：大部分接口带 `slot_id`，区分不同 SIM 卡槽的网络状态
+- **事件订阅**：`tapi_network_register` / `tapi_network_unregister` 监听注册状态/信号强度变化
+
+## 选网与扫描
+
+### tapi_network_select_auto
+
+```c
+int tapi_network_select_auto(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
 ```
+
+自动选择网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_select_manual
+
+```c
+int tapi_network_select_manual(tapi_context context, int slot_id, int event_id, tapi_operator_info* network, tapi_async_function p_handle);
+```
+
+手动选择网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `network` 网络信息。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_scan
+
+```c
+int tapi_network_scan(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 小区信息
+
+### tapi_network_get_serving_cellinfos
+
+```c
+int tapi_network_get_serving_cellinfos(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_neighbouring_cellinfos
+
+```c
+int tapi_network_get_neighbouring_cellinfos(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 语音网络状态
+
+### tapi_network_is_voice_registered
+
+```c
+int tapi_network_is_voice_registered(tapi_context context, int slot_id, bool* out);
+```
+
+查询是否已注册语音服务。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_is_voice_emergency_only
+
+```c
+int tapi_network_is_voice_emergency_only(tapi_context context, int slot_id, bool* out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_voice_network_type
+
+```c
+int tapi_network_get_voice_network_type(tapi_context context, int slot_id, tapi_network_type* out);
+```
+
+获取语音网络类型。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_is_voice_roaming
+
+```c
+int tapi_network_is_voice_roaming(tapi_context context, int slot_id, bool* out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 运营商信息
+
+### tapi_network_get_display_name
+
+```c
+int tapi_network_get_display_name(tapi_context context, int slot_id, char** out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 信号强度
+
+### tapi_network_get_signalstrength
+
+```c
+int tapi_network_get_signalstrength(tapi_context context, int slot_id, tapi_signal_strength* out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 注册信息
+
+### tapi_network_get_registration_info
+
+```c
+int tapi_network_get_registration_info(tapi_context context, int slot_id, int event_id, tapi_async_function p_handle);
+```
+
+获取网络注册信息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 上报频率与事件
+
+### tapi_network_set_cell_info_list_rate
+
+```c
+int tapi_network_set_cell_info_list_rate(tapi_context context, int slot_id, int event_id, u_int32_t period, tapi_async_function p_handle);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `period` 周期（毫秒）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_register
+
+```c
+int tapi_network_register(tapi_context context, int slot_id, tapi_indication_msg msg, void* user_obj, tapi_async_function p_handle);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `msg` 消息内容。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_unregister
+
+```c
+int tapi_network_unregister(tapi_context context, int watch_id);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 监听 ID（用于取消监听）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## MCC / MNC
+
+### tapi_network_get_mcc
+
+```c
+int tapi_network_get_mcc(tapi_context context, int slot_id, char** mcc);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `mcc` 移动国家码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_mnc
+
+```c
+int tapi_network_get_mnc(tapi_context context, int slot_id, char** mnc);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `mnc` 移动网络码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_operator_status
+
+```c
+int tapi_network_get_operator_status(tapi_context context, int slot_id, int* out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_operator_name
+
+```c
+int tapi_network_get_operator_name(tapi_context context, int slot_id, char** out);
+```
+
+获取运营商名称。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_network_get_reg_state
+
+```c
+int tapi_network_get_reg_state(tapi_context context, int slot_id, tapi_registration_state* out);
+```
+
+手动选择指定网络。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_phone.md
+++ b/doxygen/api/framework/telephony/telephony_phone.md
@@ -1,0 +1,301 @@
+# Telephony Phone Service API
+
+简化版电话服务接口，面向轻量客户端使用。相较于 `tapi_call`，该模块封装更紧凑的通话控制能力，并整合音频类型控制、无线电开关和 WTP（Wireless Telephony Profile）配套接口。
+
+头文件：`#include <tapi_phone.h>`
+
+## openvela 实现说明
+
+- **客户端会话**：通过 `tapi_start_phone_service_client` 启动，`tapi_stop_phone_service_client` 停止
+- **回调注册**：通过 `tapi_client_register_callbacks` 注册统一回调，监听通话事件
+- **无需 tapi_context**：本接口在底层自管理与服务端的连接，调用方不需要持有 `tapi_context`
+- **WTP 支持**：封装蓝牙配对手表/设备的 WTP（Wireless Telephony Profile）适配能力
+- **适用场景**：嵌入式可穿戴设备、简单通话客户端
+
+## 服务生命周期
+
+### tapi_start_phone_service_client
+
+```c
+int tapi_start_phone_service_client(const char* client_name);
+```
+
+启动电话服务客户端。
+
+**参数**：
+
+- `client_name` 客户端名称。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stop_phone_service_client
+
+```c
+int tapi_stop_phone_service_client(void);
+```
+
+停止电话服务客户端。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_client_register_callbacks
+
+```c
+int tapi_client_register_callbacks(void* callbacks);
+```
+
+注册客户端回调集合。
+
+**参数**：
+
+- `callbacks` 回调函数集合指针。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_client_unregister_callbacks
+
+```c
+int tapi_client_unregister_callbacks(void);
+```
+
+取消客户端回调注册。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 通话控制
+
+### tapi_dial_call
+
+```c
+int tapi_dial_call(const char* number);
+```
+
+拨打电话。
+
+**参数**：
+
+- `number` 要拨打的号码字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_answer_call
+
+```c
+int tapi_answer_call(void);
+```
+
+接听来电。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_reject_call
+
+```c
+int tapi_reject_call(void);
+```
+
+拒绝来电。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_hangup_call
+
+```c
+int tapi_hangup_call(void);
+```
+
+挂断当前通话。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_hold_call
+
+```c
+int tapi_hold_call(void);
+```
+
+保持当前通话。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_hold_and_answer_call
+
+```c
+int tapi_hold_and_answer_call(void);
+```
+
+保持当前通话并接听新来电。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_release_and_answer_call
+
+```c
+int tapi_release_and_answer_call(void);
+```
+
+释放当前通话并接听新来电。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_merge_call
+
+```c
+int tapi_merge_call(void);
+```
+
+合并多个通话形成会议通话。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_send_tones
+
+```c
+int tapi_send_tones(const char* tones);
+```
+
+发送 DTMF 音序列。
+
+**参数**：
+
+- `tones` DTMF 字符串（`0-9 * # A-D`）。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 音频与射频控制
+
+### tapi_client_set_audio_type
+
+```c
+int tapi_client_set_audio_type(int type);
+```
+
+设置通话期间使用的音频类型。
+
+**参数**：
+
+- `type` 音频类型枚举值。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_client_set_radio_power
+
+```c
+int tapi_client_set_radio_power(bool enabled);
+```
+
+简化版射频功率开关。
+
+**参数**：
+
+- `enabled` `true` 开启射频，`false` 关闭。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## WTP（无线电话配置文件）
+
+### tapi_client_wtp_register_cb
+
+```c
+int tapi_client_wtp_register_cb(void* callbacks);
+```
+
+注册 WTP 事件回调。
+
+**参数**：
+
+- `callbacks` WTP 回调集合指针。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_client_wtp_unregister_cb
+
+```c
+int tapi_client_wtp_unregister_cb(void);
+```
+
+取消 WTP 事件回调注册。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_wtp_set_local_info
+
+```c
+int tapi_wtp_set_local_info(const char* info);
+```
+
+设置 WTP 本地信息（设备标识、能力等）。
+
+**参数**：
+
+- `info` 本地信息字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_wtp_modify_discovery
+
+```c
+int tapi_wtp_modify_discovery(int mode);
+```
+
+修改 WTP 发现模式。
+
+**参数**：
+
+- `mode` 发现模式枚举值。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_wtp_modify_visibility
+
+```c
+int tapi_wtp_modify_visibility(int visibility);
+```
+
+修改 WTP 可见性配置。
+
+**参数**：
+
+- `visibility` 可见性枚举值。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。

--- a/doxygen/api/framework/telephony/telephony_phonebook.md
+++ b/doxygen/api/framework/telephony/telephony_phonebook.md
@@ -1,0 +1,129 @@
+# Telephony 电话簿 API
+
+SIM 卡电话簿管理接口，支持 ADN（普通电话簿）和 FDN（固定拨号号码）两类条目。
+
+头文件：`#include <tapi_phonebook.h>`
+
+## openvela 实现说明
+
+- **ADN**：普通电话簿（Abbreviated Dialling Numbers），存储在 SIM 卡上的常规号码
+- **FDN**：固定拨号号码（Fixed Dialling Numbers），启用后手机只能拨打 FDN 中的号码，受 PIN2 保护
+- **FDN 操作需要 PIN2**：`insert_fdn_entry` / `delete_fdn_entry` / `update_fdn_entry` 调用时需要传入 PIN2
+- **多卡支持**：所有接口带 `slot_id`
+- **异步回调**：所有操作使用 `tapi_async_function` 异步返回结果
+
+## ADN 电话簿
+
+### tapi_phonebook_load_adn_entries
+
+```c
+int tapi_phonebook_load_adn_entries(tapi_context context, int slot_id, int event_id,
+                                    tapi_async_function p_handle);
+```
+
+加载 SIM 卡上的 ADN 电话簿条目。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数，回调时返回 ADN 条目列表。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## FDN 固定拨号
+
+### tapi_phonebook_load_fdn_entries
+
+```c
+int tapi_phonebook_load_fdn_entries(tapi_context context, int slot_id, int event_id,
+                                    tapi_async_function p_handle);
+```
+
+加载 SIM 卡上的 FDN 条目。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数，回调时返回 FDN 条目列表。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_phonebook_insert_fdn_entry
+
+```c
+int tapi_phonebook_insert_fdn_entry(tapi_context context, int slot_id, int event_id,
+                                    char* name, char* number, char* pin2,
+                                    tapi_async_function p_handle);
+```
+
+向 FDN 列表插入一条新条目（需要 PIN2 校验）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `name` 联系人姓名。
+- `number` 电话号码。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_phonebook_update_fdn_entry
+
+```c
+int tapi_phonebook_update_fdn_entry(tapi_context context, int slot_id, int event_id,
+                                    int fdn_idx, char* new_name, char* new_number,
+                                    char* pin2, tapi_async_function p_handle);
+```
+
+更新已有 FDN 条目（需要 PIN2 校验）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `fdn_idx` 要更新的条目索引。
+- `new_name` 新的联系人姓名。
+- `new_number` 新的电话号码。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_phonebook_delete_fdn_entry
+
+```c
+int tapi_phonebook_delete_fdn_entry(tapi_context context, int slot_id, int event_id,
+                                    int fdn_idx, char* pin2,
+                                    tapi_async_function p_handle);
+```
+
+删除指定 FDN 条目（需要 PIN2 校验）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `fdn_idx` 要删除的条目索引。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。

--- a/doxygen/api/framework/telephony/telephony_sim.md
+++ b/doxygen/api/framework/telephony/telephony_sim.md
@@ -1,27 +1,455 @@
-# Telephony SIM API
+# SIM 卡管理 API
 
-Telephony SIM TAPI 提供 openvela Telephony 处理 SIM 卡（包括 STK）相关业务。APP 无需关心 SIM 卡模块的内部业务细节，仅需调用 API 获取 SIM 信息或者监听 SIM 相关消息即可完成 APP 开发。
+SIM 卡状态查询和管理。
 
-## tapi_sim.h
+头文件：`#include <tapi_sim.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_sim.h
-    :project: doxygen
+- **多卡支持**：所有接口均带 `slot_id`，支持多 SIM 卡设备
+- **PIN 管理**：提供 `enter_pin` / `change_pin` / `reset_pin` / `lock_pin` / `unlock_pin` 完整 PIN/PUK 流程
+- **APDU 通道**：通过 `open_logical_channel` / `close_logical_channel` / `transmit_apdu_*` 直接向 SIM 卡发送 APDU 命令
+- **UICC 开关**：通过 `get_uicc_enablement` / `set_uicc_enablement` 控制 SIM 卡的启用状态
+- **事件订阅**：`tapi_sim_register` / `tapi_sim_unregister` 监听 SIM 卡状态变化
+
+## SIM 状态查询
+
+### tapi_sim_has_icc_card
+
+```c
+int tapi_sim_has_icc_card(tapi_context context, int slot_id, bool* out);
 ```
 
-## tapi_stk.h
+查询是否插入 SIM 卡。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: tapi_stk.h
-    :project: doxygen
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_sim_state
+
+```c
+int tapi_sim_get_sim_state(tapi_context context, int slot_id, int* out);
 ```
 
-## tapi_phonebook.h
+获取 SIM 卡状态。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: tapi_phonebook.h
-    :project: doxygen
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_sim_operator
+
+```c
+int tapi_sim_get_sim_operator(tapi_context context, int slot_id, int length, char* out);
 ```
+
+获取 SIM 卡运营商信息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `length` 数据长度。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_sim_operator_name
+
+```c
+int tapi_sim_get_sim_operator_name(tapi_context context, int slot_id, char** out);
+```
+
+获取 SIM 卡运营商信息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_sim_iccid
+
+```c
+int tapi_sim_get_sim_iccid(tapi_context context, int slot_id, char** out);
+```
+
+获取 SIM 卡 ICCID。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_subscriber_id
+
+```c
+int tapi_sim_get_subscriber_id(tapi_context context, int slot_id, char** out);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 事件订阅
+
+### tapi_sim_register
+
+```c
+int tapi_sim_register(tapi_context context, int slot_id, tapi_indication_msg msg, void* user_obj, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `msg` 消息内容。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_unregister
+
+```c
+int tapi_sim_unregister(tapi_context context, int watch_id);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 监听 ID（用于取消监听）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## PIN 管理
+
+### tapi_sim_change_pin
+
+```c
+int tapi_sim_change_pin(tapi_context context, int slot_id, int event_id, char* pin_type, char* old_pin, char* new_pin, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `pin_type` PIN 码类型。
+- `old_pin` 旧 PIN 码。
+- `new_pin` 新 PIN 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_enter_pin
+
+```c
+int tapi_sim_enter_pin(tapi_context context, int slot_id, int event_id, char* pin_type, char* pin, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `pin_type` PIN 码类型。
+- `pin` PIN 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_reset_pin
+
+```c
+int tapi_sim_reset_pin(tapi_context context, int slot_id, int event_id, char* puk_type, char* puk, char* new_pin, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `puk_type` PUK 码类型。
+- `puk` PUK 码。
+- `new_pin` 新 PIN 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_lock_pin
+
+```c
+int tapi_sim_lock_pin(tapi_context context, int slot_id, int event_id, char* pin_type, char* pin, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `pin_type` PIN 码类型。
+- `pin` PIN 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_unlock_pin
+
+```c
+int tapi_sim_unlock_pin(tapi_context context, int slot_id, int event_id, char* pin_type, char* pin, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `pin_type` PIN 码类型。
+- `pin` PIN 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## APDU 逻辑通道
+
+### tapi_sim_open_logical_channel
+
+```c
+int tapi_sim_open_logical_channel(tapi_context context, int slot_id, int event_id, unsigned char aid[], int len, tapi_async_function p_handle);
+```
+
+打开 SIM 卡逻辑通道。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `aid` 应用 ID。
+- `len` 长度。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_close_logical_channel
+
+```c
+int tapi_sim_close_logical_channel(tapi_context context, int slot_id, int event_id, int session_id, tapi_async_function p_handle);
+```
+
+关闭 SIM 卡逻辑通道。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `session_id` 会话 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_transmit_apdu_logical_channel
+
+```c
+int tapi_sim_transmit_apdu_logical_channel(tapi_context context, int slot_id, int event_id, int session_id, unsigned char pdu[], int len, tapi_async_function p_handle);
+```
+
+通过逻辑通道发送 APDU 命令。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `session_id` 会话 ID。
+- `pdu` PDU 数据。
+- `len` 长度。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_transmit_apdu_basic_channel
+
+```c
+int tapi_sim_transmit_apdu_basic_channel(tapi_context context, int slot_id, int event_id, unsigned char pdu[], int len, tapi_async_function p_handle);
+```
+
+通过逻辑通道发送 APDU 命令。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `pdu` PDU 数据。
+- `len` 长度。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## UICC 开关
+
+### tapi_sim_get_uicc_enablement
+
+```c
+int tapi_sim_get_uicc_enablement(tapi_context context, int slot_id, tapi_sim_uicc_app_state* out);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_set_uicc_enablement
+
+```c
+int tapi_sim_set_uicc_enablement(tapi_context context, int slot_id, int event_id, int state, tapi_async_function p_handle);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `event_id` 事件 ID，用于回调匹配。
+- `state` 状态。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sim_get_sim_invalid
+
+```c
+int tapi_sim_get_sim_invalid(tapi_context context, int slot_id, int* out);
+```
+
+获取用户标识（IMSI）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_sms.md
+++ b/doxygen/api/framework/telephony/telephony_sms.md
@@ -1,19 +1,292 @@
-# Telephony SMS API
+# 短信管理 API
 
-Telephony SMS TAPI 提供 openvela Telephony 处理短信相关业务，主要包括短信收发、短信状态报告，小区广播等业务。
+短信发送和接收。
 
-## tapi_sms.h
+头文件：`#include <tapi_sms.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: tapi_sms.h
-    :project: doxygen
+- **文本与数据短信**：`send_message` 发送文本短信，`send_data_message` 发送二进制 PDU
+- **服务中心地址**：通过 `set_service_center_address` / `get_service_center_address` 配置运营商短信网关
+- **送达报告**：可通过 `enable_delivery_report` 开关送达报告
+- **SIM 卡存储**：提供 `get_all_messages_from_sim` / `copy_message_to_sim` / `delete_message_from_sim` 操作 SIM 卡上的短信
+- **事件订阅**：`tapi_sms_register` 监听收件/发件事件
+
+## 发送短信
+
+### tapi_sms_send_message
+
+```c
+int tapi_sms_send_message(tapi_context context, int slot_id, int sms_id, char* number, char* text, int event_id, tapi_async_function p_handle);
 ```
 
-## tapi_cbs.h
+发送短信。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: tapi_cbs.h
-    :project: doxygen
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `sms_id` 短信 ID。
+- `number` 电话号码。
+- `text` 文本内容。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_send_data_message
+
+```c
+int tapi_sms_send_data_message(tapi_context context, int slot_id, int sms_id, char* dest_addr, unsigned int port, char* text, int event_id, tapi_async_function p_handle);
 ```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `sms_id` 短信 ID。
+- `dest_addr` 目标号码。
+- `port` 端口号。
+- `text` 文本内容。
+- `event_id` 事件 ID，用于回调匹配。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 服务中心与送达报告
+
+### tapi_sms_set_service_center_address
+
+```c
+bool tapi_sms_set_service_center_address(tapi_context context, int slot_id, char* number);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `number` 电话号码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_get_service_center_address
+
+```c
+int tapi_sms_get_service_center_address(tapi_context context, int slot_id, char** number);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `number` 电话号码。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_enable_delivery_report
+
+```c
+int tapi_sms_enable_delivery_report(tapi_context context, int slot_id, bool enable);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `enable` 是否启用。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_get_delivery_report_status
+
+```c
+int tapi_sms_get_delivery_report_status(tapi_context context, int slot_id, bool* out);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## SIM 卡短信存储
+
+### tapi_sms_get_all_messages_from_sim
+
+```c
+int tapi_sms_get_all_messages_from_sim(tapi_context context, int slot_id, tapi_message_list* list, tapi_async_function p_handle);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `list` 列表。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_copy_message_to_sim
+
+```c
+int tapi_sms_copy_message_to_sim(tapi_context context, int slot_id, char* number, char* text, char* send_time, int type);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `number` 电话号码。
+- `text` 文本内容。
+- `send_time` 发送时间。
+- `type` 类型。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_delete_message_from_sim
+
+```c
+int tapi_sms_delete_message_from_sim(tapi_context context, int slot_id, int index);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `index` 索引。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+## 事件订阅与默认卡
+
+### tapi_sms_register
+
+```c
+int tapi_sms_register(tapi_context context, int slot_id, tapi_indication_msg msg, void* user_obj, tapi_async_function p_handle);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+- `msg` 消息内容。
+- `user_obj` 用户对象指针。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_unregister
+
+```c
+int tapi_sms_unregister(tapi_context context, int watch_id);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 监听 ID（用于取消监听）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_set_default_slot
+
+```c
+int tapi_sms_set_default_slot(tapi_context context, int slot_id);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID（0 或 1）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+
+
+### tapi_sms_get_default_slot
+
+```c
+int tapi_sms_get_default_slot(tapi_context context, int* out);
+```
+
+发送数据短信。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `out` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+

--- a/doxygen/api/framework/telephony/telephony_ss.md
+++ b/doxygen/api/framework/telephony/telephony_ss.md
@@ -1,0 +1,489 @@
+# Telephony 补充业务（SS）API
+
+Supplementary Services（补充业务）是 3GPP 蜂窝标准定义的增值通话能力，包括呼叫限制（Call Barring）、呼叫转移（Call Forwarding）、主叫识别（CLIR/CLIP）、呼叫等待、USSD 等。
+
+头文件：`#include <tapi_ss.h>`
+
+## openvela 实现说明
+
+- **呼叫限制 Call Barring**：`tapi_ss_*_call_barring*` 系列控制拨出/拨入的号码范围
+- **呼叫转移 Call Forwarding**：`tapi_ss_*_call_forwarding*` 系列配置无条件/忙/无应答/不可达四种转移
+- **CLIR/CLIP**：主叫号码显示与限制，通过 `calling_line_restriction` 和 `calling_line_presentation_info` 接口
+- **USSD**：`tapi_ss_send_ussd` 发送 `*#xxxx#` 命令，`tapi_ss_cancel_ussd` 取消会话
+- **FDN**：固定拨号开关通过 `tapi_ss_enable_fdn` / `tapi_ss_query_fdn`
+- **多卡支持**：所有接口带 `slot_id`
+- **异步回调**：所有操作使用 `tapi_async_function`
+
+## 呼叫限制
+
+### tapi_ss_request_call_barring
+
+```c
+int tapi_ss_request_call_barring(tapi_context context, int slot_id, int event_id,
+                                 char* fac, char* pin2,
+                                 tapi_async_function p_handle);
+```
+
+请求某类呼叫限制（按 FAC 编码）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `fac` 呼叫限制 FAC 码（如 `"OI"`、`"IR"` 等）。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_set_call_barring_option
+
+```c
+int tapi_ss_set_call_barring_option(tapi_context context, int slot_id, int event_id,
+                                    char* facility, char* pin2,
+                                    tapi_async_function p_handle);
+```
+
+设置呼叫限制选项。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `facility` 限制类型字符串。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_get_call_barring_option
+
+```c
+int tapi_ss_get_call_barring_option(tapi_context context, int slot_id,
+                                    const char* service_type, char** out);
+```
+
+查询当前呼叫限制配置。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `service_type` 服务类型字符串。
+- `out` 输出参数，返回配置字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_change_call_barring_password
+
+```c
+int tapi_ss_change_call_barring_password(tapi_context context, int slot_id, int event_id,
+                                         char* old_pin, char* new_pin,
+                                         tapi_async_function p_handle);
+```
+
+修改呼叫限制服务的密码。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `old_pin` 旧密码。
+- `new_pin` 新密码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_disable_all_call_barrings
+
+```c
+int tapi_ss_disable_all_call_barrings(tapi_context context, int slot_id, int event_id,
+                                      char* passwd, tapi_async_function p_handle);
+```
+
+关闭所有呼叫限制。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `passwd` 服务密码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_disable_all_incoming
+
+```c
+int tapi_ss_disable_all_incoming(tapi_context context, int slot_id,
+                                 int event_id, char* passwd,
+                                 tapi_async_function p_handle);
+```
+
+关闭所有入呼限制。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `passwd` 服务密码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_disable_all_outgoing
+
+```c
+int tapi_ss_disable_all_outgoing(tapi_context context, int slot_id,
+                                 int event_id, char* passwd,
+                                 tapi_async_function p_handle);
+```
+
+关闭所有出呼限制。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `passwd` 服务密码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 呼叫转移
+
+### tapi_ss_query_call_forwarding_option
+
+```c
+int tapi_ss_query_call_forwarding_option(tapi_context context, int slot_id, int event_id,
+                                         int cf_reason, tapi_async_function p_handle);
+```
+
+查询呼叫转移配置。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `cf_reason` 转移类型（无条件/忙/无应答/不可达，详见 `tapi_call_forward_option`）。
+- `p_handle` 异步回调函数，回调时返回 `tapi_call_forwarding_info`。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_set_call_forwarding_option
+
+```c
+int tapi_ss_set_call_forwarding_option(tapi_context context, int slot_id, int event_id,
+                                       tapi_call_forwarding_info* info,
+                                       tapi_async_function p_handle);
+```
+
+设置呼叫转移配置。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `info` 呼叫转移配置结构体。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## USSD 会话
+
+### tapi_ss_initiate_service
+
+```c
+int tapi_ss_initiate_service(tapi_context context, int slot_id, int event_id,
+                             char* command, tapi_async_function p_handle);
+```
+
+发起 SS 服务命令（USSD/SS 字符串形式，如 `*#06#`）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `command` 命令字符串。
+- `p_handle` 异步回调函数，回调返回 `tapi_ss_initiate_info`。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_get_ussd_state
+
+```c
+int tapi_get_ussd_state(tapi_context context, int slot_id, char** out);
+```
+
+查询当前 USSD 会话状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `out` 输出参数，返回状态字符串（如 `"idle"`、`"user-response"`）。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_send_ussd
+
+```c
+int tapi_ss_send_ussd(tapi_context context, int slot_id, int event_id, char* reply,
+                     tapi_async_function p_handle);
+```
+
+发送 USSD 回复消息。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `reply` 回复字符串。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_cancel_ussd
+
+```c
+int tapi_ss_cancel_ussd(tapi_context context, int slot_id, int event_id,
+                       tapi_async_function p_handle);
+```
+
+取消当前 USSD 会话。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 呼叫等待
+
+### tapi_ss_set_call_waiting
+
+```c
+int tapi_ss_set_call_waiting(tapi_context context, int slot_id, int event_id, bool enable,
+                             tapi_async_function p_handle);
+```
+
+启用或禁用呼叫等待功能。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `enable` `true` 启用，`false` 禁用。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_get_call_waiting
+
+```c
+int tapi_ss_get_call_waiting(tapi_context context, int slot_id, int event_id,
+                             tapi_async_function p_handle);
+```
+
+查询呼叫等待开关状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数，回调返回当前状态。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## CLIR / CLIP（主叫号码显示与限制）
+
+### tapi_ss_get_calling_line_presentation_info
+
+```c
+int tapi_ss_get_calling_line_presentation_info(tapi_context context, int slot_id,
+                                               int event_id, tapi_async_function p_handle);
+```
+
+查询主叫号码显示（CLIP）状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_set_calling_line_restriction
+
+```c
+int tapi_ss_set_calling_line_restriction(tapi_context context, int slot_id, int event_id,
+                                         tapi_clir_status status,
+                                         tapi_async_function p_handle);
+```
+
+设置主叫号码限制（CLIR）状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `status` CLIR 状态枚举值（`CLIR_DEFAULT` / `CLIR_INVOCATION` / `CLIR_SUPPRESSION`）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_get_calling_line_restriction_info
+
+```c
+int tapi_ss_get_calling_line_restriction_info(tapi_context context, int slot_id,
+                                              int event_id, tapi_async_function p_handle);
+```
+
+查询主叫号码限制（CLIR）状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## FDN（固定拨号）开关
+
+### tapi_ss_enable_fdn
+
+```c
+int tapi_ss_enable_fdn(tapi_context context, int slot_id, int event_id,
+                      bool enable, char* pin2, tapi_async_function p_handle);
+```
+
+启用或禁用 FDN 模式（需要 PIN2）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `enable` `true` 启用 FDN，`false` 禁用。
+- `pin2` SIM 卡 PIN2 码。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_ss_query_fdn
+
+```c
+int tapi_ss_query_fdn(tapi_context context, int slot_id, int event_id,
+                     tapi_async_function p_handle);
+```
+
+查询 FDN 开关状态。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `event_id` 事件 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 事件订阅
+
+### tapi_ss_register
+
+```c
+int tapi_ss_register(tapi_context context, int slot_id, tapi_indication_msg msg,
+                    void* user_obj, tapi_async_function p_handle);
+```
+
+注册 SS 相关事件回调。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `msg` 要监听的事件类型。
+- `user_obj` 用户数据。
+- `p_handle` 事件回调函数。
+
+**返回值**：
+
+成功时返回 watch ID，失败时返回负的错误码。
+
+### tapi_ss_unregister
+
+```c
+int tapi_ss_unregister(tapi_context context, int watch_id);
+```
+
+取消 SS 事件订阅。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `watch_id` 订阅时返回的 watch ID。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。

--- a/doxygen/api/framework/telephony/telephony_stk.md
+++ b/doxygen/api/framework/telephony/telephony_stk.md
@@ -1,0 +1,603 @@
+# Telephony SIM Toolkit (STK) API
+
+SIM Application Toolkit（STK / CAT）是运营商在 SIM 卡上预置的交互菜单与事件处理能力，常见用途包括运营商增值菜单、服务密码管理、URL 浏览器启动等。
+
+头文件：`#include <tapi_stk.h>`
+
+## openvela 实现说明
+
+- **Agent 模式**：应用侧作为"STK Agent"注册到 TAPI，SIM 卡主动发起的显示/输入/确认请求通过 Agent 回调触达应用
+- **注册层级**：支持 per-slot Agent（通过 `tapi_stk_agent_register`）与 default Agent（系统默认 UI）
+- **主菜单**：`tapi_stk_get_main_menu*` 查询 SIM 卡提供的主菜单结构
+- **Proactive Command 响应**：`tapi_stk_handle_agent_*` 系列接口用于将 Agent 对 SIM 卡主动命令的响应回传给 SIM
+- **多卡支持**：所有接口带 `slot_id`
+
+## Agent 注册
+
+### tapi_stk_agent_register
+
+```c
+int tapi_stk_agent_register(tapi_context context, int slot_id,
+                            char* agent_id, tapi_async_function p_handle);
+```
+
+为指定 SIM 卡槽注册 STK Agent。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `agent_id` Agent 标识字符串。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_agent_unregister
+
+```c
+int tapi_stk_agent_unregister(tapi_context context, int slot_id,
+                              char* agent_id, tapi_async_function p_handle);
+```
+
+取消 STK Agent 注册。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `agent_id` Agent 标识字符串。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_default_agent_register
+
+```c
+int tapi_stk_default_agent_register(tapi_context context, int slot_id,
+                                    char* agent_id, tapi_async_function p_handle);
+```
+
+注册为默认 STK Agent（全局 fallback）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `agent_id` Agent 标识字符串。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_default_agent_unregister
+
+```c
+int tapi_stk_default_agent_unregister(tapi_context context, int slot_id,
+                                      tapi_async_function p_handle);
+```
+
+取消默认 STK Agent 注册。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_agent_interface_register
+
+```c
+int tapi_stk_agent_interface_register(tapi_context context, int slot_id, char* agent_id,
+                                      tapi_stk_agent_interface* iface);
+```
+
+在 Agent 层注册具体的接口实现（回调函数集合）。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `agent_id` Agent 标识字符串。
+- `iface` Agent 接口回调结构体指针。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_agent_interface_unregister
+
+```c
+int tapi_stk_agent_interface_unregister(tapi_context context, char* agent_id);
+```
+
+注销 Agent 接口实现。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `agent_id` Agent 标识字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_default_agent_interface_register
+
+```c
+int tapi_stk_default_agent_interface_register(tapi_context context, int slot_id,
+                                              tapi_stk_agent_interface* iface);
+```
+
+为默认 Agent 注册接口实现。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `iface` Agent 接口回调结构体指针。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_default_agent_interface_unregister
+
+```c
+int tapi_stk_default_agent_interface_unregister(tapi_context context, int slot_id);
+```
+
+注销默认 Agent 的接口实现。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## 主菜单与空闲模式
+
+### tapi_stk_select_item
+
+```c
+int tapi_stk_select_item(tapi_context context, int slot_id,
+                         int item_idx, tapi_async_function p_handle);
+```
+
+选择主菜单中的某个条目，触发 SIM 卡的业务响应。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `item_idx` 条目索引。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_get_idle_mode_text
+
+```c
+int tapi_stk_get_idle_mode_text(tapi_context context, int slot_id, char** text);
+```
+
+查询 SIM 卡设定的空闲模式显示文本。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `text` 输出参数，返回文本字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_get_idle_mode_icon
+
+```c
+int tapi_stk_get_idle_mode_icon(tapi_context context, int slot_id, char** icon);
+```
+
+查询 SIM 卡设定的空闲模式图标标识。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `icon` 输出参数，返回图标标识字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_get_main_menu
+
+```c
+int tapi_stk_get_main_menu(tapi_context context, int slot_id, int* length,
+                           tapi_stk_menu_item out[]);
+```
+
+获取 SIM 卡提供的主菜单条目列表。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `length` 输入输出参数：入参表示缓冲区容量，出参返回实际条目数。
+- `out` 输出缓冲区，接收菜单条目数组。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_get_main_menu_title
+
+```c
+int tapi_stk_get_main_menu_title(tapi_context context, int slot_id, char** title);
+```
+
+查询主菜单标题。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `title` 输出参数，返回标题字符串。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_get_main_menu_icon
+
+```c
+int tapi_stk_get_main_menu_icon(tapi_context context, int slot_id, int* icon);
+```
+
+查询主菜单图标编号。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `icon` 输出参数，返回图标编号。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+## Agent 响应处理
+
+以下接口由 Agent 实现使用，用于向 SIM 卡回传 proactive command 的响应。所有接口成功时返回 `0`，失败时返回负的错误码。
+
+### tapi_stk_handle_agent_request_selection
+
+```c
+int tapi_stk_handle_agent_request_selection(tapi_context context, int slot_id,
+                                            char* agent_id, int selection,
+                                            tapi_async_function p_handle);
+```
+
+处理 SIM 卡的菜单项选择请求，回传用户选中的条目索引。
+
+**参数**：
+
+- `context` Telephony 上下文句柄。
+- `slot_id` SIM 卡槽 ID。
+- `agent_id` Agent 标识字符串。
+- `selection` 用户选中的条目索引。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_display_text
+
+```c
+int tapi_stk_handle_agent_display_text(tapi_context context, int slot_id,
+                                       char* agent_id, int result,
+                                       tapi_async_function p_handle);
+```
+
+响应 SIM 卡的文本显示请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `result` 显示操作结果（用户是否确认等）。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_input
+
+```c
+int tapi_stk_handle_agent_request_input(tapi_context context, int slot_id,
+                                        char* agent_id, char* input,
+                                        tapi_async_function p_handle);
+```
+
+响应 SIM 卡的字符串输入请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `input` 用户输入的字符串。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_digits
+
+```c
+int tapi_stk_handle_agent_request_digits(tapi_context context, int slot_id,
+                                         char* agent_id, char* digits,
+                                         tapi_async_function p_handle);
+```
+
+响应 SIM 卡的数字序列输入请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `digits` 用户输入的数字序列。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_key
+
+```c
+int tapi_stk_handle_agent_request_key(tapi_context context, int slot_id,
+                                      char* agent_id, char key,
+                                      tapi_async_function p_handle);
+```
+
+响应 SIM 卡的单键输入请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `key` 用户输入的按键字符。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_digit
+
+```c
+int tapi_stk_handle_agent_request_digit(tapi_context context, int slot_id,
+                                        char* agent_id, char digit,
+                                        tapi_async_function p_handle);
+```
+
+响应 SIM 卡的单数字输入请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `digit` 用户输入的单个数字字符。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_quick_digit
+
+```c
+int tapi_stk_handle_agent_request_quick_digit(tapi_context context, int slot_id,
+                                              char* agent_id, char digit,
+                                              tapi_async_function p_handle);
+```
+
+响应 SIM 卡的快速数字输入请求（无需回显）。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `digit` 用户输入的单个数字字符。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_request_confirmation
+
+```c
+int tapi_stk_handle_agent_request_confirmation(tapi_context context, int slot_id,
+                                               char* agent_id, bool confirmed,
+                                               tapi_async_function p_handle);
+```
+
+响应 SIM 卡的确认/取消类请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `confirmed` 用户是否确认。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_confirm_call_setup
+
+```c
+int tapi_stk_handle_agent_confirm_call_setup(tapi_context context, int slot_id,
+                                             char* agent_id, bool confirmed,
+                                             tapi_async_function p_handle);
+```
+
+响应 SIM 卡发起的 call-setup 确认请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `confirmed` 用户是否确认拨出。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_play_tone
+
+```c
+int tapi_stk_handle_agent_play_tone(tapi_context context, int slot_id,
+                                    char* agent_id, int result,
+                                    tapi_async_function p_handle);
+```
+
+响应 SIM 卡的播放提示音请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `result` 播放结果。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_loop_tone
+
+```c
+int tapi_stk_handle_agent_loop_tone(tapi_context context, int slot_id,
+                                    char* agent_id, int result,
+                                    tapi_async_function p_handle);
+```
+
+响应 SIM 卡的循环提示音请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `result` 播放结果。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_display_action_information
+
+```c
+int tapi_stk_handle_agent_display_action_information(tapi_context context, int slot_id,
+                                                     char* agent_id, int result,
+                                                     tapi_async_function p_handle);
+```
+
+响应 SIM 卡的动作进度信息显示请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `result` 显示操作结果。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_confirm_launch_browser
+
+```c
+int tapi_stk_handle_agent_confirm_launch_browser(tapi_context context, int slot_id,
+                                                 char* agent_id, bool confirmed,
+                                                 tapi_async_function p_handle);
+```
+
+响应 SIM 卡的浏览器启动确认请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `confirmed` 用户是否确认启动浏览器。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_display_action
+
+```c
+int tapi_stk_handle_agent_display_action(tapi_context context, int slot_id,
+                                         char* agent_id, int result,
+                                         tapi_async_function p_handle);
+```
+
+响应 SIM 卡的动作状态更新请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `result` 操作结果。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+
+### tapi_stk_handle_agent_confirm_open_channel
+
+```c
+int tapi_stk_handle_agent_confirm_open_channel(tapi_context context, int slot_id,
+                                               char* agent_id, bool confirmed,
+                                               tapi_async_function p_handle);
+```
+
+响应 SIM 卡发起的打开数据通道确认请求。
+
+**参数**：
+
+- `context` / `slot_id` / `agent_id` 同上。
+- `confirmed` 用户是否确认打开通道。
+- `p_handle` 异步回调函数。
+
+**返回值**：
+
+成功时返回 `0`，失败时返回负的错误码。
+
+


### PR DESCRIPTION
## Overview

Comprehensive refactor of the Telephony (TAPI) framework API reference documentation following the openvela API documentation standard.

## Coverage

**252 / 252 public APIs (100%)**, across 13 `tapi_*.h` headers:

| File | APIs | Groups | Status |
|------|------|--------|--------|
| `telephony_manager.md` | 33 | 10 | Updated |
| `telephony_call.md` | 32 | 13 | Updated |
| `telephony_data.md` | 23 | 9 | Updated |
| `telephony_network.md` | 20 | 9 | Updated |
| `telephony_sim.md` | 20 | 6 | Updated |
| `telephony_sms.md` | 13 | 5 | Updated |
| `telephony_ims.md` | 9 | 5 | Updated |
| `telephony.md` *(new)* | 21 | 5 | From `tapi.h` utilities |
| `telephony_phone.md` *(new)* | 20 | 5 | Lightweight phone service |
| `telephony_ss.md` *(new)* | 22 | 7 | Supplementary services |
| `telephony_stk.md` *(new)* | 29 | 3 | SIM Toolkit |
| `telephony_cbs.md` *(new)* | 5 | 3 | Cell Broadcast |
| `telephony_phonebook.md` *(new)* | 5 | 2 | ADN/FDN |

## Main Changes

**Updated** (7 existing files): added per-module `## openvela 实现说明` notes and functional grouping (`##` headings). Header includes standardized to angle-bracket form (`#include <tapi_*.h>`).

**Added** (6 new files) covering previously undocumented public headers: supplementary services (SS), SIM Toolkit (STK), Cell Broadcast (CBS), Phonebook, simplified phone service, and the TAPI utility/string-conversion functions from `tapi.h`.

**Updated** `index.md` with categorized navigation for all 13 modules.

## Quality

- All non-void APIs include a `**返回值**:` section.
- All APIs include a `**参数**:` section.
- Every referenced `tapi_*` function and type has been verified against the source headers in `frameworks/connectivity/telephony/include/`.
- No Doxygen or Sphinx directives remain.

## Statistics

14 files changed, +5329 / -232 lines

## Dependencies

Applies cleanly on top of current `dev`. No dependencies on other open PRs.