### PR TITLE
docs: add API reference link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ If you want to experience openvela, we provide a fully functional emulator that 
 ## Developer Documentation
 
 - [Documentation Center](https://doc.openvela.com/document)
+- [API Reference](./en/api/index.md) — Complete API specification for kernel, network, and application framework interfaces
 
 ## Application Example Center
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -156,6 +156,7 @@ openvela 采用双分支模型来平衡系统的创新性与稳定性。请根�
 ## 开发者文档
 
 - [文档中心](https://doc.openvela.com/document)
+- [API 参考文档](./zh-cn/api/index.md) — 内核接口、网络接口、应用框架 API 完整说明
 
 ## 应用示例中心
 


### PR DESCRIPTION
## Summary

Add API reference documentation links to both Chinese and English README files, providing developers with a direct entry point to the in-repo API documentation.

## Changes

- `README_zh-cn.md`: Added link to `./zh-cn/api/index.md` under "开发者文档" section
- `README.md`: Added link to `./en/api/index.md` under "Developer Documentation" section

## Notes

- Links use relative paths, clickable on both GitHub and Gitee
- Chinese and English versions are kept in sync