### PR TITLE
docs: fix mixed Chinese-English translation issues in API docs

### DIFF
--- a/en/api/framework/media/media_utils.md
+++ b/en/api/framework/media/media_utils.md
@@ -9,7 +9,7 @@ Header: `#include <media_utils.h>`
 ## openvela Implementation Notes
 
 - **DTMF**: Generates DTMF dual-tone multi-frequency signals for `0-9` / `*#ABCD` keys, with a fixed audio format of `format=s16le:sample_rate=8000:ch_layout=mono` (defined by the `MEDIA_TONE_DTMF_FORMAT` macro)
-- **Debug Interfaces**: `media_graph_dump` and `media_policy_dump` print internal state for troubleshooting
+- **Debug Interfaces**: `media_graph_dump`, `media_player_dump`, `media_recorder_dump` and `media_policy_dump` print internal state for troubleshooting
 - **Generic Command**: `media_process_command` sends custom commands to the media server for extended capabilities (e.g., triggering an operation on a specific filter within a graph)
 - **Event Name Lookup**: `media_event_get_name` converts `MEDIA_EVENT_*` numeric values to human-readable strings for log output
 
@@ -102,6 +102,33 @@ Prints the current state of the media policy for debugging.
 **Parameters**:
 
 - `options` Dump options string.
+
+
+### media_player_dump
+
+```c
+void media_player_dump(const char* options);
+```
+
+Prints the internal state of the media player for debugging.
+
+**Parameters**:
+
+- `options` Dump options string.
+
+
+### media_recorder_dump
+
+```c
+void media_recorder_dump(const char* options);
+```
+
+Prints the internal state of the media recorder for debugging.
+
+**Parameters**:
+
+- `options` Dump options string.
+
 
 ## Generic Command
 

--- a/zh-cn/api/framework/bluetooth/bt_a2dp.md
+++ b/zh-cn/api/framework/bluetooth/bt_a2dp.md
@@ -48,7 +48,7 @@ bool bt_a2dp_sink_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **返回值**：
 
-成功时返回回调 cookie，失败或已注册时返回 NULL。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_a2dp_sink_is_connected
@@ -57,16 +57,16 @@ bool bt_a2dp_sink_unregister_callbacks(bt_instance_t* ins, void* cookie);
 bool bt_a2dp_sink_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询指定设备的 A2DP Sink 是否已连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-检查是否已连接。
+已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_a2dp_sink_is_playing
@@ -75,16 +75,16 @@ bool bt_a2dp_sink_is_connected(bt_instance_t* ins, bt_address_t* addr);
 bool bt_a2dp_sink_is_playing(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-检查是否正在播放。
+查询指定设备的 A2DP Sink 是否正在播放音频流。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-检查是否正在播放。
+正在播放时返回 `true`，未播放时返回 `false`。
 
 
 ### bt_a2dp_sink_get_connection_state
@@ -93,7 +93,7 @@ bool bt_a2dp_sink_is_playing(bt_instance_t* ins, bt_address_t* addr);
 profile_connection_state_t bt_a2dp_sink_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+获取指定设备的 A2DP Sink 连接状态。
 
 **参数**：
 
@@ -103,6 +103,8 @@ profile_connection_state_t bt_a2dp_sink_get_connection_state(bt_instance_t* ins,
 
 **返回值**：
 
+返回当前连接状态枚举值，参见 `profile_connection_state_t`。
+
 
 
 ### bt_a2dp_sink_connect
@@ -111,16 +113,16 @@ profile_connection_state_t bt_a2dp_sink_get_connection_state(bt_instance_t* ins,
 bt_status_t bt_a2dp_sink_connect(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+发起与远程设备的 A2DP Sink 连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-建立连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_a2dp_sink_disconnect
@@ -129,16 +131,16 @@ bt_status_t bt_a2dp_sink_connect(bt_instance_t* ins, bt_address_t* addr);
 bt_status_t bt_a2dp_sink_disconnect(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-断开与远程设备的连接。
+断开与远程设备的 A2DP Sink 连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-断开连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_a2dp_source_unregister_callbacks
@@ -157,7 +159,7 @@ bool bt_a2dp_source_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **返回值**：
 
-成功时返回回调 cookie，失败或已注册时返回 NULL。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_a2dp_source_is_connected
@@ -166,16 +168,16 @@ bool bt_a2dp_source_unregister_callbacks(bt_instance_t* ins, void* cookie);
 bool bt_a2dp_source_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询指定设备的 A2DP Source 是否已连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-检查是否已连接。
+已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_a2dp_source_is_playing
@@ -184,16 +186,16 @@ bool bt_a2dp_source_is_connected(bt_instance_t* ins, bt_address_t* addr);
 bool bt_a2dp_source_is_playing(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-检查是否正在播放。
+查询指定设备的 A2DP Source 是否正在播放音频流。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-检查是否正在播放。
+正在播放时返回 `true`，未播放时返回 `false`。
 
 
 ### bt_a2dp_source_get_connection_state
@@ -202,7 +204,7 @@ bool bt_a2dp_source_is_playing(bt_instance_t* ins, bt_address_t* addr);
 profile_connection_state_t bt_a2dp_source_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+获取指定设备的 A2DP Source 连接状态。
 
 **参数**：
 
@@ -212,6 +214,8 @@ profile_connection_state_t bt_a2dp_source_get_connection_state(bt_instance_t* in
 
 **返回值**：
 
+返回当前连接状态枚举值，参见 `profile_connection_state_t`。
+
 
 
 ### bt_a2dp_source_connect
@@ -220,16 +224,16 @@ profile_connection_state_t bt_a2dp_source_get_connection_state(bt_instance_t* in
 bt_status_t bt_a2dp_source_connect(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+发起与远程设备的 A2DP Source 连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-建立连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_a2dp_source_disconnect

--- a/zh-cn/api/framework/bluetooth/bt_gap.md
+++ b/zh-cn/api/framework/bluetooth/bt_gap.md
@@ -31,7 +31,7 @@ bt_adapter_state_t bt_adapter_get_state(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_get_state 操作。
+返回当前适配器状态枚举值，参见 `bt_adapter_state_t`。
 
 
 #### bt_adapter_is_support_le
@@ -49,7 +49,7 @@ bool bt_adapter_is_support_le(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_is_support_le 操作。
+支持时返回 `true`，不支持时返回 `false`。
 
 
 #### bt_adapter_is_support_leaudio
@@ -67,7 +67,7 @@ bool bt_adapter_is_support_leaudio(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_is_support_leaudio 操作。
+支持时返回 `true`，不支持时返回 `false`。
 
 
 ## 设备发现
@@ -101,7 +101,7 @@ bt_status_t bt_adapter_start_discovery(bt_instance_t* ins, uint32_t timeout);
 
 **返回值**：
 
-bt_adapter_start_discovery 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_cancel_discovery
@@ -118,7 +118,7 @@ bt_status_t bt_adapter_cancel_discovery(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_cancel_discovery 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_is_discovering
@@ -136,7 +136,7 @@ bool bt_adapter_is_discovering(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_is_discovering 操作。
+正在发现时返回 `true`，否则返回 `false`。
 
 
 ## 属性管理
@@ -171,7 +171,7 @@ bt_status_t bt_adapter_set_name(bt_instance_t* ins, const char* name);
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_get_name
@@ -200,15 +200,13 @@ bt_status_t bt_adapter_set_scan_mode(bt_instance_t* ins, bt_scan_mode_t mode, bo
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `mode` 模式。
+- `mode` 扫描模式。
 - `bondable` 是否可配对。
-- `name` 输出参数，存储适配器名称。
-- `length` 缓冲区长度。
 
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回负的错误码。。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_get_scan_mode
@@ -226,9 +224,7 @@ bt_scan_mode_t bt_adapter_get_scan_mode(bt_instance_t* ins);
 
 **返回值**：
 
-
-
-#### bt_adapter_set_device_class
+返回扫描模式枚举值，参见 `bt_scan_mode_t`。
 
 ```c
 bt_status_t bt_adapter_set_device_class(bt_instance_t* ins, uint32_t cod);
@@ -262,9 +258,7 @@ uint32_t bt_adapter_get_device_class(bt_instance_t* ins);
 
 **返回值**：
 
-
-
-#### bt_adapter_set_debug_mode
+返回 24 位 Class of Device 值。
 
 ```c
 bt_status_t bt_adapter_set_debug_mode(bt_instance_t* ins, bt_debug_mode_t mode, uint8_t operation);
@@ -290,7 +284,7 @@ bt_status_t bt_adapter_set_le_address(bt_instance_t* ins, bt_address_t* addr);
 **参数**：
 
 - `ins` 蓝牙客户端实例, 参见 bt_instance_t.
-- `addr` 指向 the BLE identity address.
+- `addr` BLE 身份地址。
 
 
 #### bt_adapter_set_le_appearance
@@ -379,18 +373,11 @@ uint32_t bt_adapter_get_le_io_capability(bt_instance_t* ins);
 
 **参数**：
 
-- `ins` 蓝牙客户端实例, 参见 bt_instance_t.- `mode` 调试模式。
-- `operation` 调试操作。
-- `appearance` BLE 外观值。
-- `addr` 设备地址。
-- `type` 地址类型。
-- `cap` IO 能力值。
-- `num` 输出参数，存储设备数量。
-
+- `ins` 蓝牙客户端实例。
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+返回 BLE IO 能力值。
 
 
 ## BLE 管理
@@ -411,7 +398,7 @@ bt_status_t bt_adapter_enable(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_enable 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_disable
@@ -428,7 +415,7 @@ bt_status_t bt_adapter_disable(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_disable 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 #### bt_adapter_disable_safe
@@ -472,7 +459,7 @@ bool bt_adapter_is_le_enabled(bt_instance_t* ins);
 
 **返回值**：
 
-bt_adapter_is_le_enabled 操作。
+已启用时返回 `true`，未启用时返回 `false`。
 
 
 #### bt_adapter_le_enable_key_derivation
@@ -675,7 +662,7 @@ bt_status_t bt_adapter_get_type_async(bt_instance_t* ins, bt_device_type_cb_t ge
 bt_status_t bt_adapter_set_discovery_filter_async(bt_instance_t* ins, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the discovery filter（异步版本）。
+设置发现过滤器（异步版本）。
 
 **参数**：
 
@@ -872,7 +859,7 @@ bt_status_t bt_adapter_get_device_class_async(bt_instance_t* ins, bt_u32_cb_t ge
 bt_status_t bt_adapter_set_io_capability_async(bt_instance_t* ins, bt_io_capability_t cap, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the BR/EDR adapter IO capability（异步版本）。
+设置 BR/EDR 适配器 IO 能力（异步版本）。
 
 **参数**：
 
@@ -889,7 +876,7 @@ Set the BR/EDR adapter IO capability（异步版本）。
 bt_status_t bt_adapter_get_io_capability_async(bt_instance_t* ins, bt_adapter_get_io_capability_cb_t get_ioc_cb, void* userdata);
 ```
 
-Get the BR/EDR adapter IO capability（异步版本）。
+获取 BR/EDR 适配器 IO 能力（异步版本）。
 
 **参数**：
 
@@ -943,7 +930,7 @@ bt_status_t bt_adapter_set_page_scan_parameters_async(bt_instance_t* ins, bt_sca
 bt_status_t bt_adapter_set_le_io_capability_async(bt_instance_t* ins, uint32_t le_io_cap, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the BLE adapter IO capability（异步版本）。
+设置 BLE 适配器 IO 能力（异步版本）。
 
 **参数**：
 
@@ -960,7 +947,7 @@ Set the BLE adapter IO capability（异步版本）。
 bt_status_t bt_adapter_get_le_io_capability_async(bt_instance_t* ins, bt_u32_cb_t get_le_ioc_cb, void* userdata);
 ```
 
-Get the BLE adapter IO capability（异步版本）。
+获取 BLE 适配器 IO 能力（异步版本）。
 
 **参数**：
 
@@ -976,7 +963,7 @@ Get the BLE adapter IO capability（异步版本）。
 bt_status_t bt_adapter_get_le_address_async(bt_instance_t* ins, bt_adapter_get_le_address_cb_t cb, void* userdata);
 ```
 
-Get the BLE adapter address（异步版本）。
+获取 BLE 适配器地址（异步版本）。
 
 **参数**：
 
@@ -992,7 +979,7 @@ Get the BLE adapter address（异步版本）。
 bt_status_t bt_adapter_set_le_address_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the BLE private address（异步版本）。
+设置 BLE 私有地址（异步版本）。
 
 **参数**：
 
@@ -1009,7 +996,7 @@ Set the BLE private address（异步版本）。
 bt_status_t bt_adapter_set_le_identity_address_async(bt_instance_t* ins, bt_address_t* addr, bool is_public, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the BLE identity address（异步版本）。
+设置 BLE 身份地址（异步版本）。
 
 **参数**：
 
@@ -1027,7 +1014,7 @@ Set the BLE identity address（异步版本）。
 bt_status_t bt_adapter_set_le_appearance_async(bt_instance_t* ins, uint16_t appearance, bt_status_cb_t cb, void* userdata);
 ```
 
-Set the BLE adapter appearance（异步版本）。
+设置 BLE 适配器外观值（异步版本）。
 
 **参数**：
 
@@ -1044,7 +1031,7 @@ Set the BLE adapter appearance（异步版本）。
 bt_status_t bt_adapter_get_le_appearance_async(bt_instance_t* ins, bt_u16_cb_t cb, void* userdata);
 ```
 
-Get the BLE adapter appearance（异步版本）。
+获取 BLE 适配器外观值（异步版本）。
 
 **参数**：
 
@@ -1078,7 +1065,7 @@ bt_status_t bt_adapter_le_enable_key_derivation_async(bt_instance_t* ins, bool b
 bt_status_t bt_adapter_le_add_whitelist_async(bt_instance_t* ins, bt_address_t* addr, bt_status_cb_t cb, void* userdata);
 ```
 
-Add a device to the BLE whitelist（异步版本）。
+添加设备到 BLE 白名单（异步版本）。
 
 **参数**：
 

--- a/zh-cn/api/framework/bluetooth/bt_hfp.md
+++ b/zh-cn/api/framework/bluetooth/bt_hfp.md
@@ -26,12 +26,12 @@ bool bt_hfp_hf_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **参数**：
 
-- `cookie` 用户上下文。
 - `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
 
 **返回值**：
 
-取消注册回调函数。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_hfp_hf_is_connected
@@ -40,7 +40,7 @@ bool bt_hfp_hf_unregister_callbacks(bt_instance_t* ins, void* cookie);
 bool bt_hfp_hf_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询与远程设备的 HFP HF 是否已连接。
 
 **参数**：
 
@@ -50,7 +50,7 @@ bool bt_hfp_hf_is_connected(bt_instance_t* ins, bt_address_t* addr);
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_hfp_hf_is_audio_connected
@@ -59,7 +59,7 @@ bool bt_hfp_hf_is_connected(bt_instance_t* ins, bt_address_t* addr);
 bool bt_hfp_hf_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询与远程设备的 HFP 音频通道是否已连接。
 
 **参数**：
 
@@ -69,7 +69,7 @@ bool bt_hfp_hf_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+音频已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_hfp_hf_get_connection_state
@@ -78,7 +78,7 @@ bool bt_hfp_hf_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 profile_connection_state_t bt_hfp_hf_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+获取与远程设备的 HFP HF 连接状态。
 
 **参数**：
 
@@ -88,6 +88,7 @@ profile_connection_state_t bt_hfp_hf_get_connection_state(bt_instance_t* ins, bt
 
 **返回值**：
 
+返回当前连接状态枚举值，参见 `profile_connection_state_t`。
 
 
 ### bt_hfp_hf_connect
@@ -96,16 +97,16 @@ profile_connection_state_t bt_hfp_hf_get_connection_state(bt_instance_t* ins, bt
 bt_status_t bt_hfp_hf_connect(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+发起与远程设备的 HFP HF 连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-建立连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_hfp_hf_disconnect
@@ -391,7 +392,7 @@ bt_status_t bt_hfp_hf_query_current_calls(bt_instance_t* ins, bt_address_t* addr
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 - `allocator` 内存分配函数。- `calls` 输出参数，存储通话信息数组。
 - `num` 输出参数，存储通话数量。
 
@@ -502,16 +503,16 @@ bt_status_t bt_hfp_hf_get_subscriber_number(bt_instance_t* ins, bt_address_t* ad
 bt_status_t bt_hfp_hf_query_current_calls_with_callback(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-查询当前所有通话的状态信息（CLCC）。
+查询当前所有通话的状态信息（CLCC），结果通过回调异步返回。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
 - `addr` 远程设备蓝牙地址。
 
+**返回值**：
 
-
-- `ins` 蓝牙客户端实例。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_hfp_ag_unregister_callbacks
@@ -524,12 +525,12 @@ bool bt_hfp_ag_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **参数**：
 
-- `cookie` 用户上下文。
 - `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
 
 **返回值**：
 
-取消注册回调函数。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_hfp_ag_is_connected
@@ -538,7 +539,7 @@ bool bt_hfp_ag_unregister_callbacks(bt_instance_t* ins, void* cookie);
 bool bt_hfp_ag_is_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询与远程设备的 HFP AG 是否已连接。
 
 **参数**：
 
@@ -548,7 +549,7 @@ bool bt_hfp_ag_is_connected(bt_instance_t* ins, bt_address_t* addr);
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_hfp_ag_is_audio_connected
@@ -557,7 +558,7 @@ bool bt_hfp_ag_is_connected(bt_instance_t* ins, bt_address_t* addr);
 bool bt_hfp_ag_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+查询与远程设备的 HFP AG 音频通道是否已连接。
 
 **参数**：
 
@@ -567,7 +568,7 @@ bool bt_hfp_ag_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+音频已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_hfp_ag_get_connection_state
@@ -576,7 +577,7 @@ bool bt_hfp_ag_is_audio_connected(bt_instance_t* ins, bt_address_t* addr);
 profile_connection_state_t bt_hfp_ag_get_connection_state(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+获取与远程设备的 HFP AG 连接状态。
 
 **参数**：
 
@@ -586,6 +587,7 @@ profile_connection_state_t bt_hfp_ag_get_connection_state(bt_instance_t* ins, bt
 
 **返回值**：
 
+返回当前连接状态枚举值，参见 `profile_connection_state_t`。
 
 
 ### bt_hfp_ag_connect
@@ -594,16 +596,16 @@ profile_connection_state_t bt_hfp_ag_get_connection_state(bt_instance_t* ins, bt
 bt_status_t bt_hfp_ag_connect(bt_instance_t* ins, bt_address_t* addr);
 ```
 
-发起与远程设备的连接。
+发起与远程设备的 HFP AG 连接。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 
 **返回值**：
 
-建立连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_hfp_ag_disconnect
@@ -865,9 +867,9 @@ bt_status_t bt_hfp_ag_send_clcc_response(bt_instance_t* ins, bt_address_t* addr,
 - `dir` 方向（呼入/呼出）。
 - `state` 状态。
 - `mode` 模式。
-- `mpty` 是否 the call is multi party.
+- `mpty` 是否为多方通话。
 - `type` 类型。
-- `number` phone 数量 the call.
+- `number` 通话号码。
 
 **返回值**：
 

--- a/zh-cn/api/framework/bluetooth/bt_hid.md
+++ b/zh-cn/api/framework/bluetooth/bt_hid.md
@@ -25,12 +25,12 @@ bool bt_hid_device_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **参数**：
 
-- `cookie` 用户上下文。
 - `ins` 蓝牙客户端实例, 参见 bt_instance_t.
+- `cookie` 用户上下文。
 
 **返回值**：
 
-取消注册回调函数。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_hid_device_register_app
@@ -59,7 +59,7 @@ bt_status_t bt_hid_device_register_app(bt_instance_t* ins, hid_device_sdp_settin
 bt_status_t bt_hid_device_unregister_app(bt_instance_t* ins);
 ```
 
-取消注册操作。
+取消注册 HID 设备应用。
 
 **参数**：
 
@@ -68,7 +68,7 @@ bt_status_t bt_hid_device_unregister_app(bt_instance_t* ins);
 
 **返回值**：
 
-bt_hid_device_unregister_app 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_hid_device_connect
@@ -147,6 +147,10 @@ bt_status_t bt_hid_device_response_report(bt_instance_t* ins, bt_address_t* addr
 - `rpt_data` HID 报告数据。
 - `rpt_size` 报告数据大小（字节）。
 
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+
 
 ### bt_hid_device_report_error
 
@@ -160,13 +164,11 @@ bt_status_t bt_hid_device_report_error(bt_instance_t* ins, bt_address_t* addr, h
 
 - `ins` 蓝牙客户端实例。
 - `addr` 远程设备蓝牙地址。
-- `error` 错误码。
+- `error` 错误码，参见 `hid_status_error_t`。
 
+**返回值**：
 
-
-- `ins` 蓝牙客户端实例, 参见 bt_instance_t.
-- `addr` Address of the peer device, 参见 bt_address_t.
-- `error` Error code, 参见 hid_status_error_t.
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_hid_device_virtual_unplug
@@ -181,3 +183,7 @@ bt_status_t bt_hid_device_virtual_unplug(bt_instance_t* ins, bt_address_t* addr)
 
 - `ins` 蓝牙客户端实例。
 - `addr` 远程设备蓝牙地址。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。

--- a/zh-cn/api/framework/bluetooth/bt_spp.md
+++ b/zh-cn/api/framework/bluetooth/bt_spp.md
@@ -21,16 +21,16 @@ openvela 蓝牙 SPP（串口仿真）接口，用于替代物理串口进行数�
 bt_status_t bt_spp_unregister_app(bt_instance_t* ins, void* handle);
 ```
 
-取消注册操作。
+取消注册 SPP 应用。
 
 **参数**：
 
-- `handle` 句柄。
 - `ins` 蓝牙客户端实例。
+- `handle` 句柄。
 
 **返回值**：
 
-bt_spp_unregister_app 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_spp_server_start
@@ -102,7 +102,7 @@ bt_status_t bt_spp_connect(bt_instance_t* ins, void* handle, bt_address_t* addr,
 bt_status_t bt_spp_insecure_connect(bt_instance_t* ins, void* handle, bt_address_t* addr, int16_t scn, bt_uuid_t* uuid, uint16_t* port);
 ```
 
-发起与远程设备的连接。
+发起与远程设备的非安全连接（不要求加密）。
 
 **参数**：
 
@@ -112,6 +112,10 @@ bt_status_t bt_spp_insecure_connect(bt_instance_t* ins, void* handle, bt_address
 - `scn` 服务器通道号。
 - `uuid` 服务 UUID。
 - `port` 端口号。
+
+**返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_spp_disconnect
@@ -126,7 +130,7 @@ bt_status_t bt_spp_disconnect(bt_instance_t* ins, void* handle, bt_address_t* ad
 
 - `ins` 蓝牙客户端实例。
 - `handle` 句柄。
-- `addr` 蓝牙地址 of the peer device.
+- `addr` 对端设备蓝牙地址。
 - `port` 端口号。
 
 **返回值**：

--- a/zh-cn/api/framework/media/media_player.md
+++ b/zh-cn/api/framework/media/media_player.md
@@ -30,11 +30,11 @@ void* media_player_open(const char* stream);
 
 **参数**：
 
-- `stream` 流类型常量。 不同流类型有不同的路由逻辑.
+- `stream` 流类型常量，不同流类型有不同的路由逻辑。
 
 **返回值**：
 
-void*    播放器句柄, NULL on failure。
+成功时返回播放器句柄，失败时返回 `NULL`。
 
 
 ### media_player_close
@@ -47,7 +47,7 @@ int media_player_close(void* handle, int pending_stop);
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 - `pending_stop` 关闭前是否等待停止完成：0 表示立即停止并关闭，1 表示等待当前曲目播放完成再关闭。此参数仅对音频播放器有效；视频播放器设置为 1 时不产生等待效果。
 
 **返回值**：
@@ -65,13 +65,13 @@ int media_player_set_event_callback(void* handle, void* event_cookie, media_even
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `event_cookie` 回调参数.
+- `handle` 播放器句柄。
+- `event_cookie` 回调上下文参数。
 - `on_event` 事件回调函数，用于接收流状态变化通知。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_prepare
@@ -84,13 +84,13 @@ int media_player_prepare(void* handle, const char* url, const char* options);
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 - `url` 资源路径，支持两种模式：1. URL 模式：`url` 为本地文件路径或网络地址，框架会读取并播放；2. BUFFER 模式：`url` 为 `NULL`，调用方需通过 `media_player_write_data()` 或 `media_player_get_socket()` + `write()` 持续推送数据。
 - `options` 资源的额外配置参数，通常为描述资源格式的键值对（例如 `"format=s16le,sample_rate=44100,channels=2"`）。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_reset
@@ -99,16 +99,15 @@ int media_player_prepare(void* handle, const char* url, const char* options);
 int media_player_reset(void* handle);
 ```
 
-重置指定类型的播放器。
+重置播放器到初始状态。
 
 **参数**：
 
 - `handle` 播放器句柄，由 `media_player_open` 返回。
-- `handle` 播放器句柄.
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 同步接口 - 数据流
@@ -123,13 +122,13 @@ ssize_t media_player_write_data(void* handle, const void* data, size_t len);
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `data` 缓冲区地址.
-- `len` 缓冲区长度 to write.
+- `handle` 播放器句柄。
+- `data` 数据缓冲区地址。
+- `len` 要写入的数据长度（字节）。
 
 **返回值**：
 
-成功时返回发送的字节数，失败时返回负的错误码。
+成功时返回实际写入的字节数，失败时返回负的错误码。
 
 
 ### media_player_get_sockaddr
@@ -142,8 +141,8 @@ int media_player_get_sockaddr(void* handle, struct sockaddr_storage* addr);
 
 **参数**：
 
-- `handle` 播放器句柄
-- `addr` Socket 地址信息。
+- `handle` 播放器句柄。
+- `addr` 用于存储 Socket 地址信息的输出参数。
 
 **返回值**：
 
@@ -160,7 +159,7 @@ int media_player_get_socket(void* handle);
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
@@ -177,7 +176,7 @@ void media_player_close_socket(void* handle);
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 
 ## 同步接口 - 播放控制
@@ -188,15 +187,15 @@ void media_player_close_socket(void* handle);
 int media_player_start(void* handle);
 ```
 
-开始/resume playing the re音频源。
+开始或恢复播放音频源。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_stop
@@ -205,15 +204,15 @@ int media_player_start(void* handle);
 int media_player_stop(void* handle);
 ```
 
-停止 and clear the re音频源。
+停止播放并清除已准备的音频源。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_pause
@@ -222,15 +221,15 @@ int media_player_stop(void* handle);
 int media_player_pause(void* handle);
 ```
 
-暂停。
+暂停播放。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_seek
@@ -239,16 +238,16 @@ int media_player_pause(void* handle);
 int media_player_seek(void* handle, unsigned int position);
 ```
 
-跳转 to msec 位置 from begining。
+跳转到指定的播放位置。
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `position` 位置，单位为毫秒。
+- `handle` 播放器句柄。
+- `position` 目标位置，单位为毫秒，从起始位置计算。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_set_looping
@@ -257,20 +256,19 @@ int media_player_seek(void* handle, unsigned int position);
 int media_player_set_looping(void* handle, int loop);
 ```
 
-设置 loop times。
+设置循环播放次数。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 - `loop` 循环次数，`-1` 表示无限循环。
-
-
-## 同步接口 - 状态查询
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 同步接口 - 状态查询
 
 ### media_player_is_playing
 
@@ -278,15 +276,15 @@ int media_player_set_looping(void* handle, int loop);
 int media_player_is_playing(void* handle);
 ```
 
-检查 playing status。
+查询当前是否正在播放。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
-int  Positive on playing, zero on in活跃状态, negative on error。
+正在播放时返回正值，未播放时返回 `0`，出错时返回负的错误码。
 
 
 ### media_player_get_position
@@ -295,12 +293,12 @@ int  Positive on playing, zero on in活跃状态, negative on error。
 int media_player_get_position(void* handle, unsigned int* position);
 ```
 
-Gert current msec 位置 of re音频源。
+获取当前播放位置。
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `position` 位置，单位为毫秒。
+- `handle` 播放器句柄。
+- `position` 输出参数，当前播放位置，单位为毫秒。
 
 **返回值**：
 
@@ -313,12 +311,12 @@ Gert current msec 位置 of re音频源。
 int media_player_get_duration(void* handle, unsigned int* duration);
 ```
 
-Gert msec 时长 of current re音频源。
+获取当前音频源的总时长。
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `duration` 位置，单位为毫秒。
+- `handle` 播放器句柄。
+- `duration` 输出参数，音频源总时长，单位为毫秒。
 
 **返回值**：
 
@@ -331,20 +329,19 @@ Gert msec 时长 of current re音频源。
 int media_player_get_latency(void* handle, unsigned int* latency);
 ```
 
-Gert latency of current re音频源。
+获取当前音频源的播放延迟。
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `latency` 延迟帧数。
-
-
-## 同步接口 - 音量与属性
+- `handle` 播放器句柄。
+- `latency` 输出参数，延迟帧数。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 同步接口 - 音量与属性
 
 ### media_player_set_volume
 
@@ -352,16 +349,16 @@ Gert latency of current re音频源。
 int media_player_set_volume(void* handle, float volume);
 ```
 
-设置音量。
+设置播放音量。
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 - `volume` 音量值，取值范围 `[0.0, 1.0]`。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_player_get_volume
@@ -370,12 +367,12 @@ int media_player_set_volume(void* handle, float volume);
 int media_player_get_volume(void* handle, float* volume);
 ```
 
-获取音量。
+获取当前播放音量。
 
 **参数**：
 
-- `handle` 播放器句柄.
-- `volume` 音量值，取值范围 `[0.0, 1.0]`。
+- `handle` 播放器句柄。
+- `volume` 输出参数，当前音量值，取值范围 `[0.0, 1.0]`。
 
 **返回值**：
 
@@ -388,14 +385,14 @@ int media_player_get_volume(void* handle, float* volume);
 int media_player_set_property(void* handle, const char* target, const char* key, const char* value);
 ```
 
-设置 properties。
+设置播放器属性。
 
 **参数**：
 
 - `handle` 播放器句柄。
 - `target` 目标 filter 名称。
-- `key` Key
-- `value` Value
+- `key` 属性键名。
+- `value` 属性值。
 
 **返回值**：
 
@@ -408,25 +405,24 @@ int media_player_set_property(void* handle, const char* target, const char* key,
 int media_player_get_property(void* handle, const char* target, const char* key, char* value, int value_len);
 ```
 
-获取 properties。
+获取播放器属性。
 
 **参数**：
 
 - `handle` 播放器句柄。
 - `target` 目标 filter 名称。
-- `key` Key
-- `value` 输出缓冲区。
-- `value_len` 缓冲区长度 of value
-
-
-## 异步接口（基于 libuv）
-
-以下接口仅在启用 `CONFIG_LIBUV` 时可用，回调在 `uv_loop` 上执行，避免阻塞调用线程。
+- `key` 属性键名。
+- `value` 输出缓冲区，用于存储属性值。
+- `value_len` 输出缓冲区长度。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 异步接口（基于 libuv）
+
+以下接口仅在启用 `CONFIG_LIBUV` 时可用，回调在 `uv_loop` 上执行，避免阻塞调用线程。
 
 ### media_uv_player_open
 
@@ -434,18 +430,18 @@ int media_player_get_property(void* handle, const char* target, const char* key,
 void* media_uv_player_open(void* loop, const char* stream, media_uv_callback on_open, void* cookie);
 ```
 
-打开 an async player with given 流 type。
+打开异步播放器。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
-- `stream` 流类型常量。 . 不同流类型有不同的路由逻辑.
+- `stream` 流类型常量，不同流类型有不同的路由逻辑。
 - `on_open` 打开完成后触发的回调函数。
 - `cookie` 回调上下文，供 `on_open`、`on_event`、`on_connection`、`on_close` 共用。
 
 **返回值**：
 
-void*    Handle of player, 失败时返回 NULL。
+成功时返回播放器句柄，失败时返回 `NULL`。
 
 
 ### media_uv_player_listen
@@ -454,7 +450,7 @@ void*    Handle of player, 失败时返回 NULL。
 int media_uv_player_listen(void* handle, media_event_callback on_event);
 ```
 
-Listen to status change 事件 by setting 回调。
+注册事件监听回调，接收播放状态变化通知。
 
 **参数**：
 
@@ -472,17 +468,17 @@ Listen to status change 事件 by setting 回调。
 int media_uv_player_close(void* handle, int pending, media_uv_callback on_close);
 ```
 
-关闭 the async player。
+关闭异步播放器。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `pending` 是否以 pending 方式关闭。
+- `pending` 是否以 pending 方式关闭（等待当前播放完成）。
 - `on_close` 资源释放完成后触发的回调函数。
 
 **返回值**：
 
-成功时返回 0，无效句柄时返回负的错误码。
+成功时返回 `0`，无效句柄时返回负的错误码。
 
 
 ### media_uv_player_prepare
@@ -491,7 +487,7 @@ int media_uv_player_close(void* handle, int pending, media_uv_callback on_close)
 int media_uv_player_prepare(void* handle, const char* url, const char* options, media_uv_object_callback on_connection, media_uv_callback on_prepare, void* cookie);
 ```
 
-准备 re音频源 for playing。
+准备音频源以供播放。
 
 **参数**：
 
@@ -499,12 +495,12 @@ int media_uv_player_prepare(void* handle, const char* url, const char* options, 
 - `url` 资源路径，支持两种模式：1. URL 模式：`url` 为本地文件路径或网络地址，框架会读取并播放；2. BUFFER 模式：`url` 为 `NULL`，调用方需通过 `media_player_write_data()` 或 `media_player_get_socket()` + `write()` 持续推送数据。
 - `options` 资源的额外配置参数，通常为描述资源格式的键值对（例如 `"format=s16le,sample_rate=44100,channels=2"`）。
 - `on_connection` BUFFER 模式下接收 `uv_pipe_t` 的回调函数。
-- `on_prepare` 结果回调函数。
-- `cookie` 回调参数 for `on_prepare`.
+- `on_prepare` 准备完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_player_reset
@@ -513,13 +509,13 @@ int media_uv_player_prepare(void* handle, const char* url, const char* options, 
 int media_uv_player_reset(void* handle, media_uv_callback on_reset, void* cookie);
 ```
 
-重置 player。
+重置播放器到初始状态。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_reset` 结果回调函数。
-- `cookie` 回调参数 for `on_reset`.
+- `on_reset` 重置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -532,14 +528,14 @@ int media_uv_player_reset(void* handle, media_uv_callback on_reset, void* cookie
 int media_uv_player_start_auto(void* handle, const char* scenario, media_uv_callback on_start, void* cookie);
 ```
 
-Play or resume the prepared 音频源 with auto 焦点 request。
+播放或恢复已准备的音频源，并自动请求音频焦点。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
 - `scenario` 场景常量，不同场景对应不同的焦点优先级。
-- `on_play` 结果确认回调（用于 request/start 操作）。
-- `cookie` 回调参数 for `on_play`.
+- `on_start` 播放开始后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -557,8 +553,8 @@ int media_uv_player_start(void* handle, media_uv_callback on_start, void* cookie
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_start` 结果回调函数。
-- `cookie` 回调参数 for `on_start`.
+- `on_start` 播放开始后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -571,13 +567,13 @@ int media_uv_player_start(void* handle, media_uv_callback on_start, void* cookie
 int media_uv_player_pause(void* handle, media_uv_callback on_pause, void* cookie);
 ```
 
-暂停 the playing。
+暂停播放。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_pause` 结果回调函数。
-- `cookie` 回调参数 for `on_pause`.
+- `on_pause` 暂停完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -590,13 +586,13 @@ int media_uv_player_pause(void* handle, media_uv_callback on_pause, void* cookie
 int media_uv_player_stop(void* handle, media_uv_callback on_stop, void* cookie);
 ```
 
-停止 the playing, clear the prepared re音频源 file。
+停止播放并清除已准备的音频源。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_stop` 结果回调函数。
-- `cookie` 回调参数 for `on_stop`.
+- `on_stop` 停止完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -609,18 +605,18 @@ int media_uv_player_stop(void* handle, media_uv_callback on_stop, void* cookie);
 int media_uv_player_set_volume(void* handle, float volume, media_uv_callback on_volume, void* cookie);
 ```
 
-设置 player 音量。
+设置播放音量。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `volume` Volume in [0.0, 1.0].
-- `on_volume` 结果回调函数。
-- `cookie` 回调参数 for `on_volume`.
+- `volume` 音量值，取值范围 `[0.0, 1.0]`。
+- `on_volume` 设置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_player_get_volume
@@ -629,14 +625,13 @@ int media_uv_player_set_volume(void* handle, float volume, media_uv_callback on_
 int media_uv_player_get_volume(void* handle, media_uv_float_callback on_volume, void* cookie);
 ```
 
-获取 播放器 handle 音量。
+获取当前播放音量。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `volume` 音量值，取值范围 `0.0 - 1.0`。
-- `on_volume` 结果回调函数。
-- `cookie` 回调参数 for `on_volume`.
+- `on_volume` 结果回调函数，回调参数为当前音量值（范围 `0.0 - 1.0`）。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -649,13 +644,13 @@ int media_uv_player_get_volume(void* handle, media_uv_float_callback on_volume, 
 int media_uv_player_get_playing(void* handle, media_uv_int_callback on_playing, void* cookie);
 ```
 
-获取 current playing status。
+获取当前播放状态。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_playing` 结果回调函数。
-- `cookie` 回调参数 for `on_playing`.
+- `on_playing` 结果回调函数，回调参数为播放状态。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -668,13 +663,13 @@ int media_uv_player_get_playing(void* handle, media_uv_int_callback on_playing, 
 int media_uv_player_get_position(void* handle, media_uv_unsigned_callback on_position, void* cookie);
 ```
 
-获取 current playing 位置。
+获取当前播放位置。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_position` 结果回调函数。
-- `cookie` 回调参数 for `on_position`.
+- `on_position` 结果回调函数，回调参数为当前位置（毫秒）。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -687,13 +682,13 @@ int media_uv_player_get_position(void* handle, media_uv_unsigned_callback on_pos
 int media_uv_player_get_duration(void* handle, media_uv_unsigned_callback on_duration, void* cookie);
 ```
 
-获取 时长 of current playing re音频源。
+获取当前音频源的总时长。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_duration` 结果回调函数。
-- `cookie` 回调参数 for `on_duration`.
+- `on_duration` 结果回调函数，回调参数为总时长（毫秒）。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -706,13 +701,13 @@ int media_uv_player_get_duration(void* handle, media_uv_unsigned_callback on_dur
 int media_uv_player_get_latency(void* handle, media_uv_unsigned_callback cb, void* cookie);
 ```
 
-获取 latency of current playing re音频源。
+获取当前音频源的播放延迟。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `cb` 结果回调函数。
-- `cookie` 回调参数 for `on_latency`.
+- `cb` 结果回调函数，回调参数为延迟帧数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -725,14 +720,14 @@ int media_uv_player_get_latency(void* handle, media_uv_unsigned_callback cb, voi
 int media_uv_player_set_looping(void* handle, int loop, media_uv_callback on_looping, void* cookie);
 ```
 
-设置 the loop times。
+设置循环播放次数。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
 - `loop` 循环次数，`-1` 表示无限循环。
-- `on_looping` 结果回调函数。
-- `cookie` 回调参数 for `on_looping`.
+- `on_looping` 设置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -745,14 +740,14 @@ int media_uv_player_set_looping(void* handle, int loop, media_uv_callback on_loo
 int media_uv_player_seek(void* handle, unsigned int position, media_uv_callback on_seek, void* cookie);
 ```
 
-跳转 to msec 位置 from begining。
+跳转到指定的播放位置。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `position` 起始位置，单位为毫秒。
-- `on_seek` 结果回调函数。
-- `cookie` 回调参数 for `on_seek`.
+- `position` 目标位置，单位为毫秒，从起始位置计算。
+- `on_seek` 跳转完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -765,16 +760,16 @@ int media_uv_player_seek(void* handle, unsigned int position, media_uv_callback 
 int media_uv_player_set_property(void* handle, const char* target, const char* key, const char* value, media_uv_callback on_setprop, void* cookie);
 ```
 
-设置 properties of 播放器 handle。
+设置播放器属性。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
 - `target` 目标 filter 名称。
-- `key` Key
-- `value` Value
-- `on_setprop` 结果回调函数。
-- `cookie` 回调参数 for `on_setprop`.
+- `key` 属性键名。
+- `value` 属性值。
+- `on_setprop` 设置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -787,15 +782,15 @@ int media_uv_player_set_property(void* handle, const char* target, const char* k
 int media_uv_player_get_property(void* handle, const char* target, const char* key, media_uv_string_callback on_getprop, void* cookie);
 ```
 
-获取 properties of 播放器 handle。
+获取播放器属性。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
 - `target` 目标 filter 名称。
-- `key` Key
-- `on_getprop` 结果回调函数。
-- `cookie` 回调参数 for `on_getprop`.
+- `key` 属性键名。
+- `on_getprop` 结果回调函数，回调参数为属性值字符串。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -808,17 +803,17 @@ int media_uv_player_get_property(void* handle, const char* target, const char* k
 int media_uv_player_query(void* handle, media_uv_object_callback on_query, void* cookie);
 ```
 
-Query 元数据 of 播放器 handle。
+查询播放器元数据。
 
 **参数**：
 
 - `handle` 异步播放器句柄。
-- `on_query` 接收元数据指针的回调函数。
-- `cookie` 回调参数 for `on_query`.
+- `on_query` 结果回调函数，回调参数为元数据指针。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_player_close_socket
@@ -831,8 +826,8 @@ int media_uv_player_close_socket(void* handle);
 
 **参数**：
 
-- `handle` 播放器句柄.
+- `handle` 播放器句柄。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。

--- a/zh-cn/api/framework/media/media_policy.md
+++ b/zh-cn/api/framework/media/media_policy.md
@@ -48,15 +48,11 @@ int media_policy_get_audio_mode(char* mode, int len);
 
 **参数**：
 
-- `mode` 缓冲区地址.
-- `len` 缓冲区长度.
+- `mode` 输出缓冲区。
+- `len` 缓冲区长度。
 
 
 ## 同步接口 - 设备使用
-
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
 
 
 ### media_policy_set_devices_use
@@ -69,7 +65,7 @@ int media_policy_set_devices_use(const char* devices);
 
 **参数**：
 
-- `devices` 设备常量, 支持多设备，用 "|" 分隔.
+- `devices` 设备常量，支持多设备，用 "|" 分隔。
 
 **返回值**：
 
@@ -86,7 +82,7 @@ int media_policy_set_devices_unuse(const char* devices);
 
 **参数**：
 
-- `devices` 设备常量, 支持多设备，用 "|" 分隔.
+- `devices` 设备常量，支持多设备，用 "|" 分隔。
 
 **返回值**：
 
@@ -104,7 +100,7 @@ int media_policy_get_devices_use(char* devices, int len);
 **参数**：
 
 - `devices` 设备名称字符串，多个设备用 `|` 分隔（例如 `"sco"`、`"sco|mic"`、`"<none>"`）。
-- `len` 缓冲区长度.
+- `len` 缓冲区长度。
 
 **返回值**：
 
@@ -121,15 +117,11 @@ int media_policy_is_devices_use(const char* devices, int* use);
 
 **参数**：
 
-- `devices` 设备常量, 支持多设备，用 "|" 分隔.
+- `devices` 设备常量，支持多设备，用 "|" 分隔。
 - `use` 设备使用状态：0 表示所有设备均未使用，1 表示至少有一个设备正在使用。
 
 
 ## 同步接口 - HFP 采样率与设备可用性
-
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
 
 
 ### media_policy_set_hfp_samplerate
@@ -138,7 +130,7 @@ int media_policy_is_devices_use(const char* devices, int* use);
 int media_policy_set_hfp_samplerate(int rate);
 ```
 
-设置 HFP 蓝牙通话采样率. * HFP (Hand Free Profile) is based on bt-sco, the samplerate is uncertain before negotiation is done。
+设置 HFP 蓝牙通话采样率。HFP（Hands-Free Profile）基于 BT-SCO 传输，采样率在协商完成前不确定。
 
 **参数**：
 
@@ -159,7 +151,7 @@ int media_policy_set_devices_available(const char* devices);
 
 **参数**：
 
-- `devices` 设备常量, 支持多设备，用 "|" 分隔.
+- `devices` 设备常量，支持多设备，用 "|" 分隔。
 
 **返回值**：
 
@@ -176,7 +168,7 @@ int media_policy_set_devices_unavailable(const char* devices);
 
 **参数**：
 
-- `devices` 设备常量, 支持多设备，用 "|" 分隔.
+- `devices` 设备常量，支持多设备，用 "|" 分隔。
 
 **返回值**：
 
@@ -189,7 +181,7 @@ int media_policy_set_devices_unavailable(const char* devices);
 int media_policy_get_devices_available(char* devices, int len);
 ```
 
-获取 current 可用 设备s。
+获取当前可用设备。
 
 **参数**：
 
@@ -207,20 +199,15 @@ int media_policy_get_devices_available(char* devices, int len);
 int media_policy_is_devices_available(const char* devices, int* available);
 ```
 
-检查 whether 设备s are 可用。
+检查指定设备是否可用。
 
 **参数**：
 
-- `devices` 待检查的设备，取值为 `MEDIA_DEVICE_*` 常量。
-设备 names are separated by "|"。
+- `devices` 待检查的设备，取值为 `MEDIA_DEVICE_*` 常量，多个设备用 `|` 分隔。
 - `available` 设备可用性状态：0 表示所有设备均不可用，1 表示至少有一个设备可用。
 
 
 ## 同步接口 - 静音控制
-
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
 
 
 ### media_policy_set_mute_mode
@@ -229,7 +216,7 @@ int media_policy_is_devices_available(const char* devices, int* available);
 int media_policy_set_mute_mode(int mute);
 ```
 
-设置 静音 mode。
+设置静音模式。
 
 **参数**：
 
@@ -246,7 +233,7 @@ int media_policy_set_mute_mode(int mute);
 int media_policy_get_mute_mode(int* mute);
 ```
 
-获取 静音 mode。
+获取当前静音模式。
 
 **参数**：
 
@@ -255,10 +242,6 @@ int media_policy_get_mute_mode(int* mute);
 
 ## 同步接口 - 音量控制
 
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
-
 
 ### media_policy_set_stream_volume
 
@@ -266,11 +249,11 @@ int media_policy_get_mute_mode(int* mute);
 int media_policy_set_stream_volume(const char* stream, int volume);
 ```
 
-设置 流 type 音量 index。
+设置指定流类型的音量档位。
 
 **参数**：
 
-- `stream` MEDIA_STREAM_XXX.
+- `stream` 流类型常量（`MEDIA_STREAM_*`）。
 - `volume` 新的音量档位。
 
 **返回值**：
@@ -284,11 +267,11 @@ int media_policy_set_stream_volume(const char* stream, int volume);
 int media_policy_get_stream_volume(const char* stream, int* volume);
 ```
 
-获取 流 type 音量 index。
+获取指定流类型的音量档位。
 
 **参数**：
 
-- `stream` MEDIA_STREAM_XXX.
+- `stream` 流类型常量（`MEDIA_STREAM_*`）。
 - `volume` 当前音量档位。
 
 **返回值**：
@@ -302,11 +285,11 @@ int media_policy_get_stream_volume(const char* stream, int* volume);
 int media_policy_increase_stream_volume(const char* stream);
 ```
 
-Increase 流 type 音量 index by 1。
+将指定流类型的音量档位加 1。
 
 **参数**：
 
-- `stream` MEDIA_STREAM_XXX.
+- `stream` 流类型常量（`MEDIA_STREAM_*`）。
 
 **返回值**：
 
@@ -319,18 +302,14 @@ Increase 流 type 音量 index by 1。
 int media_policy_decrease_stream_volume(const char* stream);
 ```
 
-Decrease 流 type 音量 index by 1。
+将指定流类型的音量档位减 1。
 
 **参数**：
 
-- `stream` MEDIA_STREAM_XXX.
+- `stream` 流类型常量（`MEDIA_STREAM_*`）。
 
 
 ## 同步接口 - 麦克风静音
-
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
 
 
 ### media_policy_set_mic_mute
@@ -348,10 +327,6 @@ int media_policy_set_mic_mute(int mute);
 
 ## 同步接口 - 通用参数读写
 
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
-
 
 ### media_policy_set_int
 
@@ -359,7 +334,7 @@ int media_policy_set_mic_mute(int mute);
 int media_policy_set_int(const char* name, int value, int apply);
 ```
 
-设置 numerical value to 策略条件。
+设置策略条件的数值。
 
 **参数**：
 
@@ -378,7 +353,7 @@ int media_policy_set_int(const char* name, int value, int apply);
 int media_policy_get_int(const char* name, int* value);
 ```
 
-获取 numerical value of 策略条件。
+获取策略条件的数值。
 
 **参数**：
 
@@ -396,7 +371,7 @@ int media_policy_get_int(const char* name, int* value);
 int media_policy_get_range(const char* name, int* min_value, int* max_value);
 ```
 
-获取 numerical value range of 策略条件。
+获取策略条件的数值范围。
 
 **参数**：
 
@@ -415,7 +390,7 @@ int media_policy_get_range(const char* name, int* min_value, int* max_value);
 int media_policy_set_string(const char* name, const char* value, int apply);
 ```
 
-设置 literal value to 策略条件。
+设置策略条件的字符串值。
 
 **参数**：
 
@@ -434,13 +409,13 @@ int media_policy_set_string(const char* name, const char* value, int apply);
 int media_policy_get_string(const char* name, char* value, int len);
 ```
 
-获取 literal value from 策略条件。
+获取策略条件的字符串值。
 
 **参数**：
 
 - `name` 准则名称。
-- `value` 缓冲区地址.
-- `len` 缓冲区长度.
+- `value` 输出缓冲区。
+- `len` 缓冲区长度。
 
 **返回值**：
 
@@ -491,7 +466,7 @@ int media_policy_exclude(const char* name, const char* values, int apply);
 int media_policy_contain(const char* name, const char* values, int* result);
 ```
 
-检查 whether literal values included in InclusiveCriterion。
+检查字面值是否包含在包含型条件中。
 
 **参数**：
 
@@ -548,7 +523,7 @@ int media_policy_decrease(const char* name, int apply);
 void* media_policy_subscribe(const char* name, media_policy_change_callback on_change, void* cookie);
 ```
 
-Subscribe 策略条件 on change。
+订阅策略条件变化事件。
 
 **参数**：
 
@@ -566,7 +541,7 @@ Subscribe 策略条件 on change。
 int media_policy_unsubscribe(void* handle);
 ```
 
-Unubscribe 策略条件 on change。
+取消订阅策略条件变化事件。
 
 **参数**：
 
@@ -578,10 +553,6 @@ Unubscribe 策略条件 on change。
 
 以下接口仅在启用 `CONFIG_LIBUV` 时可用。
 
-**返回值**：
-
-成功时返回 `0`，失败时返回负的 errno。
-
 
 ### media_uv_policy_set_int
 
@@ -589,7 +560,7 @@ Unubscribe 策略条件 on change。
 int media_uv_policy_set_int(void* loop, const char* name, int value, int apply, media_uv_callback cb, void* cookie);
 ```
 
-设置 numerical value to a 策略条件。
+设置策略条件的数值。
 
 **参数**：
 
@@ -598,7 +569,7 @@ int media_uv_policy_set_int(void* loop, const char* name, int value, int apply, 
 - `value` 要设置的数值。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -611,14 +582,14 @@ int media_uv_policy_set_int(void* loop, const char* name, int value, int apply, 
 int media_uv_policy_get_int(void* loop, const char* name, media_uv_int_callback cb, void* cookie);
 ```
 
-获取 numerical value of a 策略条件。
+获取策略条件的数值。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `name` 准则名称。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -631,7 +602,7 @@ int media_uv_policy_get_int(void* loop, const char* name, media_uv_int_callback 
 int media_uv_policy_increase(void* loop, const char* name, int apply, media_uv_callback cb, void* cookie);
 ```
 
-Increase numerical value of a 策略条件 by one。
+将策略条件的数值加 1。
 
 **参数**：
 
@@ -639,7 +610,7 @@ Increase numerical value of a 策略条件 by one。
 - `name` 准则名称。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -652,7 +623,7 @@ Increase numerical value of a 策略条件 by one。
 int media_uv_policy_set_string(void* loop, const char* name, const char* value, int apply, media_uv_callback cb, void* cookie);
 ```
 
-设置 literal value to a 策略条件。
+设置策略条件的字符串值。
 
 **参数**：
 
@@ -661,7 +632,7 @@ int media_uv_policy_set_string(void* loop, const char* name, const char* value, 
 - `value` 要设置的字符串值。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -674,14 +645,14 @@ int media_uv_policy_set_string(void* loop, const char* name, const char* value, 
 int media_uv_policy_get_string(void* loop, const char* name, media_uv_string_callback cb, void* cookie);
 ```
 
-获取 literal value of a 策略条件。
+获取策略条件的字符串值。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `name` 准则名称。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -694,7 +665,7 @@ int media_uv_policy_get_string(void* loop, const char* name, media_uv_string_cal
 int media_uv_policy_decrease(void* loop, const char* name, int apply, media_uv_callback cb, void* cookie);
 ```
 
-Decrease numerical value of a 策略条件 by one。
+将策略条件的数值减 1。
 
 **参数**：
 
@@ -702,7 +673,7 @@ Decrease numerical value of a 策略条件 by one。
 - `name` 准则名称。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -721,10 +692,10 @@ int media_uv_policy_include(void* loop, const char* name, const char* value, int
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `name` 准则名称。
-- `value` 字符串值数组。.
+- `value` 字符串值数组。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -743,10 +714,10 @@ int media_uv_policy_exclude(void* loop, const char* name, const char* value, int
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `name` 准则名称。
-- `value` 字符串值数组。.
+- `value` 字符串值数组。
 - `apply` 是否将新值应用到策略配置。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -759,15 +730,15 @@ int media_uv_policy_exclude(void* loop, const char* name, const char* value, int
 int media_uv_policy_contain(void* loop, const char* name, const char* value, media_uv_int_callback cb, void* cookie);
 ```
 
-检查 whether literal values included in InclusiveCriterion。
+检查字面值是否包含在包含型条件中。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `name` 准则名称。
-- `value` 字符串值数组。.
+- `value` 字符串值数组。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -780,7 +751,7 @@ int media_uv_policy_contain(void* loop, const char* name, const char* value, med
 int media_uv_policy_set_stream_volume(void* loop, const char* stream, int volume, media_uv_callback cb, void* cookie);
 ```
 
-设置 音量 of a 流 type。
+设置指定流类型的音量。
 
 **参数**：
 
@@ -788,7 +759,7 @@ int media_uv_policy_set_stream_volume(void* loop, const char* stream, int volume
 - `stream` 流类型，取值为流类型常量。
 - `volume` 要设置的音量档位。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -801,7 +772,7 @@ int media_uv_policy_set_stream_volume(void* loop, const char* stream, int volume
 int media_uv_policy_get_stream_volume(void* loop, const char* stream, media_uv_int_callback cb, void* cookie);
 ```
 
-获取 音量 of a 流 type。
+获取指定流类型的音量。
 
 **参数**：
 
@@ -809,7 +780,7 @@ int media_uv_policy_get_stream_volume(void* loop, const char* stream, media_uv_i
 - `stream` 流类型，取值为流类型常量。
 - `volume` 要设置的音量档位。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -822,14 +793,14 @@ int media_uv_policy_get_stream_volume(void* loop, const char* stream, media_uv_i
 int media_uv_policy_increase_stream_volume(void* loop, const char* stream, media_uv_callback cb, void* cookie);
 ```
 
-Increase 音量 of a 流 type。
+将指定流类型的音量加 1。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `stream` 流类型，取值为流类型常量。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -842,14 +813,14 @@ Increase 音量 of a 流 type。
 int media_uv_policy_decrease_stream_volume(void* loop, const char* stream, media_uv_callback cb, void* cookie);
 ```
 
-Decrease 音量 of a 流 type。
+将指定流类型的音量减 1。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `stream` 流类型，取值为流类型常量。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -869,7 +840,7 @@ int media_uv_policy_set_audio_mode(void* loop, const char* mode, media_uv_callba
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `mode` 新的音频模式。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -888,7 +859,7 @@ int media_uv_policy_get_audio_mode(void* loop, media_uv_string_callback cb, void
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -901,7 +872,7 @@ int media_uv_policy_get_audio_mode(void* loop, media_uv_string_callback cb, void
 int media_uv_policy_set_devices_use(void* loop, const char* devices, bool use, media_uv_callback cb, void* cookie);
 ```
 
-Force use/unuse 设备s (or protocols)。
+强制使用或取消使用指定设备（或协议）。
 
 **参数**：
 
@@ -909,7 +880,7 @@ Force use/unuse 设备s (or protocols)。
 - `devices` 目标设备。
 - `use` 将设备设置为使用或未使用状态。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -922,13 +893,13 @@ Force use/unuse 设备s (or protocols)。
 int media_uv_policy_get_devices_use(void* loop, media_uv_string_callback cb, void* cookie);
 ```
 
-获取 current force-use 设备s。
+获取当前强制使用的设备。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -941,14 +912,14 @@ int media_uv_policy_get_devices_use(void* loop, media_uv_string_callback cb, voi
 int media_uv_policy_is_devices_use(void* loop, const char* devices, media_uv_int_callback cb, void* cookie);
 ```
 
-检查 whether 设备s are being used。
+检查指定设备是否正在被使用。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `devices` 待检查的设备。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -961,18 +932,22 @@ int media_uv_policy_is_devices_use(void* loop, const char* devices, media_uv_int
 int media_uv_policy_set_hfp_samplerate(void* loop, int rate, media_uv_callback cb, void* cookie);
 ```
 
-设置 hfp(hands free protocol) sampling rate。
+设置 HFP（Hands-Free Profile）采样率。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `rate` 采样率，CVSD 编码取 8000，mSBC 编码取 16000。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
 成功时返回 0，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口已废弃，`rate` 参数将来会改为 `int` 类型。
 
 
 ### media_uv_policy_set_devices_available
@@ -981,7 +956,7 @@ int media_uv_policy_set_hfp_samplerate(void* loop, int rate, media_uv_callback c
 int media_uv_policy_set_devices_available(void* loop, const char* devices, bool available, media_uv_callback cb, void* cookie);
 ```
 
-设置 设备s 可用 or un可用。
+设置设备可用或不可用状态。
 
 **参数**：
 
@@ -989,7 +964,7 @@ int media_uv_policy_set_devices_available(void* loop, const char* devices, bool 
 - `devices` 目标设备。
 - `available` 将设备设置为可用或不可用状态。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -1002,13 +977,13 @@ int media_uv_policy_set_devices_available(void* loop, const char* devices, bool 
 int media_uv_policy_get_devices_available(void* loop, media_uv_string_callback cb, void* cookie);
 ```
 
-获取 current 可用 设备s。
+获取当前可用设备。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -1021,14 +996,14 @@ int media_uv_policy_get_devices_available(void* loop, media_uv_string_callback c
 int media_uv_policy_is_devices_available(void* loop, const char* devices, media_uv_int_callback cb, void* cookie);
 ```
 
-检查 whether 设备s are 可用。
+检查指定设备是否可用。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `devices` 待检查的设备。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -1041,14 +1016,14 @@ int media_uv_policy_is_devices_available(void* loop, const char* devices, media_
 int media_uv_policy_set_mute_mode(void* loop, int mute, media_uv_callback cb, void* cookie);
 ```
 
-设置 静音 mode。
+设置静音模式。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `mute` 新的静音模式。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -1061,13 +1036,13 @@ int media_uv_policy_set_mute_mode(void* loop, int mute, media_uv_callback cb, vo
 int media_uv_policy_get_mute_mode(void* loop, media_uv_int_callback cb, void* cookie);
 ```
 
-获取 静音 mode。
+获取当前静音模式。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -1087,7 +1062,7 @@ int media_uv_policy_set_mic_mute(void* loop, int mute, media_uv_callback cb, voi
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
 - `mute` 静音模式。
 - `cb` 结果回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 

--- a/zh-cn/api/framework/media/media_recorder.md
+++ b/zh-cn/api/framework/media/media_recorder.md
@@ -27,11 +27,11 @@ void* media_recorder_open(const char* params);
 
 **参数**：
 
-- `params` 源类型常量。 Usually MEDIA_SOURCE_MIC.
+- `params` 源类型常量，通常为 `MEDIA_SOURCE_MIC`。
 
 **返回值**：
 
-void*    录制器句柄 on success; NULL on failure。
+成功时返回录制器句柄，失败时返回 `NULL`。
 
 
 ### media_recorder_close
@@ -44,7 +44,7 @@ int media_recorder_close(void* handle);
 
 **参数**：
 
-- `handle` 录制器句柄
+- `handle` 录制器句柄。
 
 **返回值**：
 
@@ -57,13 +57,13 @@ int media_recorder_close(void* handle);
 int media_recorder_set_event_callback(void* handle, void* cookie, media_event_callback event_cb);
 ```
 
-设置录制器事件回调, the callback will be called when state changed or something user cares。
+设置录制器事件回调，当状态变化或发生用户关注的事件时触发回调。
 
 **参数**：
 
 - `handle` 录制器句柄。
-- `cookie` 用户数据，在 `event_cb` 触发时回传给用户，通常会被修改。
-- `on_event` 事件回调函数。
+- `cookie` 用户数据，在 `event_cb` 触发时回传给用户。
+- `event_cb` 事件回调函数。
 
 **返回值**：
 
@@ -80,7 +80,7 @@ int media_recorder_prepare(void* handle, const char* url, const char* options);
 
 **参数**：
 
-- `handle` 录制器句柄
+- `handle` 录制器句柄。
 - `url` 资源路径，支持两种模式：1. URL 模式：`url` 为本地文件路径，框架会打开并录制到该路径；2. BUFFER 模式：`url` 为 `NULL`，调用方需通过 `media_recorder_read_data()` 或 `media_recorder_get_socket()` + `read()` 持续接收数据。
 - `options` 额外配置参数，字段包括：format（封装格式，如 opus/wav）、sample_rate（采样率）、ch_layout（声道布局）、b（比特率，如 `"23900"`）、vbr（0=固定码率，1=可变码率）、level（编码复杂度，0-10，默认 10）。示例：`"format=opusraw:sample_rate=16000:ch_layout=mono:b=32000:vbr=0:level=1"`。
 
@@ -95,15 +95,15 @@ int media_recorder_prepare(void* handle, const char* url, const char* options);
 int media_recorder_reset(void* handle);
 ```
 
-重置录制器。
+重置录制器到初始状态。
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 同步接口 - 数据流
@@ -118,9 +118,9 @@ ssize_t media_recorder_read_data(void* handle, void* data, size_t len);
 
 **参数**：
 
-- `handle` 录制器句柄.
-- `data` 缓冲区地址.
-- `len` 缓冲区长度 to read.
+- `handle` 录制器句柄。
+- `data` 数据缓冲区地址。
+- `len` 要读取的数据长度（字节）。
 
 **返回值**：
 
@@ -137,12 +137,12 @@ int media_recorder_get_sockaddr(void* handle, struct sockaddr_storage* addr);
 
 **参数**：
 
-- `handle` 录制器句柄.
-- `addr` Socket 地址信息。
+- `handle` 录制器句柄。
+- `addr` 用于存储 Socket 地址信息的输出参数。
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_recorder_get_socket
@@ -155,11 +155,11 @@ int media_recorder_get_socket(void* handle);
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 **返回值**：
 
-成功时返回 `0`，失败时返回负的 errno。
+成功时返回 Socket 文件描述符，失败时返回负的错误码。
 
 
 ### media_recorder_close_socket
@@ -168,11 +168,11 @@ int media_recorder_get_socket(void* handle);
 void media_recorder_close_socket(void* handle);
 ```
 
-关闭 Socket fd when recorder finish recving data。
+关闭录制器数据接收完成后的 Socket 文件描述符。
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 
 ## 同步接口 - 录制控制
@@ -183,15 +183,15 @@ void media_recorder_close_socket(void* handle);
 int media_recorder_start(void* handle);
 ```
 
-开始/resume the recording the re音频源。
+开始或恢复录制。
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_recorder_pause
@@ -200,15 +200,15 @@ int 成功时返回 0，失败时返回负的错误码。
 int media_recorder_pause(void* handle);
 ```
 
-暂停 录制器 after capturing start。
+暂停录制。
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_recorder_stop
@@ -221,11 +221,11 @@ int media_recorder_stop(void* handle);
 
 **参数**：
 
-- `handle` 录制器句柄.
+- `handle` 录制器句柄。
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 同步接口 - 属性
@@ -236,14 +236,14 @@ int 成功时返回 0，失败时返回负的错误码。
 int media_recorder_set_property(void* handle, const char* target, const char* key, const char* value);
 ```
 
-设置 properties of 录制器 path。
+设置录制器属性。
 
 **参数**：
 
 - `handle` 录制器句柄。
-- `target` 目标 filter 名称。.
-- `key` 要设置的键名。
-- `value` 要设置的值。
+- `target` 目标 filter 名称。
+- `key` 属性键名。
+- `value` 属性值。
 
 **返回值**：
 
@@ -256,23 +256,22 @@ int media_recorder_set_property(void* handle, const char* target, const char* ke
 int media_recorder_get_property(void* handle, const char* target, const char* key, char* value, int value_len);
 ```
 
-获取 properties of 录制器 path。
+获取录制器属性。
 
 **参数**：
 
 - `handle` 录制器句柄。
-- `target` 目标 filter 名称。.
-- `key` 要设置的键名。
-- `value` 输出缓冲区。.
-- `value_len` 缓冲区长度 of value.
-
-
-## 同步接口 - 图片捕获
+- `target` 目标 filter 名称。
+- `key` 属性键名。
+- `value` 输出缓冲区，用于存储属性值。
+- `value_len` 输出缓冲区长度。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 同步接口 - 图片捕获
 
 ### media_recorder_take_picture
 
@@ -299,7 +298,7 @@ int media_recorder_take_picture(char* params, char* filename, size_t number);
 void* media_recorder_start_picture(char* params, char* filename, size_t number, media_event_callback event_cb, void* cookie);
 ```
 
-开始 taking picture, including open, set_事件_回调, prepare, and start operations。
+开始拍照，内部依次执行打开、设置事件回调、准备和启动操作。
 
 **参数**：
 
@@ -320,7 +319,7 @@ void* media_recorder_start_picture(char* params, char* filename, size_t number, 
 int media_recorder_finish_picture(void* handle);
 ```
 
-关闭 录制器 when taking picture finished。
+拍照完成后关闭录制器。
 
 **参数**：
 
@@ -328,7 +327,7 @@ int media_recorder_finish_picture(void* handle);
 
 **返回值**：
 
-int 成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 异步接口（基于 libuv）
@@ -341,7 +340,7 @@ int 成功时返回 0，失败时返回负的错误码。
 void* media_uv_recorder_open(void* loop, const char* source, media_uv_callback on_open, void* cookie);
 ```
 
-打开 an async recorder。
+打开异步录制器。
 
 **参数**：
 
@@ -352,7 +351,7 @@ void* media_uv_recorder_open(void* loop, const char* source, media_uv_callback o
 
 **返回值**：
 
-成功时返回录制器句柄。
+成功时返回录制器句柄，失败时返回 `NULL`。
 
 
 ### media_uv_recorder_listen
@@ -361,7 +360,7 @@ void* media_uv_recorder_open(void* loop, const char* source, media_uv_callback o
 int media_uv_recorder_listen(void* handle, media_event_callback on_event);
 ```
 
-Listen to status change 事件 by setting 回调。
+注册事件监听回调，接收录制状态变化通知。
 
 **参数**：
 
@@ -379,7 +378,7 @@ Listen to status change 事件 by setting 回调。
 int media_uv_recorder_close(void* handle, media_uv_callback on_close);
 ```
 
-关闭 the async recorder。
+关闭异步录制器。
 
 **参数**：
 
@@ -397,15 +396,16 @@ int media_uv_recorder_close(void* handle, media_uv_callback on_close);
 int media_uv_recorder_prepare(void* handle, const char* url, const char* options, media_uv_object_callback on_connection, media_uv_callback on_prepare, void* cookie);
 ```
 
-准备 destination file。
+准备录制目标文件。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
 - `url` 目标路径。
 - `options` 目标配置参数，详见 `media_recorder_prepare`。
-- `on_connection` * @param[in] on_prepare    结果回调，在 BUFFER 模式下会携带可写入数据的 `uv_pipe_t`。
-- `cookie` 一次性回调上下文。
+- `on_connection` BUFFER 模式下接收可写入数据的 `uv_pipe_t` 的回调函数。
+- `on_prepare` 准备完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -418,14 +418,14 @@ int media_uv_recorder_prepare(void* handle, const char* url, const char* options
 int media_uv_recorder_start_auto(void* handle, const char* stream, media_uv_callback on_start, void* cookie);
 ```
 
-开始 or resume the capturing with auto 焦点 request。
+开始或恢复录制，并自动请求音频焦点。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `scenario` 场景常量。 in media_defs.h.
-- `on_start` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `scenario` 场景常量（定义在 `media_defs.h` 中）。
+- `on_start` 录制开始后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -438,13 +438,13 @@ int media_uv_recorder_start_auto(void* handle, const char* stream, media_uv_call
 int media_uv_recorder_start(void* handle, media_uv_callback on_start, void* cookie);
 ```
 
-开始 or resume the capturing。
+开始或恢复录制。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `on_start` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `on_start` 录制开始后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -457,13 +457,13 @@ int media_uv_recorder_start(void* handle, media_uv_callback on_start, void* cook
 int media_uv_recorder_pause(void* handle, media_uv_callback on_pause, void* cookie);
 ```
 
-暂停 the capturing。
+暂停录制。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `on_pause` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `on_pause` 暂停完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -476,13 +476,13 @@ int media_uv_recorder_pause(void* handle, media_uv_callback on_pause, void* cook
 int media_uv_recorder_stop(void* handle, media_uv_callback on_stop, void* cookie);
 ```
 
-停止 the capturing, finish the destination file。
+停止录制并完成目标文件写入。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `on_stop` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `on_stop` 停止完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -495,16 +495,16 @@ int media_uv_recorder_stop(void* handle, media_uv_callback on_stop, void* cookie
 int media_uv_recorder_set_property(void* handle, const char* target, const char* key, const char* value, media_uv_callback cb, void* cookie);
 ```
 
-设置 properties of 录制器。
+设置录制器属性。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `target` 目标 filter 名称。.
-- `key` Key.
-- `value` Value.
-- `cb` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `target` 目标 filter 名称。
+- `key` 属性键名。
+- `value` 属性值。
+- `cb` 设置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -517,17 +517,15 @@ int media_uv_recorder_set_property(void* handle, const char* target, const char*
 int media_uv_recorder_get_property(void* handle, const char* target, const char* key, media_uv_string_callback cb, void* cookie);
 ```
 
-获取 properties of 录制器。
+获取录制器属性。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `target` 目标 filter 名称。.
-- `key` Key.
-- `value` 输出缓冲区。.
-- `value_len` 缓冲区长度 of value.
-- `cb` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `target` 目标 filter 名称。
+- `key` 属性键名。
+- `cb` 结果回调函数，回调参数为属性值字符串。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -540,13 +538,13 @@ int media_uv_recorder_get_property(void* handle, const char* target, const char*
 int media_uv_recorder_reset(void* handle, media_uv_callback on_reset, void* cookie);
 ```
 
-重置 录制器, clear the origin record and record new one。
+重置录制器，清除当前录制内容以准备新的录制。
 
 **参数**：
 
 - `handle` 异步录制器句柄。
-- `cb` 结果回调函数。
-- `cookie` 一次性回调上下文。
+- `on_reset` 重置完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -559,7 +557,7 @@ int media_uv_recorder_reset(void* handle, media_uv_callback on_reset, void* cook
 int media_uv_recorder_take_picture(void* loop, char* params, char* filename, size_t number, media_uv_callback on_complete, void* cookie);
 ```
 
-从摄像头拍照。
+从摄像头异步拍照。
 
 **参数**：
 
@@ -567,11 +565,9 @@ int media_uv_recorder_take_picture(void* loop, char* params, char* filename, siz
 - `params` 相机打开路径参数。
 - `filename` 新图片的存储路径。
 - `number` 拍摄图片的数量。
-- `on_complete` 处理结果的回调函数。
-- `cookie` 用户私有数据。
+- `on_complete` 拍照完成后的结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
-
-

--- a/zh-cn/api/framework/media/media_session.md
+++ b/zh-cn/api/framework/media/media_session.md
@@ -28,11 +28,11 @@ void* media_session_open(const char* params);
 
 **参数**：
 
-- `params` NULL, 暂未使用.
+- `params` 暂未使用，传 `NULL`。
 
 **返回值**：
 
-void*    控制器句柄, 失败时返回 NULL。
+成功时返回控制器句柄，失败时返回 `NULL`。
 
 
 ### media_session_close
@@ -45,7 +45,7 @@ int media_session_close(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -62,13 +62,13 @@ int media_session_set_event_callback(void* handle, void* cookie, media_event_cal
 
 **参数**：
 
-- `handle` 控制器句柄
-- `cookie` 回调参数 for `on_event`.
+- `handle` 控制器句柄。
+- `cookie` 回调上下文参数。
 - `on_event` 事件回调函数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 控制器接口 - 播放控制
@@ -83,7 +83,7 @@ int media_session_start(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -100,7 +100,7 @@ int media_session_stop(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -117,7 +117,7 @@ int media_session_pause(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -134,8 +134,8 @@ int media_session_seek(void* handle, unsigned position);
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `position` 起始位置，单位为毫秒。
+- `handle` 控制器句柄。
+- `position` 目标位置，单位为毫秒。
 
 **返回值**：
 
@@ -152,7 +152,7 @@ int media_session_prev_song(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -169,15 +169,14 @@ int media_session_next_song(void* handle);
 
 **参数**：
 
-- `handle` 控制器句柄.
-
-
-## 控制器接口 - 音量控制
+- `handle` 控制器句柄。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 控制器接口 - 音量控制
 
 ### media_session_increase_volume
 
@@ -185,11 +184,11 @@ int media_session_next_song(void* handle);
 int media_session_increase_volume(void* handle);
 ```
 
-请求 increase 音量。
+请求增大音量。
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -202,11 +201,11 @@ int media_session_increase_volume(void* handle);
 int media_session_decrease_volume(void* handle);
 ```
 
-请求 decrease 音量。
+请求减小音量。
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 
 **返回值**：
 
@@ -219,16 +218,20 @@ int media_session_decrease_volume(void* handle);
 int media_session_set_volume(void* handle, int volume);
 ```
 
-Rquest set 音量。
+请求设置音量。
 
 **参数**：
 
-- `handle` 控制器句柄.
+- `handle` 控制器句柄。
 - `volume` 音量档位。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现。
 
 
 ## 控制器接口 - 状态查询
@@ -239,16 +242,16 @@ Rquest set 音量。
 int media_session_query(void* handle, const media_metadata_t** data);
 ```
 
-Query 元数据 from most 活跃状态 controllee。
+查询当前最活跃被控端的元数据。
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `data` 用于接收元数据指针的输出指针。
+- `handle` 控制器句柄。
+- `data` 用于接收元数据指针的输出参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_session_get_state
@@ -257,16 +260,16 @@ Query 元数据 from most 活跃状态 controllee。
 int media_session_get_state(void* handle, int* state);
 ```
 
-获取 all status。
+获取当前播放状态。
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `state` 当前状态。
+- `handle` 控制器句柄。
+- `state` 输出参数，当前播放状态。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_session_get_position
@@ -275,16 +278,16 @@ int media_session_get_state(void* handle, int* state);
 int media_session_get_position(void* handle, unsigned* position);
 ```
 
-获取 msec 位置。
+获取当前播放位置。
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `position` 当前位置，单位为毫秒。
+- `handle` 控制器句柄。
+- `position` 输出参数，当前位置，单位为毫秒。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_session_get_duration
@@ -293,16 +296,16 @@ int media_session_get_position(void* handle, unsigned* position);
 int media_session_get_duration(void* handle, unsigned* duration);
 ```
 
-获取 msec 时长。
+获取当前音频源的总时长。
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `duration` 当前总时长，单位为毫秒。
+- `handle` 控制器句柄。
+- `duration` 输出参数，总时长，单位为毫秒。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_session_get_volume
@@ -311,16 +314,16 @@ int media_session_get_duration(void* handle, unsigned* duration);
 int media_session_get_volume(void* handle, int* volume);
 ```
 
-获取 current 音量 index。
+获取当前音量。
 
 **参数**：
 
-- `handle` 控制器句柄.
-- `volume` 音量档位。
+- `handle` 控制器句柄。
+- `volume` 输出参数，当前音量档位。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ## 被控端接口
@@ -331,16 +334,16 @@ int media_session_get_volume(void* handle, int* volume);
 void* media_session_register(void* cookie, media_event_callback on_event);
 ```
 
-注册 as a session controllee。
+注册为媒体会话被控端。
 
 **参数**：
 
-- `cookie` Callback arguemnt of `on_event`.
-- `on_event` 事件回调函数。.
+- `cookie` 回调上下文参数。
+- `on_event` 事件回调函数，用于接收控制命令。
 
 **返回值**：
 
-成功时返回被控端句柄，失败时返回 NULL。
+成功时返回被控端句柄，失败时返回 `NULL`。
 
 
 ### media_session_unregister
@@ -349,7 +352,7 @@ void* media_session_register(void* cookie, media_event_callback on_event);
 int media_session_unregister(void* handle);
 ```
 
-取消注册 会话 controllee。
+取消注册被控端。
 
 **参数**：
 
@@ -366,14 +369,14 @@ int media_session_unregister(void* handle);
 int media_session_notify(void* handle, int event, int result, const char* extra);
 ```
 
-通知 the result of control message. * After receive MEDIA_EVENT_* from `on_事件`, as controllee you should do something to handle the control message, after you acknowledge the control message, you should call this api to send response to 控制器。
+通知控制器控制命令的处理结果。被控端收到 `MEDIA_EVENT_*` 事件后，完成相应处理，再调用此接口向控制器发送响应。
 
 **参数**：
 
 - `handle` 被控端句柄。
-- `event` MEDIA_EVENT_*
+- `event` 要响应的事件类型（`MEDIA_EVENT_*`）。
 - `result` 操作结果，成功时为 `0`，失败时为负的 errno。
-- `extra` 附加消息。
+- `extra` 附加消息字符串，不需要时传 `NULL`。
 
 **返回值**：
 
@@ -386,22 +389,21 @@ int media_session_notify(void* handle, int event, int result, const char* extra)
 int media_session_update(void* handle, const media_metadata_t* data);
 ```
 
-Update 元数据 to session。
+向会话更新元数据。
 
 **参数**：
 
 - `handle` 被控端句柄。
 - `data` 要更新的元数据。
 
-
-## 异步接口（基于 libuv）
-
-以下接口仅在启用 `CONFIG_LIBUV` 时可用，控制器与被控端均有对应异步版本。
-
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
 
+
+## 异步接口（基于 libuv）
+
+以下接口仅在启用 `CONFIG_LIBUV` 时可用，控制器与被控端均有对应异步版本。
 
 ### media_uv_session_open
 
@@ -409,18 +411,18 @@ Update 元数据 to session。
 void* media_uv_session_open(void* loop, char* params, media_uv_callback on_open, void* cookie);
 ```
 
-打开 an async session controller。
+打开异步会话控制器。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
-- `params` 暂未使用.
+- `params` 暂未使用，传 `NULL`。
 - `on_open` 打开完成后触发的回调函数。
 - `cookie` 回调上下文，供 `on_open`、`on_event`、`on_close` 共用。
 
 **返回值**：
 
-成功时返回异步控制器句柄。
+成功时返回异步控制器句柄，失败时返回 `NULL`。
 
 
 ### media_uv_session_close
@@ -429,16 +431,16 @@ void* media_uv_session_open(void* loop, char* params, media_uv_callback on_open,
 int media_uv_session_close(void* handle, media_uv_callback on_close);
 ```
 
-关闭 the async controller handle。
+关闭异步控制器。
 
 **参数**：
 
-- `handle` 待销毁的异步控制器句柄。
+- `handle` 异步控制器句柄。
 - `on_close` 关闭完成后触发的回调函数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_session_listen
@@ -447,16 +449,16 @@ int media_uv_session_close(void* handle, media_uv_callback on_close);
 int media_uv_session_listen(void* handle, media_event_callback on_event);
 ```
 
-Listen to the 事件s from controllee。
+注册事件监听回调，接收被控端状态变化通知。
 
 **参数**：
 
-- `handle` Async 控制器句柄.
-- `on_event` 事件回调函数。.
+- `handle` 异步控制器句柄。
+- `on_event` 事件回调函数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_session_start
@@ -469,9 +471,9 @@ int media_uv_session_start(void* handle, media_uv_callback on_start, void* cooki
 
 **参数**：
 
-- `handle` Async 控制器句柄.
+- `handle` 异步控制器句柄。
 - `on_start` 结果回调函数。
-- `cookie` 回调参数 of `on_start`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -488,9 +490,9 @@ int media_uv_session_stop(void* handle, media_uv_callback on_stop, void* cookie)
 
 **参数**：
 
-- `handle` Async 控制器句柄.
+- `handle` 异步控制器句柄。
 - `on_stop` 结果回调函数。
-- `cookie` 回调参数 of `on_stop`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -507,9 +509,9 @@ int media_uv_session_pause(void* handle, media_uv_callback on_pause, void* cooki
 
 **参数**：
 
-- `handle` Async 控制器句柄.
+- `handle` 异步控制器句柄。
 - `on_pause` 结果回调函数。
-- `cookie` 回调参数 of `on_pause`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -526,10 +528,10 @@ int media_uv_session_seek(void* handle, unsigned position, media_uv_callback on_
 
 **参数**：
 
-- `handle` 播放器句柄。
-- `position` 起始位置，单位为毫秒。
+- `handle` 异步控制器句柄。
+- `position` 目标位置，单位为毫秒。
 - `on_seek` 结果回调函数。
-- `cookie` 回调参数 of `on_seek`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -546,9 +548,9 @@ int media_uv_session_prev_song(void* handle, media_uv_callback on_pre_song, void
 
 **参数**：
 
-- `handle` Async 控制器句柄.
-- `on_prev` 结果回调函数。
-- `cookie` 回调参数 of `on_prev`
+- `handle` 异步控制器句柄。
+- `on_pre_song` 结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -565,9 +567,9 @@ int media_uv_session_next_song(void* handle, media_uv_callback on_next, void* co
 
 **参数**：
 
-- `handle` Async 控制器句柄.
+- `handle` 异步控制器句柄。
 - `on_next` 结果回调函数。
-- `cookie` 回调参数 of `on_next`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -580,13 +582,13 @@ int media_uv_session_next_song(void* handle, media_uv_callback on_next, void* co
 int media_uv_session_increase_volume(void* handle, media_uv_callback on_increase, void* cookie);
 ```
 
-请求 increase 音量。
+请求增大音量。
 
 **参数**：
 
 - `handle` 异步控制器句柄。
 - `on_increase` 结果回调函数。
-- `cookie` 回调参数 of `on_increase`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -599,13 +601,13 @@ int media_uv_session_increase_volume(void* handle, media_uv_callback on_increase
 int media_uv_session_decrease_volume(void* handle, media_uv_callback on_decrease, void* cookie);
 ```
 
-请求 decrease 音量。
+请求减小音量。
 
 **参数**：
 
 - `handle` 异步控制器句柄。
 - `on_decrease` 结果回调函数。
-- `cookie` 回调参数 of `on_decrease`
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -623,13 +625,17 @@ int media_uv_session_set_volume(void* handle, int volume, media_uv_callback on_s
 **参数**：
 
 - `handle` 异步控制器句柄。
-- `Volume` 音量档位。
-- `on_volume` 结果回调函数。
-- `cookie` 回调参数 of `on_volume`
+- `volume` 音量档位。
+- `on_set_volume` 结果回调函数。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现。
 
 
 ### media_uv_session_query
@@ -643,12 +649,12 @@ int media_uv_session_query(void* handle, media_uv_object_callback on_query, void
 **参数**：
 
 - `handle` 异步控制器句柄。
-- `on_query` 接收元数据指针的回调函数。
-- `cookie` 回调参数.
+- `on_query` 结果回调函数，回调参数为元数据指针。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
 
 
 ### media_uv_session_get_state
@@ -657,17 +663,21 @@ int media_uv_session_query(void* handle, media_uv_object_callback on_query, void
 int media_uv_session_get_state(void* handle, media_uv_int_callback on_state, void* cookie);
 ```
 
-获取 current state。
+获取当前播放状态。
 
 **参数**：
 
-- `handle` Async 控制器句柄.
-- `on_state` 结果回调函数。
-- `cookie` 回调参数 of `on_state`
+- `handle` 异步控制器句柄。
+- `on_state` 结果回调函数，回调参数为当前状态。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现，请使用 `media_uv_session_query` 替代。
 
 
 ### media_uv_session_get_position
@@ -681,12 +691,16 @@ int media_uv_session_get_position(void* handle, media_uv_unsigned_callback on_po
 **参数**：
 
 - `handle` 异步控制器句柄。
-- `on_position` 结果回调函数。
-- `cookie` 回调参数 of `on_position`
+- `on_position` 结果回调函数，回调参数为当前位置（毫秒）。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现，请使用 `media_uv_session_query` 替代。
 
 
 ### media_uv_session_get_duration
@@ -695,17 +709,21 @@ int media_uv_session_get_position(void* handle, media_uv_unsigned_callback on_po
 int media_uv_session_get_duration(void* handle, media_uv_unsigned_callback on_duration, void* cookie);
 ```
 
-获取 current 时长。
+获取当前音频源的总时长。
 
 **参数**：
 
 - `handle` 异步控制器句柄。
-- `on_duration` 结果回调函数。
-- `cookie` 回调参数 of `on_duration`
+- `on_duration` 结果回调函数，回调参数为总时长（毫秒）。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现，请使用 `media_uv_session_query` 替代。
 
 
 ### media_uv_session_get_volume
@@ -714,17 +732,21 @@ int media_uv_session_get_duration(void* handle, media_uv_unsigned_callback on_du
 int media_uv_session_get_volume(void* handle, media_uv_int_callback on_get_volume, void* cookie);
 ```
 
-获取 current 音量。
+获取当前音量。
 
 **参数**：
 
 - `handle` 异步控制器句柄。
-- `on_volume` 结果回调函数。
-- `cookie` 回调参数 of `on_volume`
+- `on_get_volume` 结果回调函数，回调参数为当前音量档位。
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `0`，失败时返回负的错误码。
+
+**注意**：
+
+- 此接口尚未实现，请使用 `media_uv_session_query` 替代。
 
 
 ### media_uv_session_register
@@ -733,18 +755,18 @@ int media_uv_session_get_volume(void* handle, media_uv_int_callback on_get_volum
 void* media_uv_session_register(void* loop, const char* params, media_event_callback on_event, void* cookie);
 ```
 
-注册 as a session controllee to receive control message。
+注册为异步会话被控端，接收控制命令。
 
 **参数**：
 
 - `loop` 当前线程的 `uv_loop_t*` 事件循环句柄。
-- `params` 未使用，请传 `NULL`。
+- `params` 暂未使用，传 `NULL`。
 - `on_event` 接收控制消息的回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
-void*    Async controlee handle, 失败时返回 NULL。
+成功时返回异步被控端句柄，失败时返回 `NULL`。
 
 
 ### media_uv_session_unregister
@@ -753,12 +775,12 @@ void*    Async controlee handle, 失败时返回 NULL。
 int media_uv_session_unregister(void* handle, media_uv_callback on_release);
 ```
 
-取消注册 self。
+取消注册被控端。
 
 **参数**：
 
 - `handle` 异步被控端句柄。
-- `on_release` 调用方资源释放回调函数。
+- `on_release` 资源释放完成后的回调函数。
 
 **返回值**：
 
@@ -771,16 +793,16 @@ int media_uv_session_unregister(void* handle, media_uv_callback on_release);
 int media_uv_session_notify(void* handle, int event, int result, const char* extra, media_uv_callback on_notify, void* cookie);
 ```
 
-通知 the result of control message. * After receive MEDIA_EVENT_* from `on_事件`, as controllee you should do something to handle the control message, after you acknowledge the control message, you should call this api to send response to 控制器。
+通知控制器控制命令的处理结果。被控端收到 `MEDIA_EVENT_*` 事件后，完成相应处理，再调用此接口向控制器发送响应。
 
 **参数**：
 
 - `handle` 异步被控端句柄。
-- `event` 要通知的事件。
-- `result` 事件结果，成功时通常为 `0`，失败时为负的 errno。
-- `extra` 事件的附加字符串消息，不需要时传 `NULL`。
+- `event` 要响应的事件类型。
+- `result` 操作结果，成功时为 `0`，失败时为负的 errno。
+- `extra` 附加消息字符串，不需要时传 `NULL`。
 - `on_notify` 通知确认回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
@@ -793,17 +815,15 @@ int media_uv_session_notify(void* handle, int event, int result, const char* ext
 int media_uv_session_update(void* handle, const media_metadata_t* data, media_uv_callback on_update, void* cookie);
 ```
 
-Update 元数据 to session。
+向会话更新元数据。
 
 **参数**：
 
 - `handle` 异步被控端句柄。
 - `data` 要更新的元数据。
 - `on_update` 更新确认回调函数。
-- `cookie` 回调参数.
+- `cookie` 回调上下文参数。
 
 **返回值**：
 
 成功时返回 `0`，失败时返回负的 errno。
-
-

--- a/zh-cn/api/framework/media/media_utils.md
+++ b/zh-cn/api/framework/media/media_utils.md
@@ -9,7 +9,7 @@
 ## openvela 实现说明
 
 - **DTMF**：生成 `0-9` / `*#ABCD` 对应的 DTMF 双音多频信号，音频格式固定为 `format=s16le:sample_rate=8000:ch_layout=mono`（由 `MEDIA_TONE_DTMF_FORMAT` 宏定义）
-- **调试接口**：`media_graph_dump` 和 `media_policy_dump` 用于打印内部状态，便于问题定位
+- **调试接口**：`media_graph_dump`、`media_player_dump`、`media_recorder_dump` 和 `media_policy_dump` 用于打印内部状态，便于问题定位
 - **通用命令**：`media_process_command` 向 media server 发送自定义命令，用于扩展能力（如触发 graph 内某个 filter 的操作）
 - **事件名查询**：`media_event_get_name` 把 `MEDIA_EVENT_*` 数值转成可读字符串，便于日志输出
 
@@ -102,6 +102,33 @@ void media_policy_dump(const char* options);
 **参数**：
 
 - `options` dump 选项字符串。
+
+
+### media_player_dump
+
+```c
+void media_player_dump(const char* options);
+```
+
+打印 media player 内部状态，用于调试。
+
+**参数**：
+
+- `options` dump 选项字符串。
+
+
+### media_recorder_dump
+
+```c
+void media_recorder_dump(const char* options);
+```
+
+打印 media recorder 内部状态，用于调试。
+
+**参数**：
+
+- `options` dump 选项字符串。
+
 
 ## 通用命令
 

--- a/zh-cn/api/network/wapi.md
+++ b/zh-cn/api/network/wapi.md
@@ -216,7 +216,7 @@ int wapi_freq2chan(int sock, const char *ifname, double freq, int *chan);
 
 - `sock` 套接字描述符（用于 ioctl 操作）。
 - `ifname` 网络接口名称。
-- `freq` 频率, in Hz, to be converted to a 信道编号.
+- `freq` 频率（Hz），将被转换为信道编号。
 - `chan` 输出参数。
 
 ### wapi_chan2freq
@@ -229,7 +229,7 @@ int wapi_chan2freq(int sock, const char *ifname, int chan, double *freq);
 
 - `sock` 套接字描述符（用于 ioctl 操作）。
 - `ifname` 信道。
-- `chan` 信道 number to be converted to a frequency.
+- `chan` 信道编号，将被转换为频率。
 - `freq` 输出参数。
 
 ### wapi_get_essid
@@ -487,7 +487,7 @@ int wapi_scan_channel_init(int sock, const char *ifname, const char *essid, uint
 - `sock` 套接字描述符.
 - `ifname` 网络接口名称。
 - `essid` 要扫描的 ESSID。
-- `channels` 指向 an array of 信道编号s to scan.
+- `channels` 要扫描的信道编号数组。
 - `num_channels` 信道。
 
 **返回值**：
@@ -523,7 +523,7 @@ int wapi_escan_channel_init(int sock, const char *ifname, uint8_t scan_type, con
 - `ifname` 网络接口名称。
 - `scan_type` 扫描类型。
 - `essid` 要扫描的 ESSID。
-- `channels` 指向 an array of 信道编号s to scan.
+- `channels` 要扫描的信道编号数组。
 - `num_channels` 信道。
 
 **返回值**：


### PR DESCRIPTION
Fix incomplete/broken translations across media, bluetooth, and network API documentation where Chinese and English were mixed together in function descriptions, parameter explanations, and return values.

Changes:
- media: media_player, media_recorder, media_session, media_policy
- bluetooth: bt_a2dp, bt_hfp, bt_spp, bt_gap, bt_hid
- network: wapi
- media_utils: add missing media_player_dump and media_recorder_dump APIs (zh-cn + en)

