### PR TITLE
docs: fix incorrect return values and descriptions in API docs

### DIFF
--- a/en/api/framework/bluetooth/bt_a2dp.md
+++ b/en/api/framework/bluetooth/bt_a2dp.md
@@ -48,7 +48,7 @@ Unregister callback functions and stop receiving state change notifications.
 
 **Returns**:
 
-Returns the callback cookie on success, or NULL on failure or if already registered.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_a2dp_sink_is_connected
@@ -158,7 +158,7 @@ Unregister callback functions and stop receiving state change notifications.
 
 **Returns**:
 
-Returns the callback cookie on success, or NULL on failure or if already registered.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_a2dp_source_is_connected

--- a/en/api/framework/bluetooth/bt_device.md
+++ b/en/api/framework/bluetooth/bt_device.md
@@ -72,6 +72,7 @@ Gets the type of a remote device (Classic Bluetooth/BLE/Dual-mode).
 
 **Returns**:
 
+Returns the device type, see `bt_device_type_t`.
 
 
 ### bt_device_get_name
@@ -92,7 +93,7 @@ Gets the Bluetooth name of a remote device.
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_device_get_device_class
@@ -110,6 +111,7 @@ Gets the Class of Device of a remote device, containing major device class, mino
 
 **Returns**:
 
+Returns the 24-bit Class of Device value.
 
 
 ### bt_device_get_uuids
@@ -180,7 +182,7 @@ Gets the user-defined alias of a remote device; returns the device name if no al
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_device_set_alias
@@ -219,7 +221,7 @@ Check whether the connection to the remote device is established.
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` if connected, `false` otherwise.
 
 
 ### bt_device_is_encrypted
@@ -238,7 +240,7 @@ Query whether the connection to the remote device is encrypted.
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` if encrypted, `false` otherwise.
 
 
 ### bt_device_is_bond_initiate_local
@@ -257,7 +259,7 @@ Query whether the pairing with the remote device was initiated locally.
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` if bonding was initiated locally, `false` otherwise.
 
 
 ### bt_device_get_bond_state
@@ -297,7 +299,7 @@ Query whether the remote device is bonded.
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns `true` if bonded, `false` otherwise.
 
 
 ### bt_device_create_bond

--- a/en/api/framework/bluetooth/bt_gap.md
+++ b/en/api/framework/bluetooth/bt_gap.md
@@ -200,15 +200,13 @@ Sets the scan mode.
 **Parameters**:
 
 - `ins` Bluetooth client instance.
-- `mode` Mode.
+- `mode` Scan mode.
 - `bondable` Whether pairing is allowed.
-- `name` Output parameter, stores the adapter name.
-- `length` Buffer length.
 
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or a negative error code on failure.
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.
 
 
 #### bt_adapter_get_scan_mode
@@ -381,19 +379,12 @@ Gets the BLE IO capability.
 
 **Parameters**:
 
-- `ins` Bluetooth client instance, see bt_instance_t.
-- `mode` Debug mode.
-- `operation` Debug operation.
-- `appearance` BLE appearance value.
-- `addr` Device address.
-- `type` Address type.
-- `cap` IO capability value.
-- `num` Output parameter, stores the number of devices.
+- `ins` Bluetooth client instance.
 
 
 **Returns**:
 
-Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+Returns the BLE IO capability value.
 
 
 ## BLE Management

--- a/en/api/framework/bluetooth/bt_gatt.md
+++ b/en/api/framework/bluetooth/bt_gatt.md
@@ -33,7 +33,7 @@ Create a GATT client connection instance.
 
 **Returns**:
 
-No return value.
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.
 
 
 ### bt_gattc_delete_connect

--- a/en/api/framework/bluetooth/bt_hid.md
+++ b/en/api/framework/bluetooth/bt_hid.md
@@ -30,7 +30,7 @@ Unregister callback functions and stop receiving state change notifications.
 
 **Returns**:
 
-Returns the callback cookie on success, or NULL on failure.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_hid_device_register_app
@@ -148,6 +148,11 @@ Respond to a host HID report request.
 - `rpt_size` Report data size in bytes.
 
 
+**Returns**:
+
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+
+
 ### bt_hid_device_report_error
 
 ```c
@@ -163,6 +168,11 @@ Report an HID error to the host.
 - `error` Error code.
 
 
+**Returns**:
+
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+
+
 ### bt_hid_device_virtual_unplug
 
 ```c
@@ -175,3 +185,8 @@ Send a virtual unplug request to disconnect the HID connection.
 
 - `ins` Bluetooth client instance.
 - `addr` Bluetooth address of the remote device.
+
+
+**Returns**:
+
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.

--- a/en/api/framework/bluetooth/bt_pan.md
+++ b/en/api/framework/bluetooth/bt_pan.md
@@ -30,7 +30,7 @@ Unregister callback functions and stop receiving state change notifications.
 
 **Returns**:
 
-Returns the callback cookie on success, or NULL on failure.
+Returns `true` on success, `false` on failure.
 
 
 ### bt_pan_connect

--- a/en/api/framework/bluetooth/bt_spp.md
+++ b/en/api/framework/bluetooth/bt_spp.md
@@ -114,6 +114,11 @@ Initiate an insecure connection to the remote device.
 - `port` Port number.
 
 
+**Returns**:
+
+Returns BT_STATUS_SUCCESS on success, or an error code on failure.
+
+
 ### bt_spp_disconnect
 
 ```c

--- a/en/api/framework/media/media_policy.md
+++ b/en/api/framework/media/media_policy.md
@@ -965,6 +965,10 @@ Set the HFP (Hands-Free Profile) sampling rate.
 
 Returns 0 on success, or a negative error code on failure.
 
+**Note**:
+
+- This API is deprecated. The `rate` parameter will be changed to `int` type in the future.
+
 
 ### media_uv_policy_set_devices_available
 

--- a/en/api/framework/media/media_session.md
+++ b/en/api/framework/media/media_session.md
@@ -230,6 +230,10 @@ Request to set the volume.
 
 Returns 0 on success, or a negative error code on failure.
 
+**Note**:
+
+- This API is not implemented yet.
+
 
 ## Controller Interfaces - State Queries
 
@@ -632,6 +636,10 @@ Request to set the volume.
 
 Returns 0 on success, or a negative error code on failure.
 
+**Note**:
+
+- This API is not implemented yet.
+
 
 ### media_uv_session_query
 
@@ -670,6 +678,10 @@ Get the current state.
 
 Returns 0 on success, or a negative error code on failure.
 
+**Note**:
+
+- This API is not implemented yet. Use `media_uv_session_query` instead.
+
 
 ### media_uv_session_get_position
 
@@ -688,6 +700,10 @@ Get the current playback position.
 **Returns**:
 
 Returns 0 on success, or a negative error code on failure.
+
+**Note**:
+
+- This API is not implemented yet. Use `media_uv_session_query` instead.
 
 
 ### media_uv_session_get_duration
@@ -708,6 +724,10 @@ Get the current duration.
 
 Returns 0 on success, or a negative error code on failure.
 
+**Note**:
+
+- This API is not implemented yet. Use `media_uv_session_query` instead.
+
 
 ### media_uv_session_get_volume
 
@@ -726,6 +746,10 @@ Get the current volume.
 **Returns**:
 
 Returns 0 on success, or a negative error code on failure.
+
+**Note**:
+
+- This API is not implemented yet. Use `media_uv_session_query` instead.
 
 
 ### media_uv_session_register

--- a/en/api/framework/telephony/telephony_manager.md
+++ b/en/api/framework/telephony/telephony_manager.md
@@ -32,7 +32,7 @@ Open a Telephony connection and obtain a context handle.
 
 **Returns**:
 
-Returns 0 on success, or a negative error code on failure.
+Returns a valid `tapi_context` handle on success, or `NULL` on failure.
 
 
 
@@ -42,7 +42,7 @@ Returns 0 on success, or a negative error code on failure.
 tapi_context tapi_open_service(const char* client_name, tapi_client_ready_function callback, void* user_data, unsigned int tapi_service);
 ```
 
-Open a Telephony connection.
+Open a Telephony connection with a specified service type.
 
 **Parameters**:
 
@@ -53,7 +53,7 @@ Open a Telephony connection.
 
 **Returns**:
 
-Returns 0 on success, or a negative error code on failure.
+Returns a valid `tapi_context` handle on success, or `NULL` on failure.
 
 
 
@@ -87,11 +87,11 @@ Query whether a specified feature is supported.
 
 **Parameters**:
 
-- `feature` Feature name.
+- `feature` Feature type enum value.
 
 **Returns**:
 
-Returns 0 on success, or a negative error code on failure.
+Returns `true` if supported, `false` otherwise.
 
 
 

--- a/en/api/framework/telephony/telephony_sms.md
+++ b/en/api/framework/telephony/telephony_sms.md
@@ -83,7 +83,7 @@ Sets the SMSC (Short Message Service Center) address.
 
 **Returns**:
 
-Returns 0 on success, or a negative error code on failure.
+Returns `true` on success, `false` on failure.
 
 
 

--- a/zh-cn/api/framework/bluetooth/bt_device.md
+++ b/zh-cn/api/framework/bluetooth/bt_device.md
@@ -71,6 +71,8 @@ bt_device_type_t bt_device_get_device_type(bt_instance_t* ins, bt_address_t* add
 
 **返回值**：
 
+返回设备类型枚举值，参见 `bt_device_type_t`。
+
 
 
 ### bt_device_get_name
@@ -85,13 +87,13 @@ bool bt_device_get_name(bt_instance_t* ins, bt_address_t* addr, char* name, uint
 
 - `ins` 蓝牙客户端实例。
 - `addr` 远程设备蓝牙地址。
-- `name` 名称。
-- `length` 长度。
+- `name` 输出缓冲区，用于存储设备名称。
+- `length` 缓冲区长度。
 
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_device_get_device_class
@@ -108,6 +110,8 @@ uint32_t bt_device_get_device_class(bt_instance_t* ins, bt_address_t* addr);
 - `addr` 远程设备地址.
 
 **返回值**：
+
+返回 24 位 Class of Device 值，包含主设备类、子设备类和服务类信息。
 
 
 
@@ -172,12 +176,13 @@ bool bt_device_get_alias(bt_instance_t* ins, bt_address_t* addr, char* alias, ui
 
 - `ins` 蓝牙客户端实例, 参见 bt_instance_t.
 - `addr` 远程设备地址.
-- `length` 长度。- `alias` 输出参数，存储别名字符串。
+- `length` 缓冲区长度。
+- `alias` 输出参数，存储别名字符串。
 
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_device_set_alias
@@ -205,7 +210,7 @@ bt_status_t bt_device_set_alias(bt_instance_t* ins, bt_address_t* addr, const ch
 bool bt_device_is_connected(bt_instance_t* ins, bt_address_t* addr, bt_transport_t transport);
 ```
 
-发起与远程设备的连接。
+查询与远程设备是否已建立连接。
 
 **参数**：
 
@@ -215,7 +220,7 @@ bool bt_device_is_connected(bt_instance_t* ins, bt_address_t* addr, bt_transport
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+已连接时返回 `true`，未连接时返回 `false`。
 
 
 ### bt_device_is_encrypted
@@ -234,7 +239,7 @@ bool bt_device_is_encrypted(bt_instance_t* ins, bt_address_t* addr, bt_transport
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+已加密时返回 `true`，未加密时返回 `false`。
 
 
 ### bt_device_is_bond_initiate_local
@@ -253,7 +258,7 @@ bool bt_device_is_bond_initiate_local(bt_instance_t* ins, bt_address_t* addr, bt
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+由本地发起时返回 `true`，否则返回 `false`。
 
 
 ### bt_device_get_bond_state
@@ -293,7 +298,7 @@ bool bt_device_is_bonded(bt_instance_t* ins, bt_address_t* addr, bt_transport_t 
 
 **返回值**：
 
-成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
+已配对时返回 `true`，未配对时返回 `false`。
 
 
 ### bt_device_create_bond

--- a/zh-cn/api/framework/bluetooth/bt_gatt.md
+++ b/zh-cn/api/framework/bluetooth/bt_gatt.md
@@ -22,7 +22,7 @@ openvela 蓝牙 GATT（通用属性规范）接口，支持 BLE 数据属性的�
 bt_status_t bt_gattc_create_connect(bt_instance_t* ins, gattc_handle_t* phandle, gattc_callbacks_t* callbacks);
 ```
 
-发起与远程设备的连接。
+创建 GATT 客户端连接实例。
 
 **参数**：
 
@@ -33,7 +33,7 @@ bt_status_t bt_gattc_create_connect(bt_instance_t* ins, gattc_handle_t* phandle,
 
 **返回值**：
 
-无返回值。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_delete_connect
@@ -42,7 +42,7 @@ bt_status_t bt_gattc_create_connect(bt_instance_t* ins, gattc_handle_t* phandle,
 bt_status_t bt_gattc_delete_connect(gattc_handle_t conn_handle);
 ```
 
-发起与远程设备的连接。
+删除 GATT 客户端连接实例，释放相关资源。
 
 **参数**：
 
@@ -51,7 +51,7 @@ bt_status_t bt_gattc_delete_connect(gattc_handle_t conn_handle);
 
 **返回值**：
 
-建立连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_connect
@@ -89,7 +89,7 @@ bt_status_t bt_gattc_disconnect(gattc_handle_t conn_handle);
 
 **返回值**：
 
-断开连接。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_discover_service
@@ -107,7 +107,7 @@ bt_status_t bt_gattc_discover_service(gattc_handle_t conn_handle, bt_uuid_t* fil
 
 **返回值**：
 
-bt_gattc_discover_service 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_get_attribute_by_handle
@@ -287,7 +287,7 @@ bt_status_t bt_gattc_exchange_mtu(gattc_handle_t conn_handle, uint32_t mtu);
 
 **返回值**：
 
-bt_gattc_exchange_mtu 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_update_connection_parameter
@@ -296,7 +296,7 @@ bt_gattc_exchange_mtu 操作。
 bt_status_t bt_gattc_update_connection_parameter(gattc_handle_t conn_handle, uint32_t min_interval, uint32_t max_interval, uint32_t latency, uint32_t timeout, uint32_t min_connection_event_length, uint32_t max_connection_event_length);
 ```
 
-发起与远程设备的连接。
+更新 BLE 连接参数。
 
 **参数**：
 
@@ -320,7 +320,7 @@ bt_status_t bt_gattc_update_connection_parameter(gattc_handle_t conn_handle, uin
 bt_status_t bt_gattc_read_phy(gattc_handle_t conn_handle);
 ```
 
-读取远程设备的 GATT 特征值或描述符，结果通过回调异步返回。
+读取当前连接的 PHY 配置，结果通过回调异步返回。
 
 **参数**：
 
@@ -329,7 +329,7 @@ bt_status_t bt_gattc_read_phy(gattc_handle_t conn_handle);
 
 **返回值**：
 
-bt_gattc_read_phy 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gattc_update_phy
@@ -358,7 +358,7 @@ PHY 配置操作。
 bt_status_t bt_gattc_read_rssi(gattc_handle_t conn_handle);
 ```
 
-读取远程设备的 GATT 特征值或描述符，结果通过回调异步返回。
+读取远程设备的 RSSI 值，结果通过回调异步返回。
 
 **参数**：
 
@@ -367,7 +367,7 @@ bt_status_t bt_gattc_read_rssi(gattc_handle_t conn_handle);
 
 **返回值**：
 
-bt_gattc_read_rssi 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gatts_register_service
@@ -376,16 +376,18 @@ bt_gattc_read_rssi 操作。
 bt_status_t bt_gatts_register_service(bt_instance_t* ins, gatts_handle_t* phandle, gatts_callbacks_t* callbacks);
 ```
 
-注册GATT 服务。
+注册 GATT 服务。
 
 **参数**：
 
 - `ins` 蓝牙客户端实例。
-- `phandle` 输出参数，存储 GATT 客户端句柄。
+- `phandle` 输出参数，存储 GATT 服务句柄。
 - `callbacks` 回调函数集合。
 
 
 **返回值**：
+
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 
@@ -395,7 +397,7 @@ bt_status_t bt_gatts_register_service(bt_instance_t* ins, gatts_handle_t* phandl
 bt_status_t bt_gatts_unregister_service(gatts_handle_t srv_handle);
 ```
 
-取消注册GATT 服务。
+取消注册 GATT 服务。
 
 **参数**：
 
@@ -404,7 +406,7 @@ bt_status_t bt_gatts_unregister_service(gatts_handle_t srv_handle);
 
 **返回值**：
 
-bt_gatts_unregister_service 操作。
+成功时返回 BT_STATUS_SUCCESS，失败时返回错误码。
 
 
 ### bt_gatts_connect

--- a/zh-cn/api/framework/bluetooth/bt_pan.md
+++ b/zh-cn/api/framework/bluetooth/bt_pan.md
@@ -25,12 +25,12 @@ bool bt_pan_unregister_callbacks(bt_instance_t* ins, void* cookie);
 
 **参数**：
 
-- `cookie` 用户上下文。
 - `ins` 蓝牙客户端实例。
+- `cookie` 用户上下文。
 
 **返回值**：
 
-取消注册回调函数。
+成功时返回 `true`，失败时返回 `false`。
 
 
 ### bt_pan_connect

--- a/zh-cn/api/framework/telephony/telephony_manager.md
+++ b/zh-cn/api/framework/telephony/telephony_manager.md
@@ -32,7 +32,7 @@ tapi_context tapi_open(const char* client_name, tapi_client_ready_function callb
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回有效的 `tapi_context` 句柄，失败时返回 `NULL`。
 
 
 
@@ -42,7 +42,7 @@ tapi_context tapi_open(const char* client_name, tapi_client_ready_function callb
 tapi_context tapi_open_service(const char* client_name, tapi_client_ready_function callback, void* user_data, unsigned int tapi_service);
 ```
 
-打开 Telephony 连接。
+打开 Telephony 连接，指定服务类型。
 
 **参数**：
 
@@ -53,7 +53,7 @@ tapi_context tapi_open_service(const char* client_name, tapi_client_ready_functi
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回有效的 `tapi_context` 句柄，失败时返回 `NULL`。
 
 
 
@@ -87,11 +87,11 @@ bool tapi_is_feature_supported(tapi_feature_type feature);
 
 **参数**：
 
-- `feature` 功能名称。
+- `feature` 功能类型枚举值。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+支持时返回 `true`，不支持时返回 `false`。
 
 
 

--- a/zh-cn/api/framework/telephony/telephony_sms.md
+++ b/zh-cn/api/framework/telephony/telephony_sms.md
@@ -73,17 +73,17 @@ int tapi_sms_send_data_message(tapi_context context, int slot_id, int sms_id, ch
 bool tapi_sms_set_service_center_address(tapi_context context, int slot_id, char* number);
 ```
 
-发送数据短信。
+设置短信服务中心地址。
 
 **参数**：
 
 - `context` Telephony 上下文句柄。
 - `slot_id` SIM 卡槽 ID（0 或 1）。
-- `number` 电话号码。
+- `number` 服务中心号码。
 
 **返回值**：
 
-成功时返回 0，失败时返回负的错误码。
+成功时返回 `true`，失败时返回 `false`。
 
 
 


### PR DESCRIPTION
## Summary

Fix multiple inaccuracies across bluetooth, media and telephony API
documentation. The English docs in particular had several places where
return value descriptions or function descriptions did not match the
actual function signatures or behaviour. This PR brings them back in
line with the source headers and (in many cases) with the existing
Chinese version.

## Changes

### Return value corrections (bool functions)

Functions returning `bool` were previously documented as returning
`BT_STATUS_SUCCESS`. Updated to `true` / `false`:

- `bt_a2dp_sink_unregister_callbacks` / `bt_a2dp_source_unregister_callbacks`
- `bt_device_get_name`, `bt_device_get_alias`, `bt_device_is_connected`,
  `bt_device_is_encrypted`, `bt_device_is_bond_initiate_local`,
  `bt_device_is_bonded`
- `bt_hid_device_unregister_callbacks`, `bt_pan_unregister_callbacks`
- `tapi_is_feature_supported`, `tapi_sms_set_service_center_address`

### Return type corrections (handle / enum returning)

- `tapi_open` / `tapi_open_service` return a `tapi_context` handle or
  `NULL`, not 0 / negative errno
- `bt_device_get_device_type` returns a device type enum
- `bt_device_get_device_class` returns the 24-bit Class of Device
- `bt_adapter_get_le_io_capability` returns the IO capability value

### Description corrections

Several functions had copy-pasted "Initiate connection to remote device"
descriptions that did not match what the function actually does:

- `bt_gattc_create_connect` → creates a GATT client connection instance
- `bt_gattc_delete_connect` → deletes the instance and frees resources
- `bt_gattc_read_phy` → reads the current PHY configuration
- `bt_gattc_read_rssi` → reads the remote RSSI
- `bt_gattc_update_connection_parameter` → updates BLE connection parameters
- `bt_device_is_connected` → query, not initiate
- `tapi_sms_set_service_center_address` → set SMSC address, not send SMS

### Parameter list cleanup

`bt_adapter_set_scan_mode` and `bt_adapter_get_le_io_capability` had
parameters from unrelated functions (`name`, `length`, `appearance`,
`cap`, `num`, etc.) that were not actually in the signature. Removed.

### Missing Returns sections

Added missing `Returns` sections (English version was missing what the
Chinese version already had):

- `bt_hid_device_send_report`, `bt_hid_device_report_error`,
  `bt_hid_device_virtual_unplug`
- `bt_spp_connect_insecure`

### Notes added

- `media_uv_policy_set_hfp_sample_rate`: marked deprecated
- `media_uv_session` getters (state, position, duration, volume) and
  `set_volume`: marked not-yet-implemented, with pointer to
  `media_uv_session_query` where appropriate

### Placeholder parameter descriptions

Replaced `name 名称` / `length 长度` style stubs with meaningful
descriptions in `bt_device_get_name` / `bt_device_get_alias`.

## Verification

- Cross-checked descriptions against the function signatures shown in
  the docs themselves and the corresponding Chinese versions
- 16 files changed, +114 / -66
- No content beyond the items listed above is touched
