### PR TITLE
docs: bump cross-repo links and repo-init branch to trunk-5.5

### DIFF
--- a/en/quickstart/openvela_ubuntu_quick_start.md
+++ b/en/quickstart/openvela_ubuntu_quick_start.md
@@ -71,7 +71,7 @@ After installation, you can run `repo --version` to verify it.
     mkdir openvela && cd openvela
     ```
 
-2. Initialize the project manifest using `repo` and specify the `trunk-5.5` branch.
+2. Initialize the project manifest using `repo` and specify the `trunk-5.5` release tag.
 
     Please select one of the following methods (SSH is recommended) based on your network environment and preference to initialize the repository.
 
@@ -82,13 +82,13 @@ After installation, you can run `repo --version` to verify it.
         This method requires you to add your SSH public key to your GitHub account first. Please refer to the [official GitHub documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
         ```bash
-        repo init -u ssh://git@github.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u ssh://git@github.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - Method 2: HTTPS
 
         ```bash
-        repo init -u https://github.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://github.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     #### Option B: Download from Gitee
@@ -98,13 +98,13 @@ After installation, you can run `repo --version` to verify it.
         This method requires you to add your SSH public key to your Gitee account first. Please refer to the [official Gitee documentation](https://gitee.com/help/articles/4191).
 
         ```bash
-        repo init --u ssh://git@gitee.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init --u ssh://git@gitee.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - Method 2: HTTPS
 
         ```bash
-        repo init -u https://gitee.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://gitee.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     #### Option C: Download from GitCode
@@ -114,13 +114,13 @@ After installation, you can run `repo --version` to verify it.
         This method requires you to add your SSH public key to your GitCode account first. Please refer to the [official GitCode documentation](https://docs.gitcode.com/docs/help/home/user_center/security_management/ssh).
 
         ```bash
-        repo init -u ssh://git@gitcode.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u ssh://git@gitcode.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - Method 2: HTTPS
 
         ```bash
-        repo init -u https://gitcode.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://gitcode.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
 3. Execute the sync command. `repo` will download all related source code repositories according to the manifest file (`openvela.xml`).

--- a/zh-cn/quickstart/openvela_ubuntu_quick_start.md
+++ b/zh-cn/quickstart/openvela_ubuntu_quick_start.md
@@ -71,7 +71,7 @@ sudo mv repo /usr/local/bin
     mkdir openvela && cd openvela
     ```
 
-2. 使用 `repo` 初始化项目清单，并指定 `trunk-5.5` 分支。
+2. 使用 `repo` 初始化项目清单，并指定 `trunk-5.5` 版本标签。
 
     请根据您的网络环境和偏好，从以下任一平台选择一种方式（推荐使用 SSH）来初始化仓库。
 
@@ -82,13 +82,13 @@ sudo mv repo /usr/local/bin
         此方式需要您先将 SSH 公钥添加至您的 GitHub 账户，请参考 [GitHub 官方文档](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)。
 
         ```bash
-        repo init -u ssh://git@github.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u ssh://git@github.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - 方式二：HTTPS
 
         ```bash
-        repo init -u https://github.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://github.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     #### 选项 B：从 Gitee 下载
@@ -98,13 +98,13 @@ sudo mv repo /usr/local/bin
         此方式需要您先将 SSH 公钥添加至您的 Gitee 账户，请参考 [Gitee 官方文档](https://gitee.com/help/articles/4191)。
 
         ```bash
-        repo init --u ssh://git@gitee.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init --u ssh://git@gitee.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - 方式二：HTTPS
 
         ```bash
-        repo init -u https://gitee.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://gitee.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     #### 选项 C：从 GitCode 下载
@@ -114,13 +114,13 @@ sudo mv repo /usr/local/bin
         此方式需要您先将 SSH 公钥添加至您的 GitCode 账户，请参考 [GitCode 官方文档](https://docs.gitcode.com/docs/help/home/user_center/security_management/ssh)。
 
         ```bash
-        repo init -u ssh://git@gitcode.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u ssh://git@gitcode.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
     - 方式二：HTTPS
 
         ```bash
-        repo init -u https://gitcode.com/open-vela/manifests.git -b trunk-5.5 -m openvela.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
+        repo init -u https://gitcode.com/open-vela/manifests.git -b trunk -m tags/trunk-5.5.xml --repo-url=https://mirrors.tuna.tsinghua.edu.cn/git/git-repo/ --git-lfs
         ```
 
 3. 执行同步命令，repo 将根据清单文件 (`openvela.xml`) 下载所有相关的源代码仓库。


### PR DESCRIPTION
Align doc references with the trunk-5.5 release, mirroring the convention used for the trunk-5.4 tag.

- Bump cross-repo URL links (nuttx / nuttx-apps / vendor_* / packages_demos / packages_fe_examples / docs) from /blob|tree/trunk/ to /blob|tree/trunk-5.5/
- Update `repo init -b trunk` commands and surrounding prose in the Ubuntu quick-start guides to use `-b trunk-5.5`
- Update patch-version naming example in README from trunk-5.2.1 to trunk-5.5.1

Historical release notes (v5.2.md, v5.4.md), commit-SHA pinned links in the chip-porting guides, the PR template's link to CONTRIBUTING (kept on `trunk` so contributors always see the latest guidelines), and descriptive prose about the `trunk` branch itself are left untouched.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

