### PR TITLE
docs: update POSIX compatibility number to 89%

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The name "Vela" is originated from the Latin term for "sail," which is also the 
 
 - **Standard Compliant and High Portability**
 
-    openvela Kernel is built upon Apache NuttX,  which is often referred to as "tiny Linux". With this foundation, openvela achieves a high degree of conformity with the POSIX standard. Our team has been continually enhancing its POSIX compatibility, which has now reached an impressive 88%. Because of this standards conformance, software developed under other standard OSs (such as Linux) can be easily ported to openvela with minimum effort.
+    openvela Kernel is built upon Apache NuttX,  which is often referred to as "tiny Linux". With this foundation, openvela achieves a high degree of conformity with the POSIX standard. Our team has been continually enhancing its POSIX compatibility, which has now reached an impressive 89%. Because of this standards conformance, software developed under other standard OSs (such as Linux) can be easily ported to openvela with minimum effort.
 
 - **Comprehensive Connectivity Suite**
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -48,7 +48,7 @@ Vela 的命名源自拉丁语中船帆的含义，也是南方星空中船帆星
 
 - **标准兼容和高可移植性**
 
-    openvela 内核基于 Apache NuttX ，这个被称为 "Tiny Linux" 的系统为 openvela 提供了高标准的 POSIX 兼容性。通过持续提升其 POSIX 兼容性，openvela 当前已达到 88% 的兼容水平。这种高标准的兼容性意味着在其他标准操作系统（例如 Linux）上开发的软件可以轻松迁移到 openvela，几乎不需要额外的工作。
+    openvela 内核基于 Apache NuttX ，这个被称为 "Tiny Linux" 的系统为 openvela 提供了高标准的 POSIX 兼容性。通过持续提升其 POSIX 兼容性，openvela 当前已达到 89% 的兼容水平。这种高标准的兼容性意味着在其他标准操作系统（例如 Linux）上开发的软件可以轻松迁移到 openvela，几乎不需要额外的工作。
 
 - **全面的连接套件**
 


### PR DESCRIPTION
## Summary

Update the POSIX compatibility number in both Chinese and English README files from 88% to 89%, reflecting the latest internal compatibility assessment after recent kernel API coverage improvements.

## Background

The previous 88% figure has been cited in both READMEs for a while. With the recent kernel-level API documentation and coverage work (thread/sched/signal/msgqueue/mem modules all at 100% source coverage), the POSIX compatibility number has moved up to 89%.

## Changes

| File | Change |
|------|--------|
| `README.md` | `88%` → `89%` in the "Standard Compliant and High Portability" section |
| `README_zh-cn.md` | `88%` → `89%` in the "标准兼容和高可移植性" section |

## Stats

2 files changed, +2 / -2 lines