### PR TITLE
docs: refactor and split network API documentation

### DIFF
--- a/doxygen/api/network/index.md
+++ b/doxygen/api/network/index.md
@@ -2,4 +2,19 @@
 
 openvela 包括一个全面的网络子系统，提供标准的 BSD 套接字接口和 DNS 解析功能。网络子系统是可选的，可以根据应用需求进行配置。openvela 提供的网络接口遵循 POSIX 标准，可以很容易地将现有的网络应用程序移植到 openvela。
 
-- **[网络接口](net.md)** — BSD 套接字、DNS、网络工具库
+## 核心接口
+
+- **[网络接口](net.md)** — BSD 套接字接口（socket/bind/connect/send/recv）与 DNS 解析
+
+## 地址管理与配置
+
+- **[DHCP](net_dhcp.md)** — DHCP 客户端（IPv4）、DHCPv6 客户端与 DHCP 服务器
+- **[网络工具库 netlib](netlib.md)** — IPv4/IPv6 地址、路由、MAC、MTU、iptables、连通性检查等辅助接口
+
+## 无线网络
+
+- **[WAPI 无线接口](wapi.md)** — Wi-Fi 接口配置、扫描、关联、功率管理（基于 Linux Wireless Extensions）
+
+## 文件服务
+
+- **[FTP 服务器](net_ftp.md)** — 轻量 FTP 服务器接口

--- a/doxygen/api/network/net.md
+++ b/doxygen/api/network/net.md
@@ -1,81 +1,589 @@
-# 网络接口详情
+# 网络 API
 
-## 套接字接口（sys/socket.h）
+openvela 提供与 BSD 兼容的套接字接口，支持 IPv4（`AF_INET`）、IPv6（`AF_INET6`）等协议族，以及流套接字（`SOCK_STREAM`）、数据报套接字（`SOCK_DGRAM`）和原始套接字（`SOCK_RAW`）。
 
-openvela 支持与 BSD 兼容的套接字接口层，为应用程序开发人员提供熟悉的网络 API。这些套接字接口可以通过架构配置文件中的设置来启用。套接字层支持多种协议族，包括 IPv4（AF_INET）和 IPv6（AF_INET6），以及各种套接字类型，如流套接字（SOCK_STREAM）、数据报套接字（SOCK_DGRAM）和原始套接字。
+头文件：`#include <sys/socket.h>`、`#include <netinet/in.h>`、`#include <arpa/inet.h>`
 
-```eval_rst
+## openvela 实现说明
 
-.. doxygenfile:: socket.h
-    :project: doxygen
+- **协议族支持**：`AF_INET`（IPv4）、`AF_INET6`（IPv6）、`AF_LOCAL`/`AF_UNIX`（本地套接字）、`AF_PACKET`（原始链路层）等，具体取决于网络栈配置
+- **配置依赖**：网络子系统是可选的，需要启用 `CONFIG_NET` 及相关协议配置（如 `CONFIG_NET_TCP`、`CONFIG_NET_UDP`）
+- **非阻塞 I/O**：通过 `fcntl(fd, F_SETFL, O_NONBLOCK)` 或 `SOCK_NONBLOCK` 标志设置
+- **DNS 解析**：需要启用 `CONFIG_NETDB_DNSCLIENT`，通过 `nuttx/net/dns.h` 接口管理 DNS 服务器
 
+## 套接字创建与管理
+
+### socket
+
+```c
+int socket(int domain, int type, int protocol);
 ```
 
-## DNS 接口（net/dns.h）
+创建一个通信端点（套接字），返回文件描述符。
 
-openvela 提供了用于配置和管理 DNS 服务器的 DNS 解析器功能。这些功能定义在 nuttx/net/dns.h 中，允许应用程序添加、移除和查询 DNS 名称服务器。
+**参数**：
 
-```eval_rst
+- `domain` 协议族：
+  - `AF_INET` IPv4
+  - `AF_INET6` IPv6
+  - `AF_LOCAL` / `AF_UNIX` 本地套接字
+  - `AF_PACKET` 原始链路层
+- `type` 套接字类型：
+  - `SOCK_STREAM` 面向连接的流套接字（TCP）
+  - `SOCK_DGRAM` 无连接的数据报套接字（UDP）
+  - `SOCK_RAW` 原始套接字
+  - 可与 `SOCK_NONBLOCK`、`SOCK_CLOEXEC` 按位或组合
+- `protocol` 协议编号，通常为 0（自动选择）。也可指定 `IPPROTO_TCP`、`IPPROTO_UDP` 等。
 
-.. doxygenfile:: dns.h
-    :project: doxygen
+**返回值**：
 
+成功时返回非负文件描述符，失败时返回 -1 并设置 `errno`：
+
+- `EAFNOSUPPORT` 不支持的协议族。
+- `EPROTONOSUPPORT` 不支持的协议类型。
+- `EMFILE` 进程文件描述符数量已达上限。
+- `ENOMEM` 内存不足。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### socketpair
+
+```c
+int socketpair(int domain, int type, int protocol, int sv[2]);
 ```
 
-## 应用层接口（apps/include）
+创建一对已连接的套接字，常用于父子进程间通信。
 
-apps 目录下网络相关的接口介绍。
+**参数**：
 
-### netutils/dhcpc.h
+- `domain` 协议族，通常为 `AF_LOCAL`。
+- `type` 套接字类型（`SOCK_STREAM` 或 `SOCK_DGRAM`）。
+- `protocol` 通常为 0。
+- `sv` 输出参数，存储两个已连接的文件描述符。
 
-```eval_rst
+**返回值**：
 
-.. doxygenfile:: dhcpc.h
-    :project: doxygen
+成功时返回 0，失败时返回 -1 并设置 `errno`：
 
+- `EAFNOSUPPORT` 不支持的协议族。
+- `EMFILE` 文件描述符数量已达上限。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### shutdown
+
+```c
+int shutdown(int sockfd, int how);
 ```
 
-### netutils/dhcp6c.h
+关闭套接字的部分或全部通信方向。与 `close()` 不同，`shutdown()` 可以只关闭读或写方向。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: dhcp6c.h
-    :project: doxygen
+- `sockfd` 套接字文件描述符。
+- `how` 关闭方式：
+  - `SHUT_RD` 关闭读方向。
+  - `SHUT_WR` 关闭写方向（发送 FIN）。
+  - `SHUT_RDWR` 关闭读写双向。
 
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ENOTCONN` 套接字未连接。
+- `EINVAL` `how` 参数无效。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+## 连接管理
+
+### bind
+
+```c
+int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 ```
 
-### netutils/dhcpd.h
+将套接字绑定到指定的本地地址和端口。服务器端在 `listen()` 前必须调用 `bind()`。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: dhcpd.h
-    :project: doxygen
+- `sockfd` 套接字文件描述符。
+- `addr` 本地地址结构体（`struct sockaddr_in` 或 `struct sockaddr_in6`）。
+- `addrlen` 地址结构体的大小。
 
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `EINVAL` 套接字已绑定，或地址无效。
+- `EADDRINUSE` 地址已被使用。
+- `EADDRNOTAVAIL` 请求的地址不可用。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### connect
+
+```c
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 ```
 
-### netutils/ftpd.h
+发起到远程地址的连接。对于 TCP 套接字，执行三次握手；对于 UDP 套接字，设置默认目标地址。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: ftpd.h
-    :project: doxygen
+- `sockfd` 套接字文件描述符。
+- `addr` 远程地址结构体。
+- `addrlen` 地址结构体的大小。
 
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ECONNREFUSED` 远程主机拒绝连接。
+- `ETIMEDOUT` 连接超时。
+- `ENETUNREACH` 网络不可达。
+- `EINPROGRESS` 非阻塞模式下连接正在进行。
+- `EISCONN` 套接字已连接。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### listen
+
+```c
+int listen(int sockfd, int backlog);
 ```
 
-### netutils/netlib.h
+将套接字标记为被动监听状态，准备接受连接请求。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: netlib.h
-    :project: doxygen
+- `sockfd` 已绑定的套接字文件描述符。
+- `backlog` 等待连接队列的最大长度。
 
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `EOPNOTSUPP` 套接字类型不支持 `listen()`。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### accept
+
+```c
+int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 ```
 
-### wireless/wapi.h
+从监听套接字的等待队列中取出第一个连接请求，创建并返回一个新的已连接套接字。如果队列为空，阻塞等待。
 
-```eval_rst
+**参数**：
 
-.. doxygenfile:: wapi.h
-    :project: doxygen
+- `sockfd` 监听套接字文件描述符。
+- `addr` 如果非 `NULL`，存储客户端地址。
+- `addrlen` 输入时为 `addr` 缓冲区大小，输出时为实际地址大小。
 
+**返回值**：
+
+成功时返回新的已连接套接字描述符，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `EMFILE` 文件描述符数量已达上限。
+- `ECONNABORTED` 连接被中止。
+- `EINTR` 被信号中断。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### accept4
+
+```c
+int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
 ```
+
+与 `accept()` 相同，但可通过 `flags` 设置新套接字的属性。
+
+**参数**：
+
+- `sockfd` 监听套接字文件描述符。
+- `addr` 客户端地址（可为 `NULL`）。
+- `addrlen` 地址长度。
+- `flags` 标志位：
+  - `SOCK_NONBLOCK` 新套接字设为非阻塞。
+  - `SOCK_CLOEXEC` 新套接字设为 exec 时关闭。
+
+**返回值**：
+
+同 `accept()`。
+
+**POSIX 兼容性**：兼容 Linux 扩展接口（非 POSIX 标准）。
+
+## 数据发送
+
+### send
+
+```c
+ssize_t send(int sockfd, const void *buf, size_t len, int flags);
+```
+
+在已连接的套接字上发送数据。等价于 `sendto()` 不指定目标地址。
+
+**参数**：
+
+- `sockfd` 已连接的套接字文件描述符。
+- `buf` 要发送的数据缓冲区。
+- `len` 数据长度（字节）。
+- `flags` 发送标志：
+  - `MSG_DONTWAIT` 非阻塞发送。
+  - `MSG_NOSIGNAL` 对端关闭时不产生 `SIGPIPE`。
+  - `0` 默认行为。
+
+**返回值**：
+
+成功时返回发送的字节数，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ENOTCONN` 套接字未连接。
+- `EAGAIN` / `EWOULDBLOCK` 非阻塞模式下发送缓冲区满。
+- `EPIPE` 对端已关闭连接。
+- `EINTR` 被信号中断。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### sendto
+
+```c
+ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
+               const struct sockaddr *to, socklen_t tolen);
+```
+
+发送数据到指定地址。主要用于 UDP 套接字，也可用于已连接的 TCP 套接字（此时忽略目标地址）。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `buf` 数据缓冲区。
+- `len` 数据长度。
+- `flags` 发送标志（同 `send()`）。
+- `to` 目标地址。对于已连接套接字可为 `NULL`。
+- `tolen` 目标地址长度。
+
+**返回值**：
+
+成功时返回发送的字节数，失败时返回 -1 并设置 `errno`（同 `send()`，另加）：
+
+- `EDESTADDRREQ` 未连接的套接字且未指定目标地址。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### sendmsg
+
+```c
+ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags);
+```
+
+通过 `msghdr` 结构发送数据，支持分散/聚集 I/O 和辅助数据（如文件描述符传递）。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `msg` 消息头结构体，包含目标地址、I/O 向量、辅助数据等。
+- `flags` 发送标志。
+
+**返回值**：
+
+成功时返回发送的字节数，失败时返回 -1 并设置 `errno`。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+## 数据接收
+
+### recv
+
+```c
+ssize_t recv(int sockfd, void *buf, size_t len, int flags);
+```
+
+从已连接的套接字接收数据。
+
+**参数**：
+
+- `sockfd` 已连接的套接字文件描述符。
+- `buf` 接收缓冲区。
+- `len` 缓冲区大小（字节）。
+- `flags` 接收标志：
+  - `MSG_DONTWAIT` 非阻塞接收。
+  - `MSG_PEEK` 查看数据但不移除。
+  - `MSG_WAITALL` 等待接收完整的 `len` 字节。
+  - `0` 默认行为。
+
+**返回值**：
+
+成功时返回接收的字节数（0 表示对端关闭连接），失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ENOTCONN` 套接字未连接。
+- `EAGAIN` / `EWOULDBLOCK` 非阻塞模式下无数据可读。
+- `EINTR` 被信号中断。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### recvfrom
+
+```c
+ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+                 struct sockaddr *from, socklen_t *fromlen);
+```
+
+接收数据并获取发送方地址。主要用于 UDP 套接字。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `buf` 接收缓冲区。
+- `len` 缓冲区大小。
+- `flags` 接收标志（同 `recv()`）。
+- `from` 如果非 `NULL`，存储发送方地址。
+- `fromlen` 输入时为 `from` 缓冲区大小，输出时为实际地址大小。
+
+**返回值**：
+
+成功时返回接收的字节数，失败时返回 -1 并设置 `errno`（同 `recv()`）。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### recvmsg
+
+```c
+ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags);
+```
+
+通过 `msghdr` 结构接收数据，支持分散/聚集 I/O 和辅助数据。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `msg` 消息头结构体。
+- `flags` 接收标志。
+
+**返回值**：
+
+成功时返回接收的字节数，失败时返回 -1 并设置 `errno`。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+## 套接字选项
+
+### setsockopt
+
+```c
+int setsockopt(int sockfd, int level, int option, const void *value, socklen_t value_len);
+```
+
+设置套接字选项。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `level` 选项所在的协议层：
+  - `SOL_SOCKET` 套接字层选项。
+  - `IPPROTO_TCP` TCP 层选项。
+  - `IPPROTO_IP` IP 层选项。
+  - `IPPROTO_IPV6` IPv6 层选项。
+- `option` 选项名称（如 `SO_REUSEADDR`、`SO_KEEPALIVE`、`TCP_NODELAY` 等）。
+- `value` 选项值。
+- `value_len` 选项值的大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ENOPROTOOPT` 不支持的选项。
+- `EINVAL` 选项值无效。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### getsockopt
+
+```c
+int getsockopt(int sockfd, int level, int option, void *value, socklen_t *value_len);
+```
+
+获取套接字选项。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `level` 协议层（同 `setsockopt()`）。
+- `option` 选项名称。
+- `value` 存储选项值的缓冲区。
+- `value_len` 输入时为缓冲区大小，输出时为实际值大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`（同 `setsockopt()`）。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+## 地址查询
+
+### getsockname
+
+```c
+int getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+```
+
+获取套接字绑定的本地地址。
+
+**参数**：
+
+- `sockfd` 套接字文件描述符。
+- `addr` 存储本地地址的缓冲区。
+- `addrlen` 输入时为缓冲区大小，输出时为实际地址大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `EINVAL` `addrlen` 无效。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+### getpeername
+
+```c
+int getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+```
+
+获取已连接套接字的远程地址。
+
+**参数**：
+
+- `sockfd` 已连接的套接字文件描述符。
+- `addr` 存储远程地址的缓冲区。
+- `addrlen` 输入时为缓冲区大小，输出时为实际地址大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1 并设置 `errno`：
+
+- `EBADF` 无效的文件描述符。
+- `ENOTCONN` 套接字未连接。
+
+**POSIX 兼容性**：兼容 POSIX/BSD 同名接口。
+
+## DNS 接口
+
+头文件：`#include <nuttx/net/dns.h>`
+
+### dns_add_nameserver
+
+```c
+int dns_add_nameserver(const struct sockaddr *addr, socklen_t addrlen);
+```
+
+添加一个 DNS 名称服务器。
+
+**参数**：
+
+- `addr` DNS 服务器地址（`struct sockaddr_in` 或 `struct sockaddr_in6`）。
+- `addrlen` 地址结构体大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+### dns_default_nameserver
+
+```c
+int dns_default_nameserver(void);
+```
+
+重置 DNS 解析器，仅使用默认 DNS 服务器。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+### dns_foreach_nameserver
+
+```c
+int dns_foreach_nameserver(dns_callback_t callback, void *arg);
+```
+
+遍历所有已配置的 DNS 服务器，对每个服务器调用回调函数。
+
+**参数**：
+
+- `callback` 回调函数，对每个 DNS 服务器调用。
+- `arg` 传递给回调函数的用户参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+### dns_register_notify
+
+```c
+int dns_register_notify(dns_callback_t callback, void *arg);
+```
+
+注册 DNS 服务器变更通知。当 DNS 服务器列表发生变化时，调用回调函数。
+
+**参数**：
+
+- `callback` 变更通知回调函数。
+- `arg` 传递给回调函数的用户参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+### dns_unregister_notify
+
+```c
+int dns_unregister_notify(dns_callback_t callback, void *arg);
+```
+
+取消 DNS 服务器变更通知注册。
+
+**参数**：
+
+- `callback` 之前注册的回调函数。
+- `arg` 注册时提供的用户参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。
+
+### dns_set_queryfamily
+
+```c
+int dns_set_queryfamily(sa_family_t family);
+```
+
+设置 DNS 查询使用的地址族。
+
+**参数**：
+
+- `family` 地址族（`AF_INET`、`AF_INET6` 或 `AF_UNSPEC`）。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+**POSIX 兼容性**：openvela/NuttX 扩展接口。

--- a/doxygen/api/network/net_dhcp.md
+++ b/doxygen/api/network/net_dhcp.md
@@ -1,0 +1,235 @@
+# DHCP API
+
+DHCP（Dynamic Host Configuration Protocol）客户端与服务器接口，覆盖 IPv4（`dhcpc_*` / `dhcpd_*`）和 IPv6（`dhcp6c_*`）两套地址分配协议。
+
+头文件：`#include <netutils/dhcpc.h>`、`#include <netutils/dhcp6c.h>`、`#include <netutils/dhcpd.h>`
+
+## openvela 实现说明
+
+- **IPv4 客户端**：`dhcpc_*` 系列封装完整的 DHCP 客户端状态机（DISCOVER/OFFER/REQUEST/ACK）
+- **IPv6 客户端**：`dhcp6c_*` 系列处理 IPv6 的 SLAAC / DHCPv6 流程
+- **服务器**：`dhcpd_*` 系列提供简单的 DHCP 服务器能力，可在热点/AP 模式下分配 IP
+- **异步调用**：`*_request_async` 接口提供回调式调用，避免阻塞当前线程
+- **配置依赖**：需启用 `CONFIG_NETUTILS_DHCPC` / `CONFIG_NETUTILS_DHCP6C` / `CONFIG_NETUTILS_DHCPD`
+
+## DHCP 客户端
+
+头文件：`#include <netutils/dhcpc.h>`
+
+### dhcpc_open
+
+```c
+void *dhcpc_open(const char *interface, const void *mac_addr, int mac_len);
+```
+
+创建 DHCP 客户端会话。
+
+**参数**：
+
+- `interface` 网络接口名称（如 `"eth0"`）。
+- `mac_addr` MAC 地址。
+- `mac_len` MAC 地址长度。
+
+**返回值**：
+
+成功时返回会话句柄，失败时返回 `NULL`。
+
+### dhcpc_request
+
+```c
+int dhcpc_request(void *handle, struct dhcpc_state *presult);
+```
+
+执行 DHCP 协商获取 IP 地址（阻塞调用）。
+
+**参数**：
+
+- `handle` 由 `dhcpc_open()` 返回的会话句柄。
+- `presult` 存储获取的网络配置（IP、子网掩码、网关、DNS、租约时间）。
+
+**返回值**：
+
+成功时返回 0，失败时返回 -1。
+
+### dhcpc_request_async
+
+```c
+int dhcpc_request_async(void *handle, dhcpc_callback_t callback);
+```
+
+异步执行 DHCP 协商，在后台线程中运行，通过回调返回结果。
+
+**参数**：
+
+- `handle` 会话句柄。
+- `callback` 结果回调函数。
+
+**返回值**：
+
+成功启动时返回 0，失败时返回 -1。
+
+### dhcpc_cancel
+
+```c
+void dhcpc_cancel(void *handle);
+```
+
+取消正在进行的 DHCP 协商。
+
+### dhcpc_close
+
+```c
+void dhcpc_close(void *handle);
+```
+
+关闭 DHCP 客户端会话，释放所有资源。内部会先调用 `dhcpc_cancel()`。
+
+
+## DHCPv6 客户端
+
+头文件：`#include <netutils/dhcp6c.h>`
+
+### dhcp6c_open
+
+```c
+void *dhcp6c_open(const char *interface);
+```
+
+创建 DHCPv6 客户端会话。
+
+**参数**：
+
+- `interface` 网络接口名称。
+
+**返回值**：
+
+成功时返回会话句柄，失败时返回 `NULL`。
+
+### dhcp6c_request
+
+```c
+int dhcp6c_request(void *handle, struct dhcp6c_state *presult);
+```
+
+执行 DHCPv6 协商获取地址（阻塞调用）。
+
+### dhcp6c_request_async
+
+```c
+int dhcp6c_request_async(void *handle, dhcp6c_callback_t callback);
+```
+
+异步执行 DHCPv6 协商。
+
+### dhcp6c_cancel
+
+```c
+void dhcp6c_cancel(void *handle);
+```
+
+取消正在进行的 DHCPv6 协商。
+
+### dhcp6c_close
+
+```c
+void dhcp6c_close(void *handle);
+```
+
+关闭 DHCPv6 客户端会话。
+
+
+## DHCP 服务器
+
+头文件：`#include <netutils/dhcpd.h>`
+
+### dhcpd_run
+
+```c
+int dhcpd_run(const char *interface);
+```
+
+在当前线程运行 DHCP 服务器（阻塞，直到出错才返回）。
+
+### dhcpd_start
+
+```c
+int dhcpd_start(const char *interface);
+```
+
+以后台任务启动 DHCP 服务器守护进程。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### dhcpd_stop
+
+```c
+int dhcpd_stop(void);
+```
+
+停止运行中的 DHCP 服务器守护进程。
+
+### dhcpd_set_startip
+
+```c
+int dhcpd_set_startip(in_addr_t startip);
+```
+
+配置 DHCP 服务器分配地址池的起始 IP 地址。
+
+**参数**：
+
+- `startip` 起始 IP 地址（网络字节序）。
+
+**返回值**：
+
+始终返回 `0`。
+
+### dhcpd_set_routerip
+
+```c
+int dhcpd_set_routerip(in_addr_t routerip);
+```
+
+配置 DHCP 服务器下发给客户端的默认网关地址。
+
+**参数**：
+
+- `routerip` 默认网关 IP（网络字节序）。
+
+**返回值**：
+
+始终返回 `0`。
+
+### dhcpd_set_netmask
+
+```c
+int dhcpd_set_netmask(in_addr_t netmask);
+```
+
+配置 DHCP 服务器下发给客户端的子网掩码。
+
+**参数**：
+
+- `netmask` 子网掩码（网络字节序）。
+
+**返回值**：
+
+始终返回 `0`。
+
+### dhcpd_set_dnsip
+
+```c
+int dhcpd_set_dnsip(in_addr_t dnsip);
+```
+
+配置 DHCP 服务器下发给客户端的 DNS 服务器地址。
+
+**参数**：
+
+- `dnsip` DNS 服务器 IP（网络字节序）。
+
+**返回值**：
+
+始终返回 `0`。

--- a/doxygen/api/network/net_ftp.md
+++ b/doxygen/api/network/net_ftp.md
@@ -1,0 +1,71 @@
+# FTP 服务器 API
+
+简单的 FTP 服务器接口，提供用户管理和会话处理能力。
+
+头文件：`#include <netutils/ftpd.h>`
+
+## openvela 实现说明
+
+- **适用场景**：IoT 设备调试、固件上传、文件下载等轻量 FTP 应用
+- **配置依赖**：需启用 `CONFIG_NETUTILS_FTPD`
+- **用户管理**：通过 `ftpd_adduser` 添加用户与权限
+- **会话模型**：`ftpd_session` 为一个客户端连接提供会话处理，通常在独立线程中调用
+
+## FTP 服务器
+
+头文件：`#include <netutils/ftpd.h>`
+
+### ftpd_open
+
+```c
+FTPD_SESSION ftpd_open(int port, sa_family_t family);
+```
+
+创建 FTP 服务器会话。
+
+**参数**：
+
+- `port` 监听端口（通常为 21）。
+- `family` 地址族（`AF_INET` 或 `AF_INET6`）。
+
+**返回值**：
+
+成功时返回会话句柄。
+
+### ftpd_adduser
+
+```c
+int ftpd_adduser(FTPD_SESSION handle, uint8_t accountflags,
+                 const char *user, const char *passwd, const char *home);
+```
+
+添加 FTP 用户。
+
+**参数**：
+
+- `handle` 由 `ftpd_open()` 返回的句柄。
+- `accountflags` 用户属性标志（参见 `FTPD_ACCOUNTFLAGS_*`）。
+- `user` 用户名（`NULL` 表示无需登录）。
+- `passwd` 密码（`NULL` 表示无需密码）。
+- `home` 用户主目录。
+
+### ftpd_session
+
+```c
+int ftpd_session(FTPD_SESSION handle, int timeout);
+```
+
+运行 FTP 服务器会话，等待并处理一个客户端连接。
+
+**参数**：
+
+- `handle` 会话句柄。
+- `timeout` 等待连接的超时时间（毫秒），0 表示无限等待。
+
+### ftpd_close
+
+```c
+void ftpd_close(FTPD_SESSION handle);
+```
+
+关闭 FTP 服务器会话。

--- a/doxygen/api/network/netlib.md
+++ b/doxygen/api/network/netlib.md
@@ -1,0 +1,974 @@
+# 网络工具库（netlib）API
+
+openvela 网络工具库（`netlib_*`）提供了一系列简化 BSD 套接字操作的辅助函数，涵盖 IPv4/IPv6 地址管理、路由、ARP、MAC 地址、MTU、防火墙（iptables/ip6tables）、网络连通性检查等。
+
+头文件：`#include <netutils/netlib.h>`
+
+## openvela 实现说明
+
+- **定位**：在 BSD socket API 基础上的便利封装，隐藏 `ioctl` + `SIOCGIF*` 等底层细节
+- **覆盖范围**：
+    - IPv4/IPv6 地址、网关、子网掩码、DNS、路由
+    - MAC 地址读写、接口上/下、MTU 设置
+    - VLAN 管理、ARP 表操作
+    - iptables/ip6tables 操作
+    - 网络连通性检查（`ping` / HTTP / 接口可达性）
+    - URL 解析工具
+- **配置依赖**：需启用 `CONFIG_NETUTILS_NETLIB`，部分子接口另需对应模块配置（如 `CONFIG_NET_ARP`、`CONFIG_NET_IPv6` 等）
+- **错误处理**：多数接口成功时返回 `0` 或 `OK`，失败时返回 `ERROR`（`-1`）并设置 `errno`
+
+## 网络工具库
+
+头文件：`#include <netutils/netlib.h>`
+
+netlib 提供网络配置工具函数，包括接口地址设置、路由管理、ARP 操作等。
+
+**IPv4 地址管理**
+
+### netlib_get_ipv4addr
+
+```c
+int netlib_get_ipv4addr(const char *ifname, struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 用于存储 IP 地址
+
+### netlib_set_ipv4addr
+
+```c
+int netlib_set_ipv4addr(const char *ifname, const struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_set_dripv4addr
+
+```c
+int netlib_set_dripv4addr(const char *ifname, const struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_get_dripv4addr
+
+```c
+int netlib_get_dripv4addr(const char *ifname, struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 用于存储默认路由地址
+
+### netlib_set_ipv4netmask
+
+```c
+int netlib_set_ipv4netmask(const char *ifname, const struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_get_ipv4netmask
+
+```c
+int netlib_get_ipv4netmask(const char *ifname, struct in_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 用于存储子网掩码
+
+### netlib_ipv4adaptor
+
+```c
+int netlib_ipv4adaptor(in_addr_t destipaddr, in_addr_t *srcipaddr);
+```
+
+**参数**：
+
+- `destipaddr` 目标 IPv4 地址
+- `srcipaddr` 用于存储适配器地址
+
+### netlib_read_ipv4route
+
+```c
+ssize_t netlib_read_ipv4route(FILE *stream, struct netlib_ipv4_route_s *route);
+```
+
+**参数**：
+
+- `fd` procfs IPv4 路由表的文件描述符
+- `route` 用于存储下一条路由表项
+
+### netlib_ipv4router
+
+```c
+int netlib_ipv4router(const struct in_addr *destipaddr, struct in_addr *router);
+```
+
+**参数**：
+
+- `destipaddr` 目标 IP 地址。
+- `router` - 用于存储网关的 IP 地址，即
+
+### netlib_obtain_ipv4addr
+
+```c
+int netlib_obtain_ipv4addr(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+### netlib_set_ipv4dnsaddr
+
+```c
+int netlib_set_ipv4dnsaddr(const struct in_addr *inaddr);
+```
+
+**参数**：
+
+- `inaddr` 要设置的地址
+
+**IPv6 地址管理**
+
+### netlib_add_ipv6addr
+
+```c
+int netlib_add_ipv6addr(const char *ifname, const struct in6_addr *addr, uint8_t preflen);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 地址 to add
+- `preflen` 前缀长度（位）。
+
+### netlib_del_ipv6addr
+
+```c
+int netlib_del_ipv6addr(const char *ifname, const struct in6_addr *addr, uint8_t preflen);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 地址 to delete
+- `preflen` 前缀长度（位）。
+
+### netlib_get_ipv6addr
+
+```c
+int netlib_get_ipv6addr(const char *ifname, struct in6_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 用于存储 IP 地址
+
+### netlib_set_ipv6addr
+
+```c
+int netlib_set_ipv6addr(const char *ifname, const struct in6_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_set_dripv6addr
+
+```c
+int netlib_set_dripv6addr(const char *ifname, const struct in6_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_set_ipv6netmask
+
+```c
+int netlib_set_ipv6netmask(const char *ifname, const struct in6_addr *addr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `ipaddr` 要设置的地址
+
+### netlib_ipv6adaptor
+
+```c
+int netlib_ipv6adaptor(const struct in6_addr *destipaddr, struct in6_addr *srcipaddr);
+```
+
+**参数**：
+
+- `destipaddr` 目标 IP 地址。
+- `srcipaddr` - 用于存储适配器地址
+
+### netlib_ipv6netmask2prefix
+
+```c
+uint8_t netlib_ipv6netmask2prefix(const uint16_t *mask);
+```
+
+**参数**：
+
+- `mask` 子网掩码。
+
+### netlib_prefix2ipv6netmask
+
+```c
+void netlib_prefix2ipv6netmask(uint8_t preflen, struct in6_addr *netmask);
+```
+
+**参数**：
+
+- `preflen` 前缀长度（位）。
+- `netmask` 用于存储子网掩码.
+
+### netlib_read_ipv6route
+
+```c
+ssize_t netlib_read_ipv6route(FILE *stream, struct netlib_ipv6_route_s *route);
+```
+
+**参数**：
+
+- `fd` 路由表项。
+- `route` 用于存储下一条路由表项
+
+### netlib_ipv6router
+
+```c
+int netlib_ipv6router(const struct in6_addr *destipaddr, struct in6_addr *router);
+```
+
+**参数**：
+
+- `destipaddr` 目标 IP 地址。
+- `router` - 用于存储网关的 IP 地址，即
+
+### netlib_obtain_ipv6addr
+
+```c
+int netlib_obtain_ipv6addr(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称。
+
+### netlib_set_ipv6dnsaddr
+
+```c
+int netlib_set_ipv6dnsaddr(const struct in6_addr *inaddr);
+```
+
+**参数**：
+
+- `inaddr` 要设置的地址
+
+**接口管理**
+
+### netlib_setmacaddr
+
+```c
+int netlib_setmacaddr(const char *ifname, const uint8_t *macaddr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `macaddr` MAC 地址。
+
+### netlib_getmacaddr
+
+```c
+int netlib_getmacaddr(const char *ifname, uint8_t *macaddr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `macaddr` 用于存储 MAC 地址
+
+### netlib_getessid
+
+```c
+int netlib_getessid(const char *ifname, char *essid, size_t idlen);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `essid` 用于存储结果。
+- `idlen` ESSID 缓冲区大小。
+
+### netlib_setessid
+
+```c
+int netlib_setessid(const char *ifname, const char *essid);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `essid` ESSID（网络名称）。
+
+### netlib_getifstatus
+
+```c
+int netlib_getifstatus(const char *ifname, uint8_t *flags);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `flags` 接口标志。
+
+### netlib_ifup
+
+```c
+int netlib_ifup(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+### netlib_ifdown
+
+```c
+int netlib_ifdown(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+### netlib_set_mtu
+
+```c
+int netlib_set_mtu(const char *ifname, int mtu);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `mtu` 最大传输单元（MTU）。
+
+**返回值**：
+
+:
+
+### netlib_getifstatistics
+
+```c
+int netlib_getifstatistics(const char *ifname, struct netdev_statistics_s *stat);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称。
+- `stat` 用于存储设备统计信息。
+
+### netlib_check_ifconflict
+
+```c
+int netlib_check_ifconflict(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+**路由管理**
+
+### netlib_get_route
+
+```c
+ssize_t netlib_get_route(struct rtentry *rtelist, unsigned int nentries, sa_family_t family);
+```
+
+**参数**：
+
+- `rtelist` 用于存储设备列表。
+- `nentries` 数组容量（条目数）。
+- `family` - 地址族。  See AF_* definitions in
+
+**ARP 管理**
+
+### netlib_del_arpmapping
+
+```c
+int netlib_del_arpmapping(const struct sockaddr_in *inaddr, const char *ifname);
+```
+
+**参数**：
+
+- `inaddr` IPv4 地址。
+- `ifname` 网络接口名称。
+
+### netlib_get_arpmapping
+
+```c
+int netlib_get_arpmapping(const struct sockaddr_in *inaddr, uint8_t *macaddr, const char *ifname);
+```
+
+**参数**：
+
+- `inaddr` IPv4 地址。
+- `macaddr` 用于存储对应的以太网 MAC 地址
+- `ifname` 网络接口名称。
+
+### netlib_set_arpmapping
+
+```c
+int netlib_set_arpmapping(const struct sockaddr_in *inaddr, const uint8_t *macaddr, const char *ifname);
+```
+
+**参数**：
+
+- `inaddr` IPv4 地址。
+- `macaddr` MAC 地址。
+- `ifname` 网络接口名称。
+
+### netlib_get_arptable
+
+```c
+ssize_t netlib_get_arptable(struct arpreq *arptab, unsigned int nentries);
+```
+
+**参数**：
+
+- `arptab` 用于存储 ARP 表副本
+- `nentries` 数组容量（条目数）。
+
+### netlib_ifarp
+
+```c
+int netlib_ifarp(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+### netlib_ifnoarp
+
+```c
+int netlib_ifnoarp(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+**DNS 管理**
+
+### netlib_clear_dnsaddr
+
+```c
+void netlib_clear_dnsaddr(void);
+```
+
+**VLAN 管理**
+
+### netlib_add_vlan
+
+```c
+int netlib_add_vlan(const char *ifname, int vlanid, int prio);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称。
+- `vlanid` VLAN 标识符。
+- `prio` 默认 VLAN 优先级（PCP）。
+
+### netlib_del_vlan
+
+```c
+int netlib_del_vlan(const char *vlanif);
+```
+
+**iptables**
+
+### netlib_ipt_commit
+
+```c
+int netlib_ipt_commit(const struct ipt_replace *repl);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+
+### netlib_ipt_flush
+
+```c
+int netlib_ipt_flush(const char *table, enum nf_inet_hooks hook);
+```
+
+**参数**：
+
+- `table` 表名。
+- `hook` 钩子点。
+
+### netlib_ipt_policy
+
+```c
+int netlib_ipt_policy(const char *table, enum nf_inet_hooks hook, int verdict);
+```
+
+**参数**：
+
+- `table` 策略。
+- `hook` 钩子点。
+- `verdict` 判定值。
+
+### netlib_ipt_append
+
+```c
+int netlib_ipt_append(struct ipt_replace **repl, const struct ipt_entry *entry, enum nf_inet_hooks hook);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要追加的规则条目。
+- `hook` 钩子点。
+
+### netlib_ipt_insert
+
+```c
+int netlib_ipt_insert(struct ipt_replace **repl, const struct ipt_entry *entry, enum nf_inet_hooks hook, int rulenum);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要插入的规则条目。
+- `hook` 钩子点。
+- `rulenum` 规则编号。
+
+### netlib_ipt_delete
+
+```c
+int netlib_ipt_delete(struct ipt_replace *repl, const struct ipt_entry *entry, enum nf_inet_hooks hook, int rulenum);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要删除的规则条目。
+- `hook` 钩子点。
+- `rulenum` 规则编号。
+
+### netlib_ipt_fillifname
+
+```c
+int netlib_ipt_fillifname(struct ipt_entry *entry, const char *inifname, const char *outifname);
+```
+
+**参数**：
+
+- `entry` 要填充的规则条目。
+- `inifname` 输入设备名称，`NULL` 表示不变。
+- `outifname` 输出设备名称，`NULL` 表示不变。
+
+### netlib_ip6t_commit
+
+```c
+int netlib_ip6t_commit(const struct ip6t_replace *repl);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+
+### netlib_ip6t_flush
+
+```c
+int netlib_ip6t_flush(const char *table, enum nf_inet_hooks hook);
+```
+
+**参数**：
+
+- `table` 表名。
+- `hook` 钩子点。
+
+### netlib_ip6t_policy
+
+```c
+int netlib_ip6t_policy(const char *table, enum nf_inet_hooks hook, int verdict);
+```
+
+**参数**：
+
+- `table` 策略。
+- `hook` 钩子点。
+- `verdict` 判定值。
+
+### netlib_ip6t_append
+
+```c
+int netlib_ip6t_append(struct ip6t_replace **repl, const struct ip6t_entry *entry, enum nf_inet_hooks hook);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要追加的规则条目。
+- `hook` 钩子点。
+
+### netlib_ip6t_insert
+
+```c
+int netlib_ip6t_insert(struct ip6t_replace **repl, const struct ip6t_entry *entry, enum nf_inet_hooks hook, int rulenum);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要插入的规则条目。
+- `hook` 钩子点。
+- `rulenum` 规则编号。
+
+### netlib_ip6t_delete
+
+```c
+int netlib_ip6t_delete(struct ip6t_replace *repl, const struct ip6t_entry *entry, enum nf_inet_hooks hook, int rulenum);
+```
+
+**参数**：
+
+- `repl` 要提交的配置。
+- `entry` 要删除的规则条目。
+- `hook` 钩子点。
+- `rulenum` 规则编号。
+
+### netlib_ip6t_fillifname
+
+```c
+int netlib_ip6t_fillifname(struct ip6t_entry *entry, const char *inifname, const char *outifname);
+```
+
+**参数**：
+
+- `entry` 要填充的规则条目。
+- `inifname` 输入设备名称，`NULL` 表示不变。
+- `outifname` 输出设备名称，`NULL` 表示不变。
+
+**连接检测**
+
+### netlib_check_ipconnectivity
+
+```c
+int netlib_check_ipconnectivity(const char *ip, int timeout, int retry);
+```
+
+**参数**：
+
+- `ip` 要检查的 IPv4 地址。
+- `timeout` 超时时间。
+- `retry` 重试次数。
+
+### netlib_check_ifconnectivity
+
+```c
+int netlib_check_ifconnectivity(const char *ifname, int timeout, int retry);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `timeout` 超时时间。
+- `retry` 重试次数。
+
+**URL 解析**
+
+### netlib_parsehttpurl
+
+```c
+int netlib_parsehttpurl(const char *url, uint16_t *port, char *hostname, int hostlen, char *filename, int namelen);
+```
+
+**参数**：
+
+- `url` HTTP 相关参数。
+- `port` 指向 `uint16_t`，用于存储解析出的端口号。
+- `hostname` 用于存储结果的缓冲区。
+- `hostlen` 缓冲区大小。
+- `filename` 用于存储结果的缓冲区。
+- `namelen` 缓冲区大小。
+
+### netlib_parseurl
+
+```c
+int netlib_parseurl(const char *str, struct url_s *url);
+```
+
+### netlib_check_httpconnectivity
+
+```c
+int netlib_check_httpconnectivity(const char *host, const char *getmsg, int port, int expect_code);
+```
+
+**参数**：
+
+- `host` 远程主机地址。
+- `getmsg` HTTP 相关参数。
+- `port` 端口号。
+- `expect_code` HTTP 相关参数。
+
+**其他**
+
+### netlib_get_devices
+
+```c
+ssize_t netlib_get_devices(struct netlib_device_s *devlist, unsigned int nentries, sa_family_t family);
+```
+
+**参数**：
+
+- `devlist` 用于存储设备列表。
+- `nentries` 数组容量（条目数）。
+- `family` 地址族。  See AF_* definitions in
+
+### netlib_seteaddr
+
+```c
+int netlib_seteaddr(const char *ifname, const uint8_t *eaddr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `eaddr` 新地址。
+
+### netlib_getpanid
+
+```c
+int netlib_getpanid(const char *ifname, uint8_t *panid);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `panid` 用于存储当前 PAN ID
+
+### netlib_getproperties
+
+```c
+int netlib_getproperties(const char *ifname, struct pktradio_properties_s *properties);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `nodeadd` 用于存储节点地址。
+
+### netlib_setnodeaddr
+
+```c
+int netlib_setnodeaddr(const char *ifname, const struct pktradio_addr_s *nodeaddr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `nodeadd` 新地址。
+
+### netlib_getnodnodeaddr
+
+```c
+int netlib_getnodnodeaddr(const char *ifname, struct pktradio_addr_s *nodeaddr);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+- `nodeadd` 用于存储节点地址。
+
+### netlib_get_nbtable
+
+```c
+ssize_t netlib_get_nbtable(struct neighbor_entry_s *nbtab, unsigned int nentries);
+```
+
+**参数**：
+
+- `nbtab` 用于存储邻居表副本
+- `nentries` 数组容量（条目数）。
+
+### netlib_icmpv6_autoconfiguration
+
+```c
+int netlib_icmpv6_autoconfiguration(const char *ifname);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称
+
+### netlib_parse_conntrack
+
+```c
+int netlib_parse_conntrack(const struct nlmsghdr *nlh, size_t len, struct netlib_conntrack_s *ct);
+```
+
+**参数**：
+
+- `nlh` 要解析的 netlink 消息。
+- `ct` 连接跟踪条目。
+
+### netlib_get_conntrack
+
+```c
+int netlib_get_conntrack(sa_family_t family, netlib_conntrack_cb_t cb);
+```
+
+**参数**：
+
+- `family` 地址族，用于过滤 conntrack 表项。
+- `cb` 连接跟踪条目。
+
+### netlib_listenon
+
+```c
+int netlib_listenon(uint16_t portno);
+```
+
+**参数**：
+
+- `portno` 端口号。
+
+### netlib_server
+
+```c
+void netlib_server(uint16_t portno, pthread_startroutine_t handler, int stacksize);
+```
+
+**参数**：
+
+- `portno` 端口号。
+- `handler` 任务入口函数。
+- `stacksize` 栈大小。
+
+### netlib_get_iobinfo
+
+```c
+int netlib_get_iobinfo(struct iob_stats_s *iob);
+```
+
+**参数**：
+
+- `iob` IOB 信息结构体。
+
+
+### netlib_ipv4addrconv
+
+```c
+bool netlib_ipv4addrconv(const char *addrstr, uint8_t *addr);
+```
+
+将 IPv4 地址字符串（如 `"192.168.1.1"`）转换为 4 字节二进制数组。
+
+**参数**：
+
+- `addrstr` IPv4 地址字符串。
+- `addr` 输出缓冲区（4 字节）。
+
+**返回值**：
+
+转换成功返回 `true`，格式非法时返回 `false`。
+
+### netlib_ethaddrconv
+
+```c
+bool netlib_ethaddrconv(const char *hwstr, uint8_t *hw);
+```
+
+将以太网 MAC 地址字符串（如 `"aa:bb:cc:dd:ee:ff"`）转换为 6 字节二进制数组。
+
+**参数**：
+
+- `hwstr` MAC 地址字符串。
+- `hw` 输出缓冲区（6 字节）。
+
+**返回值**：
+
+转换成功返回 `true`，格式非法时返回 `false`。
+
+### netlib_saddrconv
+
+```c
+bool netlib_saddrconv(const char *hwstr, uint8_t *hw);
+```
+
+将 IEEE 802.15.4 短地址（2 字节）字符串转换为二进制形式。
+
+**参数**：
+
+- `hwstr` 地址字符串。
+- `hw` 输出缓冲区（2 字节）。
+
+**返回值**：
+
+转换成功返回 `true`，格式非法时返回 `false`。
+
+### netlib_eaddrconv
+
+```c
+bool netlib_eaddrconv(const char *hwstr, uint8_t *hw);
+```
+
+将 IEEE 802.15.4 扩展地址（8 字节）字符串转换为二进制形式。
+
+**参数**：
+
+- `hwstr` 地址字符串。
+- `hw` 输出缓冲区（8 字节）。
+
+**返回值**：
+
+转换成功返回 `true`，格式非法时返回 `false`。
+
+### netlib_nodeaddrconv
+
+```c
+bool netlib_nodeaddrconv(const char *addrstr,
+                         struct pktradio_addr_s *nodeaddr);
+```
+
+将 pktradio 节点地址字符串转换为 `pktradio_addr_s` 结构体。
+
+**参数**：
+
+- `addrstr` 节点地址字符串。
+- `nodeaddr` 输出结构体指针。
+
+**返回值**：
+
+转换成功返回 `true`，格式非法时返回 `false`。

--- a/doxygen/api/network/wapi.md
+++ b/doxygen/api/network/wapi.md
@@ -1,0 +1,767 @@
+# 无线网络接口（WAPI）API
+
+`wapi_*` 系列接口基于 Linux Wireless Extensions（WEXT）封装，提供无线网络配置、扫描、关联、功率管理、区域代码和 PMKSA 缓存等能力。
+
+头文件：`#include <wireless/wapi.h>`
+
+## openvela 实现说明
+
+- **底层机制**：基于 Linux Wireless Extensions（WEXT）的 ioctl 协议与 Wi-Fi 驱动通信
+- **支持场景**：Station（客户端）模式、AP 模式、混杂模式（由驱动支持程度决定）
+- **配置依赖**：需启用 `CONFIG_WIRELESS_WAPI` 及对应的 Wi-Fi 芯片驱动
+- **典型用法**：
+    - `wapi_set_ifup`/`wapi_set_ifdown` 控制接口启停
+    - `wapi_set_essid` + `wapi_set_mode` 配置连接目标
+    - `wapi_scan_*` / `wapi_escan_*` 扫描周围 AP
+    - `wapi_load_config` / `wapi_save_config` 持久化配置
+- **扩展能力**：通过 `wapi_extend_params` / `wapi_set_pmksa` 等接口与驱动私有特性交互
+
+## 无线网络接口
+
+头文件：`#include <wireless/wapi.h>`
+
+wapi 提供无线网络配置接口，包括 SSID 扫描、连接、频率设置等。
+
+**连接管理**
+
+### wapi_get_ifup
+
+```c
+int wapi_get_ifup(int sock, const char *ifname, int *is_up);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称.
+- `is_up` 接口状态，0 表示启用，1 表示禁用。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_ifup
+
+```c
+int wapi_set_ifup(int sock, const char *ifname);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称.
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_ifdown
+
+```c
+int wapi_set_ifdown(int sock, const char *ifname);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称，将被关闭。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_ip
+
+```c
+int wapi_get_ip(int sock, const char *ifname, struct in_addr *addr);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称.
+- `addr` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_ip
+
+```c
+int wapi_set_ip(int sock, const char *ifname, const struct in_addr *addr);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称，其 IP 地址
+- `addr` 指向包含新 IP 地址的结构体。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_netmask
+
+```c
+int wapi_get_netmask(int sock, const char *ifname, struct in_addr *addr);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称.
+- `addr` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_netmask
+
+```c
+int wapi_set_netmask(int sock, const char *ifname, const struct in_addr *addr);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称.
+- `addr` 指向包含新子网掩码的结构体。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_add_route_gw
+
+```c
+int wapi_add_route_gw(int sock, enum wapi_route_target_e targettype, const struct in_addr *target, const struct in_addr *netmask, const struct in_addr *gw);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `targettype` 目标类型。
+- `target` 指向目标 IP 地址。
+- `netmask` 指向目标地址对应的子网掩码。
+- `gw` 指向对应的网关（路由器）IP 地址，用于
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_del_route_gw
+
+```c
+int wapi_del_route_gw(int sock, enum wapi_route_target_e targettype, const struct in_addr *target, const struct in_addr *netmask, const struct in_addr *gw);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `targettype` 目标类型。
+- `target` 指向路由的目标 IP 地址
+- `netmask` 指向目标地址对应的子网掩码。
+- `gw` 指向对应的网关（路由器）IP 地址，用于
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_freq
+
+```c
+int wapi_get_freq(int sock, const char *ifname, double *freq, enum wapi_freq_flag_e *flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `freq` 输出参数。
+- `flag` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_freq
+
+```c
+int wapi_set_freq(int sock, const char *ifname, double freq, enum wapi_freq_flag_e flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `freq` 频率值。
+- `flag` 频率值。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_freq2chan
+
+```c
+int wapi_freq2chan(int sock, const char *ifname, double freq, int *chan);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `freq` 频率, in Hz, to be converted to a 信道编号.
+- `chan` 输出参数。
+
+### wapi_chan2freq
+
+```c
+int wapi_chan2freq(int sock, const char *ifname, int chan, double *freq);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 信道。
+- `chan` 信道 number to be converted to a frequency.
+- `freq` 输出参数。
+
+### wapi_get_essid
+
+```c
+int wapi_get_essid(int sock, const char *ifname, char *essid, enum wapi_essid_flag_e *flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `essid` 用于存储结果。
+- `flag` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_essid
+
+```c
+int wapi_set_essid(int sock, const char *ifname, const char *essid, enum wapi_essid_flag_e flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `essid` 指向一个以 `\0` 结尾的 ESSID 字符串
+- `flag` 控制标志。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_mode
+
+```c
+int wapi_get_mode(int sock, const char *ifname, enum wapi_mode_e *mode);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `mode` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_mode
+
+```c
+int wapi_set_mode(int sock, const char *ifname, enum wapi_mode_e mode);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `mode` 输出参数。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_make_broad_ether
+
+```c
+int wapi_make_broad_ether(struct ether_addr *sa);
+```
+
+**参数**：
+
+- `sa` 输出参数。
+
+**返回值**：
+
+Returns the result of the underlying wapi_make_ether() call,
+
+### wapi_make_null_ether
+
+```c
+int wapi_make_null_ether(struct ether_addr *sa);
+```
+
+**参数**：
+
+- `sa` 输出参数。
+
+**返回值**：
+
+Returns the result of the underlying wapi_make_ether() call,
+
+### wapi_get_ap
+
+```c
+int wapi_get_ap(int sock, const char *ifname, struct ether_addr *ap);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `ap` 要设置的地址。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_ap
+
+```c
+int wapi_set_ap(int sock, const char *ifname, const struct ether_addr *ap);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `ap` 接入点的 MAC 地址。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_bitrate
+
+```c
+int wapi_get_bitrate(int sock, const char *ifname, int *bitrate, enum wapi_bitrate_flag_e *flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `bitrate` 输出参数，用于存储查询到的比特率。
+- `flag` 输出参数，用于存储比特率标志位。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_bitrate
+
+```c
+int wapi_set_bitrate(int sock, const char *ifname, int bitrate, enum wapi_bitrate_flag_e flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符（用于 ioctl 操作）。
+- `ifname` 网络接口名称。
+- `bitrate` 比特率 .
+- `flag` 比特率 flag.
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_dbm2mwatt
+
+```c
+int wapi_dbm2mwatt(int dbm);
+```
+
+**参数**：
+
+- `dbm` 要转换的 dBm 值。
+
+**返回值**：
+
+转换后的毫瓦值。
+
+### wapi_mwatt2dbm
+
+```c
+int wapi_mwatt2dbm(int mwatt);
+```
+
+**参数**：
+
+- `mwatt` 毫瓦值。
+
+**返回值**：
+
+转换后的 dBm 值。
+
+### wapi_get_txpower
+
+```c
+int wapi_get_txpower(int sock, const char *ifname, int *power, enum wapi_txpower_flag_e *flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `power` 输出参数，用于存储发射功率值。
+- `flag` 输出参数，用于存储发射功率的单位。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_txpower
+
+```c
+int wapi_set_txpower(int sock, const char *ifname, int power, enum wapi_txpower_flag_e flag);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `power` 发射功率。
+- `flag` 发射功率。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_make_socket
+
+```c
+int wapi_make_socket(void);
+```
+
+### wapi_scan_init
+
+```c
+int wapi_scan_init(int sock, const char *ifname, const char *essid);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `essid` 要扫描的 ESSID。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_scan_channel_init
+
+```c
+int wapi_scan_channel_init(int sock, const char *ifname, const char *essid, uint8_t *channels, int num_channels);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `essid` 要扫描的 ESSID。
+- `channels` 指向 an array of 信道编号s to scan.
+- `num_channels` 信道。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_escan_init
+
+```c
+int wapi_escan_init(int sock, const char *ifname, uint8_t scan_type, const char *essid);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `scan_type` 扫描类型。
+- `essid` 要扫描的 ESSID。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_escan_channel_init
+
+```c
+int wapi_escan_channel_init(int sock, const char *ifname, uint8_t scan_type, const char *essid, uint8_t *channels, int num_channels);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `scan_type` 扫描类型。
+- `essid` 要扫描的 ESSID。
+- `channels` 指向 an array of 信道编号s to scan.
+- `num_channels` 信道。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_scan_stat
+
+```c
+int wapi_scan_stat(int sock, const char *ifname);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+
+### wapi_scan_coll
+
+```c
+int wapi_scan_coll(int sock, const char *ifname, struct wapi_list_s *aps);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `aps` 收集的扫描结果列表。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_scan_coll_free
+
+```c
+void wapi_scan_coll_free(struct wapi_list_s *aps);
+```
+
+**参数**：
+
+- `aps` 要释放的扫描结果列表。
+
+### wapi_set_country
+
+```c
+int wapi_set_country(int sock, const char *ifname, const char *country);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `country` 指向双字符字符串，表示要设置的
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_country
+
+```c
+int wapi_get_country(int sock, const char *ifname, char *country);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `country` 指向调用方提供的缓冲区，用于接收
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_sensitivity
+
+```c
+int wapi_get_sensitivity(int sock, const char *ifname, int *sense);
+```
+
+**参数**：
+
+- `sock` 套接字描述符.
+- `ifname` 网络接口名称。
+- `sense` 指向调用方提供的整型变量，用于接收
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_load_config
+
+```c
+void *wapi_load_config(const char *ifname, const char *confname, struct wpa_wconfig_s *conf);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称。
+- `confname` 路径。
+- `conf` 指向调用方提供的结构体，用于填入
+
+### wapi_unload_config
+
+```c
+void wapi_unload_config(void *load);
+```
+
+**参数**：
+
+- `load` 配置资源句柄。
+
+### wapi_save_config
+
+```c
+int wapi_save_config(const char *ifname, const char *confname, const struct wpa_wconfig_s *conf);
+```
+
+**参数**：
+
+- `ifname` 网络接口名称。
+- `confname` 路径。
+- `conf` 指向包含配置信息的结构体
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_pta_prio
+
+```c
+int wapi_set_pta_prio(int sock, const char *ifname, enum wapi_pta_prio_e pta_prio);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `pta_prio` PTA 优先级。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_pta_prio
+
+```c
+int wapi_get_pta_prio(int sock, const char *ifname, enum wapi_pta_prio_e *pta_prio);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `pta_prio` 指向用于接收当前 PTA 优先级的变量
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_pmksa
+
+```c
+int wapi_set_pmksa(int sock, const char *ifname, const uint8_t *pmk, int len);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `pmk` 指向包含 PMKSA 数据的缓冲区
+- `len` 长度。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_pmksa
+
+```c
+int wapi_get_pmksa(int sock, const char *ifname, uint8_t *pmk, int len);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `pmk` 指向用于接收查询到的 PMKSA 数据的缓冲区
+- `len` 缓冲区大小。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_extend_params
+
+```c
+int wapi_extend_params(int sock, int cmd, struct iwreq *wrq);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `cmd` 私有 ioctl 命令码。
+- `wrq` 指向 `iwreq` 结构体，调用方需预先
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_set_power_save
+
+```c
+int wapi_set_power_save(int sock, const char *ifname, bool on);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `on` 控制标志。
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+
+### wapi_get_power_save
+
+```c
+int wapi_get_power_save(int sock, const char *ifname, bool *on);
+```
+
+**参数**：
+
+- `sock` 文件描述符。
+- `ifname` 网络接口名称。
+- `on` 指向用于接收当前状态的布尔变量
+
+**返回值**：
+
+成功时返回 0，失败时返回负的错误码。
+


### PR DESCRIPTION
## Overview

Split the 2439-line monolithic `net.md` into focused files and bring each to 100% coverage of its source headers.

## Files

| File | Scope | APIs | Source headers |
|------|-------|------|----------------|
| `net.md` | BSD socket + DNS (unchanged scope, trimmed from 2439 → 589 lines) | 24 | `<sys/socket.h>`, `<netinet/in.h>`, `<arpa/inet.h>` |
| `net_dhcp.md` **NEW** | DHCP client (IPv4), DHCPv6 client, DHCP server | **15** | `netutils/dhcpc.h`, `dhcp6c.h`, `dhcpd.h` |
| `net_ftp.md` **NEW** | Lightweight FTP server | **4** | `netutils/ftpd.h` |
| `netlib.md` **NEW** | IPv4/IPv6 address/route/MAC/MTU, iptables, connectivity checks, URL parsing | **81** | `netutils/netlib.h` |
| `wapi.md` **NEW** | Wi-Fi interface configuration, scanning, power management, PMKSA (Linux Wireless Extensions) | **47** | `wireless/wapi.h` |
| `index.md` | Updated with categorized navigation | - | - |

## Structure Fixes

- Promote **142 individual APIs** from `####` (four-level) to `###`, per `api-doc-standards.md` ("组内每个 API 用 `### 函数名`").
- Each file has its own `## openvela 实现说明` section and explicit `#include` header declaration.

## Coverage Fixes Found During Audit

- **`net_dhcp.md`**: split one composite section (`### set_startip / set_routerip / set_netmask / set_dnsip`) into 4 independent APIs with proper `**参数**:` / `**返回值**:` descriptions.
- **`netlib.md`**: added 5 previously missing address-conversion helpers (`netlib_ipv4addrconv`, `netlib_ethaddrconv`, `netlib_saddrconv`, `netlib_eaddrconv`, `netlib_nodeaddrconv`).

## Content Quality

- Translate **~31 parameter descriptions** that mixed English and Chinese (e.g. `ipaddr 用于存储 the IP address` → `ipaddr 用于存储 IP 地址`).
- Preserve industry standard terms (BSD socket, `SIOCGIF*`, WEXT, Linux Wireless Extensions, `struct sockaddr_in`, etc.) per the standard.

## Coverage

Every `dhcpc_*` / `dhcp6c_*` / `dhcpd_*` / `ftpd_*` / `netlib_*` / `wapi_*` function declared in the source headers is present in the documentation. **313 public APIs** total across the 5 files, up from 166 before, with every section verified against its source.

## Statistics

6 files changed, +2652 / -82 lines.