### PR TITLE
docs(network): fix dhcp6c description - remove incorrect SLAAC reference

### DIFF
--- a/en/api/framework/telephony/index.md
+++ b/en/api/framework/telephony/index.md
@@ -9,7 +9,7 @@ TAPI is independent of the openvela telephony core stack. Its internal logic use
 ## openvela Implementation Notes
 
 - **Architecture**: TAPI encapsulates the Telephony Core Stack (oFono) via D-Bus, exposing standard C interfaces externally
-- **Multi-SIM support**: Different SIM slots are distinguished via the `slot_id` parameter
+- **SIM identification**: Different SIM slots are distinguished via the `slot_id` parameter
 - **Asynchronous model**: Most operations return results asynchronously through callback functions
 
 ## Module Overview

--- a/en/api/framework/telephony/telephony_call.md
+++ b/en/api/framework/telephony/telephony_call.md
@@ -8,7 +8,7 @@ Header: `#include <tapi_call.h>`
 
 ## openvela Implementation Notes
 
-- **Multi-SIM support**: Some interfaces do not take a `slot_id` and use the default slot; use `tapi_call_set_default_slot` to switch when a specific slot is needed
+- **SIM identification**: Some interfaces do not take a `slot_id` and use the default slot; use `tapi_call_set_default_slot` to switch when a specific slot is needed
 - **Synchronous/Asynchronous**: Time-consuming operations such as dialing and answering provide both synchronous versions and `_async` versions (callback-style)
 - **Operate by ID**: Long-lived calls are uniquely identified by the call ID (string) returned; `*_by_id` interfaces operate on the call accordingly
 - **DTMF**: Keypad tones are triggered via `tapi_call_send_tones` (batch) or `tapi_call_start_dtmf` / `tapi_call_stop_dtmf` (continuous key press)

--- a/en/api/framework/telephony/telephony_cbs.md
+++ b/en/api/framework/telephony/telephony_cbs.md
@@ -11,7 +11,7 @@ Header: `#include <tapi_cbs.h>`
 - **Power control**: Enable/disable cell broadcast reception via `set_cell_broadcast_power_on`
 - **Topic subscription**: Configure broadcast topic ranges (by channel ID) via `set_cell_broadcast_topics`
 - **Event callback**: Register event callbacks via `tapi_cbs_register` to receive broadcast messages
-- **Multi-SIM support**: All interfaces include a `slot_id` parameter for multi-SIM devices
+- **SIM identification**: All interfaces include a `slot_id` parameter for multi-SIM devices
 - **Related protocol**: Corresponds to the Cell Broadcast procedure defined in 3GPP TS 23.041
 
 ## Power Control

--- a/en/api/framework/telephony/telephony_data.md
+++ b/en/api/framework/telephony/telephony_data.md
@@ -11,7 +11,7 @@ Header file: `#include <tapi_data.h>`
 - **APN context**: Manage APN configurations (add/remove/edit/query) via the `tapi_data_*_apn_context` series of interfaces
 - **On-demand connection**: `tapi_data_request_network` / `tapi_data_release_network` controls data network establishment and release
 - **Roaming control**: Explicitly toggle data roaming via `tapi_data_enable_roaming`
-- **Multi-SIM support**: Operations involving a specific SIM use the `slot_id` parameter; the default data SIM is set via `tapi_data_set_default_slot`
+- **SIM identification**: Operations involving a specific SIM use the `slot_id` parameter; the default data SIM is set via `tapi_data_set_default_slot`
 - **State subscription**: `tapi_data_register` / `tapi_data_unregister` for registering/unregistering state change events
 
 ## APN Configuration Management

--- a/en/api/framework/telephony/telephony_ims.md
+++ b/en/api/framework/telephony/telephony_ims.md
@@ -12,7 +12,7 @@ Header: `#include <tapi_ims.h>`
 - **Registration Status**: Queries whether IMS is registered to the network, subscribes to registration state change events
 - **Service Switch**: `set_service_status` controls enabling of specific services (e.g. voice, video)
 - **VoLTE Support**: Queries whether the current network supports VoLTE via `is_volte_available`
-- **Multi-SIM Support**: All interfaces include a `slot_id` parameter
+- **SIM identification**: All interfaces include a `slot_id` parameter
 
 ## IMS Switch
 

--- a/en/api/framework/telephony/telephony_manager.md
+++ b/en/api/framework/telephony/telephony_manager.md
@@ -9,7 +9,7 @@ Header: `#include <tapi_manager.h>`
 ## openvela Implementation Notes
 
 - **D-Bus Based**: TAPI Manager communicates with the Telephony Core Stack (oFono) via D-Bus, exposing standard C interfaces externally
-- **Multi-SIM Support**: The manager layer does not directly handle SIM slot selection; slot-specific operations use the `slot_id` parameter in submodules such as `tapi_sim`
+- **SIM identification**: The manager layer does not directly handle SIM slot selection; slot-specific operations use the `slot_id` parameter in submodules such as `tapi_sim`
 - **Client Handle**: Obtain a `tapi_context` via `tapi_open`; all subsequent calls take this context as the first parameter
 - **Event Subscription**: Register event callbacks via `tapi_register`, unsubscribe via `tapi_unregister`
 - **Synchronous vs Asynchronous**: Most interfaces are asynchronous (with callbacks); some provide `*_sync` variants for simple scenarios

--- a/en/api/framework/telephony/telephony_network.md
+++ b/en/api/framework/telephony/telephony_network.md
@@ -11,7 +11,7 @@ Header: `#include <tapi_network.h>`
 - **Network selection mode**: Supports automatic selection (`select_auto`) and manual selection (`select_manual`)
 - **Scanning**: `tapi_network_scan` scans for available network operators
 - **Cell information**: `get_serving_cellinfos` retrieves the current serving cell, `get_neighbouring_cellinfos` retrieves neighboring cells
-- **Multi-SIM support**: Most interfaces include a `slot_id` parameter to distinguish network state across different SIM slots
+- **SIM identification**: Most interfaces include a `slot_id` parameter to distinguish network state across different SIM slots
 - **Event subscription**: `tapi_network_register` / `tapi_network_unregister` monitor registration state and signal strength changes
 
 ## Network Selection and Scanning

--- a/en/api/framework/telephony/telephony_phonebook.md
+++ b/en/api/framework/telephony/telephony_phonebook.md
@@ -11,7 +11,7 @@ Header: `#include <tapi_phonebook.h>`
 - **ADN**: Abbreviated Dialling Numbers, regular numbers stored on the SIM card
 - **FDN**: Fixed Dialling Numbers; when enabled, the phone can only dial numbers in the FDN list, protected by PIN2
 - **FDN operations require PIN2**: `insert_fdn_entry` / `delete_fdn_entry` / `update_fdn_entry` calls require PIN2
-- **Multi-SIM support**: All interfaces include a `slot_id` parameter
+- **SIM identification**: All interfaces include a `slot_id` parameter
 - **Asynchronous callbacks**: All operations return results asynchronously via `tapi_async_function`
 
 ## ADN Phonebook

--- a/en/api/framework/telephony/telephony_sim.md
+++ b/en/api/framework/telephony/telephony_sim.md
@@ -8,7 +8,7 @@ Header file: `#include <tapi_sim.h>`
 
 ## openvela Implementation Notes
 
-- **Multi-SIM support**: All interfaces include `slot_id` to support multi-SIM devices
+- **SIM management**: All interfaces include `slot_id` parameter for SIM card identification
 - **PIN management**: Provides `enter_pin` / `change_pin` / `reset_pin` / `lock_pin` / `unlock_pin` for complete PIN/PUK workflows
 - **APDU channel**: Use `open_logical_channel` / `close_logical_channel` / `transmit_apdu_*` to send APDU commands directly to the SIM card
 - **UICC switch**: Control SIM card enablement state via `get_uicc_enablement` / `set_uicc_enablement`

--- a/en/api/framework/telephony/telephony_ss.md
+++ b/en/api/framework/telephony/telephony_ss.md
@@ -13,7 +13,7 @@ Header file: `#include <tapi_ss.h>`
 - **CLIR/CLIP**: Calling line identification display and restriction via `calling_line_restriction` and `calling_line_presentation_info` interfaces
 - **USSD**: `tapi_ss_send_ussd` sends `*#xxxx#` commands, `tapi_ss_cancel_ussd` cancels the session
 - **FDN**: Fixed Dialing Number switch via `tapi_ss_enable_fdn` / `tapi_ss_query_fdn`
-- **Multi-SIM support**: All interfaces include `slot_id`
+- **SIM identification**: All interfaces include `slot_id`
 - **Asynchronous callback**: All operations use `tapi_async_function`
 
 ## Call Barring

--- a/en/api/framework/telephony/telephony_stk.md
+++ b/en/api/framework/telephony/telephony_stk.md
@@ -12,7 +12,7 @@ Header file: `#include <tapi_stk.h>`
 - **Registration levels**: Supports per-slot Agent (via `tapi_stk_agent_register`) and default Agent (system default UI).
 - **Main menu**: `tapi_stk_get_main_menu*` queries the main menu structure provided by the SIM card.
 - **Proactive Command responses**: The `tapi_stk_handle_agent_*` family of interfaces is used to send the Agent's responses to SIM card proactive commands back to the SIM.
-- **Multi-SIM support**: All interfaces include a `slot_id` parameter.
+- **SIM identification**: All interfaces include a `slot_id` parameter.
 
 ## Agent Registration
 

--- a/en/api/network/net_dhcp.md
+++ b/en/api/network/net_dhcp.md
@@ -9,7 +9,7 @@ Header files: `#include <netutils/dhcpc.h>`, `#include <netutils/dhcp6c.h>`, `#i
 ## openvela Implementation Notes
 
 - **IPv4 client**: The `dhcpc_*` series encapsulates the complete DHCP client state machine (DISCOVER/OFFER/REQUEST/ACK)
-- **IPv6 client**: The `dhcp6c_*` series handles the IPv6 SLAAC / DHCPv6 process
+- **IPv6 client**: The `dhcp6c_*` series implements the DHCPv6 client protocol
 - **Server**: The `dhcpd_*` series provides simple DHCP server capabilities for IP allocation in hotspot/AP mode
 - **Asynchronous calls**: The `*_request_async` interfaces provide callback-based invocation to avoid blocking the current thread
 - **Configuration dependency**: Requires enabling `CONFIG_NETUTILS_DHCPC` / `CONFIG_NETUTILS_DHCP6C` / `CONFIG_NETUTILS_DHCPD`

--- a/zh-cn/api/framework/telephony/index.md
+++ b/zh-cn/api/framework/telephony/index.md
@@ -9,7 +9,7 @@ TAPI 独立于 openvela telephony core stack，内部逻辑基于 DBUS LIB 对 C
 ## openvela 实现说明
 
 - **架构**：TAPI 基于 D-Bus 对 Telephony Core Stack（oFono）进行封装，以标准 C 接口对外提供
-- **多卡支持**：通过 `slot_id` 参数区分不同 SIM 卡槽
+- **SIM 卡标识**：通过 `slot_id` 参数区分不同 SIM 卡槽
 - **异步模型**：大部分操作通过回调函数异步返回结果
 
 ## 模块代码介绍

--- a/zh-cn/api/framework/telephony/telephony_call.md
+++ b/zh-cn/api/framework/telephony/telephony_call.md
@@ -8,7 +8,7 @@
 
 ## openvela 实现说明
 
-- **多卡支持**：部分接口不带 `slot_id`，使用默认卡；需要指定卡时通过 `tapi_call_set_default_slot` 切换
+- **SIM 卡标识**：部分接口不带 `slot_id`，使用默认卡；需要指定卡时通过 `tapi_call_set_default_slot` 切换
 - **同步/异步**：拨号、应答等耗时操作同时提供同步版本和 `_async` 版本（回调风格）
 - **按 ID 操作**：长生命周期通话通过返回的 call ID（字符串）唯一标识，`*_by_id` 接口据此执行操作
 - **DTMF**：拨号盘按键通过 `tapi_call_send_tones`（批量）或 `tapi_call_start_dtmf` / `tapi_call_stop_dtmf`（持续按键）触发

--- a/zh-cn/api/framework/telephony/telephony_cbs.md
+++ b/zh-cn/api/framework/telephony/telephony_cbs.md
@@ -11,7 +11,7 @@ Cell Broadcast Service（CBS）是蜂窝网络的小区广播能力，常用于�
 - **开关控制**：通过 `set_cell_broadcast_power_on` 启用/禁用小区广播接收
 - **主题订阅**：通过 `set_cell_broadcast_topics` 配置要接收的广播主题范围（按频道 ID）
 - **事件回调**：通过 `tapi_cbs_register` 注册事件回调，接收到的广播消息
-- **多卡支持**：所有接口带 `slot_id`，支持多 SIM 卡设备
+- **SIM 卡标识**：所有接口带 `slot_id`，支持多 SIM 卡设备
 - **相关协议**：底层对应 3GPP TS 23.041 定义的 Cell Broadcast 流程
 
 ## 开关控制

--- a/zh-cn/api/framework/telephony/telephony_data.md
+++ b/zh-cn/api/framework/telephony/telephony_data.md
@@ -11,7 +11,7 @@
 - **APN 上下文**：通过 `tapi_data_*_apn_context` 系列接口管理 APN 配置（增删改查）
 - **按需连接**：`tapi_data_request_network` / `tapi_data_release_network` 控制数据网络的建立与释放
 - **漫游控制**：通过 `tapi_data_enable_roaming` 显式开关数据漫游
-- **多卡支持**：涉及特定卡的操作使用 `slot_id` 参数；数据默认卡通过 `tapi_data_set_default_slot` 设置
+- **SIM 卡标识**：涉及特定卡的操作使用 `slot_id` 参数；数据默认卡通过 `tapi_data_set_default_slot` 设置
 - **状态订阅**：`tapi_data_register` / `tapi_data_unregister` 用于注册/取消状态变化事件
 
 ## APN 配置管理

--- a/zh-cn/api/framework/telephony/telephony_ims.md
+++ b/zh-cn/api/framework/telephony/telephony_ims.md
@@ -12,7 +12,7 @@ IP 多媒体子系统（VoLTE/VoWiFi）管理。
 - **注册状态**：查询 IMS 是否已注册到网络，订阅注册状态变化事件
 - **业务开关**：`set_service_status` 控制具体业务（如语音、视频）的启用
 - **VoLTE 支持**：通过 `is_volte_available` 查询当前网络是否支持 VoLTE
-- **多卡支持**：所有接口带 `slot_id`
+- **SIM 卡标识**：所有接口带 `slot_id` 参数
 
 ## IMS 开关
 

--- a/zh-cn/api/framework/telephony/telephony_manager.md
+++ b/zh-cn/api/framework/telephony/telephony_manager.md
@@ -9,7 +9,7 @@
 ## openvela 实现说明
 
 - **基于 D-Bus**：TAPI Manager 通过 D-Bus 与 Telephony Core Stack（oFono）通信，对外以标准 C 接口封装
-- **多卡支持**：管理器层面不直接涉及 SIM 卡槽选择，涉及特定卡槽的操作在 `tapi_sim` 等子模块中使用 `slot_id` 参数
+- **SIM 卡标识**：管理器层面不直接涉及 SIM 卡槽选择，涉及特定卡槽的操作在 `tapi_sim` 等子模块中使用 `slot_id` 参数
 - **客户端句柄**：通过 `tapi_open` 获取 `tapi_context`，所有后续调用均以该 context 作为第一个参数
 - **事件订阅**：通过 `tapi_register` 注册事件回调，`tapi_unregister` 取消订阅
 - **同步 vs 异步**：多数接口是异步的（带回调），部分提供 `*_sync` 变体用于简单场景

--- a/zh-cn/api/framework/telephony/telephony_network.md
+++ b/zh-cn/api/framework/telephony/telephony_network.md
@@ -11,7 +11,7 @@
 - **选网模式**：支持自动选网（`select_auto`）和手动选网（`select_manual`）
 - **扫描**：`tapi_network_scan` 扫描可用的网络运营商
 - **小区信息**：`get_serving_cellinfos` 获取当前服务小区，`get_neighbouring_cellinfos` 获取相邻小区
-- **多卡支持**：大部分接口带 `slot_id`，区分不同 SIM 卡槽的网络状态
+- **SIM 卡标识**：大部分接口带 `slot_id`，区分不同 SIM 卡槽的网络状态
 - **事件订阅**：`tapi_network_register` / `tapi_network_unregister` 监听注册状态/信号强度变化
 
 ## 选网与扫描

--- a/zh-cn/api/framework/telephony/telephony_phonebook.md
+++ b/zh-cn/api/framework/telephony/telephony_phonebook.md
@@ -11,7 +11,7 @@ SIM 卡电话簿管理接口，支持 ADN（普通电话簿）和 FDN（固定�
 - **ADN**：普通电话簿（Abbreviated Dialling Numbers），存储在 SIM 卡上的常规号码
 - **FDN**：固定拨号号码（Fixed Dialling Numbers），启用后手机只能拨打 FDN 中的号码，受 PIN2 保护
 - **FDN 操作需要 PIN2**：`insert_fdn_entry` / `delete_fdn_entry` / `update_fdn_entry` 调用时需要传入 PIN2
-- **多卡支持**：所有接口带 `slot_id`
+- **SIM 卡标识**：所有接口带 `slot_id`
 - **异步回调**：所有操作使用 `tapi_async_function` 异步返回结果
 
 ## ADN 电话簿

--- a/zh-cn/api/framework/telephony/telephony_sim.md
+++ b/zh-cn/api/framework/telephony/telephony_sim.md
@@ -8,7 +8,7 @@ SIM 卡状态查询和管理。
 
 ## openvela 实现说明
 
-- **多卡支持**：所有接口均带 `slot_id`，支持多 SIM 卡设备
+- **SIM 卡管理**：所有接口均带 `slot_id` 参数，用于标识 SIM 卡
 - **PIN 管理**：提供 `enter_pin` / `change_pin` / `reset_pin` / `lock_pin` / `unlock_pin` 完整 PIN/PUK 流程
 - **APDU 通道**：通过 `open_logical_channel` / `close_logical_channel` / `transmit_apdu_*` 直接向 SIM 卡发送 APDU 命令
 - **UICC 开关**：通过 `get_uicc_enablement` / `set_uicc_enablement` 控制 SIM 卡的启用状态

--- a/zh-cn/api/framework/telephony/telephony_ss.md
+++ b/zh-cn/api/framework/telephony/telephony_ss.md
@@ -13,7 +13,7 @@ Supplementary Services（补充业务）是 3GPP 蜂窝标准定义的增值通�
 - **CLIR/CLIP**：主叫号码显示与限制，通过 `calling_line_restriction` 和 `calling_line_presentation_info` 接口
 - **USSD**：`tapi_ss_send_ussd` 发送 `*#xxxx#` 命令，`tapi_ss_cancel_ussd` 取消会话
 - **FDN**：固定拨号开关通过 `tapi_ss_enable_fdn` / `tapi_ss_query_fdn`
-- **多卡支持**：所有接口带 `slot_id`
+- **SIM 卡标识**：所有接口带 `slot_id`
 - **异步回调**：所有操作使用 `tapi_async_function`
 
 ## 呼叫限制

--- a/zh-cn/api/framework/telephony/telephony_stk.md
+++ b/zh-cn/api/framework/telephony/telephony_stk.md
@@ -12,7 +12,7 @@ SIM Application Toolkit（STK / CAT）是运营商在 SIM 卡上预置的交互�
 - **注册层级**：支持 per-slot Agent（通过 `tapi_stk_agent_register`）与 default Agent（系统默认 UI）
 - **主菜单**：`tapi_stk_get_main_menu*` 查询 SIM 卡提供的主菜单结构
 - **Proactive Command 响应**：`tapi_stk_handle_agent_*` 系列接口用于将 Agent 对 SIM 卡主动命令的响应回传给 SIM
-- **多卡支持**：所有接口带 `slot_id`
+- **SIM 卡标识**：所有接口带 `slot_id`
 
 ## Agent 注册
 

--- a/zh-cn/api/network/net_dhcp.md
+++ b/zh-cn/api/network/net_dhcp.md
@@ -9,7 +9,7 @@ DHCP（Dynamic Host Configuration Protocol）客户端与服务器接口，覆�
 ## openvela 实现说明
 
 - **IPv4 客户端**：`dhcpc_*` 系列封装完整的 DHCP 客户端状态机（DISCOVER/OFFER/REQUEST/ACK）
-- **IPv6 客户端**：`dhcp6c_*` 系列处理 IPv6 的 SLAAC / DHCPv6 流程
+- **IPv6 客户端**：`dhcp6c_*` 系列实现 DHCPv6 客户端协议流程
 - **服务器**：`dhcpd_*` 系列提供简单的 DHCP 服务器能力，可在热点/AP 模式下分配 IP
 - **异步调用**：`*_request_async` 接口提供回调式调用，避免阻塞当前线程
 - **配置依赖**：需启用 `CONFIG_NETUTILS_DHCPC` / `CONFIG_NETUTILS_DHCP6C` / `CONFIG_NETUTILS_DHCPD`


### PR DESCRIPTION
## Summary

Fix incorrect description in DHCP API documentation and replace "Multi-SIM support" with "SIM identification" in Telephony documentation.

**DHCP fix:**
- Before: "dhcp6c_* 系列处理 IPv6 的 SLAAC / DHCPv6 流程"
- After: "dhcp6c_* 系列实现 DHCPv6 客户端协议流程"
- Reason: dhcp6c_* only implements DHCPv6 protocol, not SLAAC.

**Telephony fix:**
- Before: "多卡支持" / "Multi-SIM Support"
- After: "SIM 卡标识" / "SIM identification"
- Reason: Product uses eSIM without dual-SIM support at RIL layer.

Both zh-cn and en versions updated (24 files total).

## Impact

Documentation only. No code changes.

## Testing

N/A - documentation fix based on expert review feedback.