### PR TITLE
docs(contest_2026): add minimum NSH baseline defconfig reference for Hardware Porting Track

### DIFF
--- a/en/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md
+++ b/en/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md
@@ -1,0 +1,289 @@
+# Minimum Bootable NSH System defconfig Reference
+
+\[ English | [简体中文](../../../../zh-cn/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md) \]
+
+This document targets contestants of the Hardware Porting Track. The goal is to help contestants **boot to the NSH command-line prompt on their development board first**. The recommended workflow is: start from the minimum set provided in this document, verify that the serial console and NSH work correctly, and then incrementally enable subsystems such as filesystem, networking, and sensors.
+
+## 1. Overview
+
+### 1.1 Document goal
+
+When a contestant receives a development board not yet supported by openvela, the most critical first step is to bring the system up to the NSH command-line prompt. This document provides a **bare-minimum** reference defconfig that contains only the configuration items required to boot NSH, helping contestants quickly identify:
+
+- Which CONFIGs **must be modified** (strongly tied to target hardware);
+- Which CONFIGs **can be reused as-is** (hardware-independent runtime support);
+- After L0 brings up, in which order to **incrementally enable** subsystems.
+
+### 1.2 Recommended workflow
+
+```
+Step 0: Hardware ready
+        - Target chip is supported under nuttx/arch/<arch>/src/<chip>/
+        - Board directory exists at boards/<arch>/<chip>/<board>/
+        - Serial TX/RX pins are connected to the host
+        ↓
+Step 1: Apply this minimum set → build → flash → see NSH prompt on console
+        ↓
+Step 2: Incrementally enable subsystems based on hardware capability
+        - Filesystem (FAT / LittleFS)
+        - Networking stack (Ethernet / Wi-Fi)
+        - Graphics (LCD / framebuffer / LVGL)
+        - Sensors (uORB / I2C / SPI sensors)
+        ↓
+Step 3: Trim for release once porting stabilizes
+        - Disable DEBUG_*, ALLSYMS, and similar debug items
+        - Adjust stack sizes based on measured needs
+```
+
+## 2. Minimum NSH required configuration
+
+The configuration items in this section are derived from `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` (35 lines), and also draw on Mateusz Szafoni's [NuttX small systems blog series](https://www.railab.me/tags/small-systems/) for practical minimization techniques.
+
+### 2.1 Architecture and board identity (Must be replaced for the target hardware)
+
+```
+CONFIG_ARCH="arm"
+CONFIG_ARCH_CHIP="stm32"
+CONFIG_ARCH_CHIP_STM32=y
+CONFIG_ARCH_CHIP_STM32F303RE=y
+CONFIG_ARCH_BOARD="nucleo-f303re"
+CONFIG_ARCH_BOARD_NUCLEO_F303RE=y
+```
+
+#### Replacement guidelines
+
+| Item | Replacement guideline |
+| ---- | ---- |
+| `CONFIG_ARCH=` | Target CPU architecture, e.g. `"arm"`, `"arm64"`, `"risc-v"`, `"xtensa"` |
+| `CONFIG_ARCH_CHIP=` and `CONFIG_ARCH_CHIP_<FAMILY>=y` | Target SoC family, must match `nuttx/arch/<arch>/src/<chip>/` (e.g. `stm32`, `stm32h7`, `nrf52`, `esp32s3`) |
+| `CONFIG_ARCH_CHIP_<DEVICE>=y` | Specific device, e.g. `STM32F407VG`, `NRF52840`, `ESP32S3` |
+| `CONFIG_ARCH_BOARD=` and `CONFIG_ARCH_BOARD_<NAME>=y` | Board directory name, must match `nuttx/boards/<arch>/<chip>/<board>/` |
+
+### 2.2 Memory layout (Must be filled in per target hardware)
+
+```
+CONFIG_RAM_START=0x20000000
+CONFIG_RAM_SIZE=65536
+CONFIG_MM_REGIONS=2
+CONFIG_BOARD_LOOPSPERMSEC=6522
+```
+
+#### Item descriptions
+
+- `CONFIG_RAM_START`: starting physical address of the main SRAM, refer to the target chip's datasheet (most ARM Cortex-M chips use `0x20000000`).
+- `CONFIG_RAM_SIZE`: main SRAM size in bytes.
+- `CONFIG_MM_REGIONS`: number of memory regions managed by the heap allocator. Adjust accordingly when the chip has multiple discontiguous SRAM blocks (e.g. STM32F4's CCM, STM32H7's AXI/AHB SRAM).
+- `CONFIG_BOARD_LOOPSPERMSEC`: busy-wait delay calibration value, related to CPU frequency. May be filled with an estimated value initially and calibrated later via `up_mdelay()`.
+
+### 2.3 Serial console (Must be replaced per target hardware)
+
+```
+CONFIG_STM32_USART2=y
+CONFIG_USART2_SERIAL_CONSOLE=y
+CONFIG_STM32_JTAG_SW_ENABLE=y
+```
+
+#### Replacement guidelines
+
+| Item | Replacement guideline |
+| ---- | ---- |
+| `CONFIG_<CHIP>_USART<N>=y` | Enable the target chip's UART peripheral. STM32 uses `STM32_USARTx`, nRF52 uses `NRF52_UART0`, ESP32 uses `ESP32_UART0` |
+| `CONFIG_USART<N>_SERIAL_CONSOLE=y` | Designate that UART as the system console |
+| `CONFIG_<CHIP>_JTAG_SW_ENABLE=y` | Optional per chip; preserves the SWD debug port |
+
+Refer to `board.h` under `nuttx/boards/<arch>/<chip>/<board>/include/` for pin definitions and confirm that the serial port maps to TX/RX pins matching your hardware design.
+
+### 2.4 NSH Shell entry point (Reuse as-is)
+
+```
+CONFIG_SYSTEM_NSH=y
+CONFIG_INIT_ENTRYPOINT="nsh_main"
+```
+
+#### Item descriptions
+
+- `CONFIG_SYSTEM_NSH=y`: builds NSH as a system application.
+- `CONFIG_INIT_ENTRYPOINT="nsh_main"`: makes NSH the first user-mode task after system boot. Once the serial console is connected, the command-line prompt appears.
+
+### 2.5 Scheduling and runtime support (Reuse as-is)
+
+```
+CONFIG_RR_INTERVAL=200
+CONFIG_SCHED_WAITPID=y
+CONFIG_PREALLOC_TIMERS=4
+CONFIG_IDLETHREAD_STACKSIZE=2048
+CONFIG_TASK_NAME_SIZE=0
+CONFIG_START_DAY=27
+CONFIG_START_YEAR=2013
+```
+
+#### Item descriptions
+
+- `CONFIG_RR_INTERVAL=200`: round-robin scheduling time slice of 200 ms.
+- `CONFIG_SCHED_WAITPID=y`: enables the `waitpid()` syscall, which NSH relies on when running built-in commands.
+- `CONFIG_PREALLOC_TIMERS=4`: pre-allocates 4 POSIX timers, sufficient for basic needs.
+- `CONFIG_IDLETHREAD_STACKSIZE=2048`: idle-thread stack size. 2 KB is suitable for most Cortex-M boards. Reduce to 1024 if RAM is tight.
+- `CONFIG_TASK_NAME_SIZE=0`: disables task-name strings to save RAM. Set to 16~32 if the `ps` command is needed to display task names.
+- `CONFIG_START_DAY` and `CONFIG_START_YEAR`: initial date when the system boots; can be set to any reasonable values.
+
+### 2.6 Debug and diagnostics (Strongly recommended to retain)
+
+```
+CONFIG_DEBUG_SYMBOLS=y
+CONFIG_ARCH_STACKDUMP=y
+CONFIG_INTELHEX_BINARY=y
+CONFIG_RAW_BINARY=y
+```
+
+#### Item descriptions
+
+- `CONFIG_DEBUG_SYMBOLS=y`: retains debug symbols for GDB single-stepping and backtrace analysis.
+- `CONFIG_ARCH_STACKDUMP=y`: prints stack contents on hardfault — an essential aid during the porting phase.
+- `CONFIG_INTELHEX_BINARY=y` and `CONFIG_RAW_BINARY=y`: produce both `.hex` and `.bin` artifacts after the build.
+
+### 2.7 CPU feature trimming (Adjust as needed)
+
+```
+# CONFIG_ARCH_FPU is not set
+```
+
+#### Description
+
+`CONFIG_ARCH_FPU` controls whether the hardware floating-point unit is enabled. Cortex-M4F, M7 and similar cores with FPU should set `CONFIG_ARCH_FPU=y` if floating-point operations are required. Cortex-M0/M3 cores have no FPU and should leave it disabled.
+
+### 2.8 Board-level helpers (Optional)
+
+```
+CONFIG_ARCH_BUTTONS=y
+```
+
+#### Description
+
+`CONFIG_ARCH_BUTTONS=y`: enables the button driver framework when the board has a USER button. Omit if the target board has no buttons.
+
+## 3. Reusable defconfig fragment
+
+The following 13 items are hardware-independent and may be used as-is on any ARM Cortex-M board:
+
+```
+CONFIG_RR_INTERVAL=200
+CONFIG_SCHED_WAITPID=y
+CONFIG_PREALLOC_TIMERS=4
+CONFIG_IDLETHREAD_STACKSIZE=2048
+CONFIG_TASK_NAME_SIZE=0
+CONFIG_START_DAY=27
+CONFIG_START_YEAR=2013
+CONFIG_SYSTEM_NSH=y
+CONFIG_INIT_ENTRYPOINT="nsh_main"
+CONFIG_DEBUG_SYMBOLS=y
+CONFIG_ARCH_STACKDUMP=y
+CONFIG_INTELHEX_BINARY=y
+CONFIG_RAW_BINARY=y
+```
+
+Contestants only need to fill in the hardware-specific items marked "Must be replaced per target hardware" in Section 2 (architecture identity, memory layout, serial console) to form a complete L0 defconfig.
+
+## 4. Reference implementations
+
+### 4.1 Nucleo-F303RE (recommended reference board)
+
+Full defconfig path:
+
+```
+nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig
+```
+
+This board is built around the STM32F303RE (Cortex-M4F @ 72 MHz, 512 KB Flash, 64 KB SRAM) and integrates the ST-Link/V2-1 debugger with a USB virtual serial port. With a single USB cable, contestants can perform both flashing and serial communication, making it the most convenient hardware reference for verifying the minimum-NSH workflow.
+
+### 4.2 Other minimal NSH defconfigs for reference
+
+| Reference board | Path | Lines | Use case |
+| ---- | ---- | ---- | ---- |
+| Nucleo-F303RE | `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` | 35 | Mainstream ARM Cortex-M4F reference |
+| nRF52840-DK | `nuttx/boards/arm/nrf52/nrf52840-dk/configs/nsh/defconfig` | 41 | Reference for the Nordic nRF52 family |
+| STM32F411-Minimum | `nuttx/boards/arm/stm32/stm32f411-minimum/configs/nsh/defconfig` | 46 | STM32F4 with constrained resources |
+| STM32F4Discovery | `nuttx/boards/arm/stm32/stm32f4discovery/configs/nsh/defconfig` | 50 | Classic STM32F4 evaluation board (includes some extras) |
+
+## 5. Incrementally enabling subsystems
+
+Once L0 boots successfully (the NSH prompt is visible on the serial console), subsystems can be enabled progressively per the target board's capability. Common CONFIG entry points for each subsystem are:
+
+| Subsystem | Primary CONFIG entry points |
+| ---- | ---- |
+| Filesystem (FAT, LittleFS, PROCFS) | `CONFIG_FS_FAT`, `CONFIG_FS_LITTLEFS`, `CONFIG_FS_PROCFS` |
+| Networking stack (TCP/IP, Wi-Fi) | `CONFIG_NET`, `CONFIG_NET_TCP`, `CONFIG_NET_UDP` |
+| Graphics and display (fb, LCD, LVGL) | `CONFIG_VIDEO_FB`, `CONFIG_GRAPHICS_LVGL` |
+| Sensors and uORB | `CONFIG_SENSORS`, `CONFIG_UORB` |
+| Bluetooth (BLE) | `CONFIG_BLUETOOTH`, `CONFIG_NIMBLE` |
+| Audio | `CONFIG_AUDIO` |
+| Power management | `CONFIG_PM` |
+
+Contestants may also refer to `vendor/openvela/boards/vela/configs/goldfish-x86_64-ap/defconfig` (253 lines) as a reference example of openvela's full CONFIG set with all subsystems enabled, useful as a comparison baseline when adding subsystems incrementally.
+
+## 6. Functional validation
+
+Once subsystems are enabled, it is recommended to validate functional completeness on the target hardware using standardized test cases. The openvela community maintains an xTS test case collection for community developers, covering peripheral drivers, filesystem, networking, media, and other subsystems, which can serve as a functional acceptance reference once a subsystem has been enabled.
+
+### 6.1 Recommended usage
+
+- **L0 boot validation**: after the minimum set in this document brings up NSH, manually run commands such as `help`, `uname`, and `ps` on the serial console to verify basic shell and syscall behavior.
+- **Subsystem functional validation**: after enabling each subsystem, run the corresponding test cases from the xTS collection (e.g. run the SPI_I2C tests after enabling the SPI/I2C drivers).
+- **Regression validation**: once porting stabilizes, the full xTS suite can serve as a regression set for verifying functionality after subsequent configuration changes.
+
+### 6.2 xTS coverage areas
+
+| Test topic | Applicable scenario |
+| ---- | ---- |
+| SPI / I2C drivers | Validate bus communication after peripheral drivers are enabled (includes a BMI160 sensor example) |
+| Ymodem file transfer | Validate serial-port file transfer capability |
+| mediatool media tests | Validate audio/video codec and playback pipelines |
+| Wi-Fi compatibility | Verified-router list and connection-stability validation |
+| Self-test framework (cmocka) | How to use the framework when authoring custom unit tests |
+
+For detailed test steps, test resources, and dependency configurations, refer to the [openvela Community Developer xTS Test Case Collection (zh-cn)](../../../../zh-cn/test_dev_guide/openvela_xts_test_cases.md) and the [openvela Test Framework Usage Guide](../../../test_dev_guide/openvela_testcase_dev_guide.md). The xTS test case collection is currently available in Chinese only.
+
+## 7. New-hardware adaptation Checklist
+
+After completing BSP porting, contestants are advised to validate the defconfig and target-hardware compatibility against the following checklist:
+
+- [ ] `CONFIG_ARCH`, `CONFIG_ARCH_CHIP`, and `CONFIG_ARCH_BOARD` have been replaced with target-hardware identifiers
+- [ ] `CONFIG_RAM_START` and `CONFIG_RAM_SIZE` have been filled in per the target chip's datasheet
+- [ ] For chips with multiple SRAM regions (e.g. STM32F4 with CCM), `CONFIG_MM_REGIONS` has been set correctly
+- [ ] The serial peripheral macro (e.g. `CONFIG_STM32_USART2=y`) has been switched to the target chip's UART
+- [ ] `CONFIG_USART<N>_SERIAL_CONSOLE=y` is consistent with the pin definitions in `board.h`
+- [ ] The serial baud rate defaults to 115200 and matches the host terminal
+- [ ] `CONFIG_SYSTEM_NSH=y` and `CONFIG_INIT_ENTRYPOINT="nsh_main"` are enabled
+- [ ] `CONFIG_DEBUG_SYMBOLS=y` and `CONFIG_ARCH_STACKDUMP=y` are enabled to aid boot-issue diagnostics
+- [ ] Cores with FPU (M4F/M7) have `CONFIG_ARCH_FPU=y`; cores without FPU (M0/M3) keep it disabled
+- [ ] `CONFIG_BOARD_LOOPSPERMSEC` has an initial estimate based on the CPU frequency
+
+After passing the checklist, run `./build.sh <vendor>:<config> -j` to build. After flashing, when the serial console is connected and the `nsh> ` prompt appears, L0 has booted successfully.
+
+## 8. References
+
+### 8.1 openvela internal references
+
+| Resource | Description |
+| ---- | ---- |
+| `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` | Recommended L0 reference defconfig (35 lines) |
+| `nuttx/boards/arm/stm32/nucleo-f303re/include/board.h` | Board-level clock and pin reference |
+| `nuttx/boards/arm/nrf52/nrf52840-dk/configs/nsh/defconfig` | Minimum NSH reference for the nRF52 platform |
+| `nuttx/boards/sim/sim/sim/configs/nsh/defconfig` | Toolchain self-check reference |
+| `vendor/openvela/boards/vela/configs/goldfish-x86_64-ap/defconfig` | Full-subsystem example (253 lines), useful as a reference when enabling subsystems incrementally |
+| [openvela Chip Porting Guide](../../../chip_porting/porting_guide.md) | Complete BSP porting workflow from scratch |
+| [Hardware Porting Track Guide (zh-cn)](../../../../zh-cn/contest_2026/hardware_porting/hardware_porting_track_guide.md) | Track description, scoring criteria and reference resources (Chinese only at this stage) |
+| [Kconfig Usage Guide](../../../device_dev_guide/build/Kconfig.md) | Detailed explanation of the relationship between menuconfig, defconfig, and .config |
+| [openvela Community Developer xTS Test Case Collection (zh-cn)](../../../../zh-cn/test_dev_guide/openvela_xts_test_cases.md) | Functional validation test cases for subsystems after enablement (covers peripherals, filesystem, networking, media, etc., Chinese only at this stage) |
+| [openvela Test Framework Usage Guide](../../../test_dev_guide/openvela_testcase_dev_guide.md) | Setup and usage of the test framework (cmocka, etc.) |
+
+### 8.2 External references
+
+The "NuttX and small systems" blog series by Mateusz Szafoni ([@raiden00pl](https://github.com/raiden00pl)) provides an in-depth exploration of minimal NuttX configuration practices on resource-constrained MCUs. It is a valuable reference for resource trimming and incremental subsystem enablement after L0:
+
+| Article | Topic |
+| ---- | ---- |
+| [Apache NuttX and small systems - Hello, World !](https://www.railab.me/posts/2024/11/nuttx-and-small-systems-hello-world/) | Booting a minimal NuttX system on a small MCU |
+| [Apache NuttX and small systems - NuttX Core Size](https://www.railab.me/posts/2024/12/nuttx-and-small-systems-core-os/) | NuttX kernel size analysis and Flash/RAM footprint |
+| [Apache NuttX and small systems - OS components](https://www.railab.me/posts/2025/1/nuttx-and-small-systems-os-components/) | OS component switches and their resource costs |
+| [Apache NuttX and small systems - CAN node example](https://www.railab.me/posts/2025/2/nuttx-and-small-systems-can-node-example/) | A minimal CAN node implementation on STM32 |
+| [Apache NuttX and small systems - Modbus slave example](https://www.railab.me/posts/2025/3/nuttx-and-small-systems-modbus-slave-example/) | Fitting a Modbus RTU slave application within 64 KB of Flash |

--- a/zh-cn/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md
+++ b/zh-cn/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md
@@ -1,0 +1,289 @@
+# 最小可运行 NSH 系统 defconfig 参考
+
+\[ [English](../../../../en/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md) | 简体中文 \]
+
+本文档面向「新硬件适配赛道」的开发者，目标是帮助开发者在自己的开发板上**先启动到 NSH 命令行提示符**。建议的工作流是：先以本文给出的最小集启动，验证串口与 NSH 工作正常后，再按需逐步打开文件系统、网络、传感器等子系统。
+
+## 一、概述
+
+### 1、文档目标
+
+参赛者拿到一块尚未适配 openvela 的开发板后，最关键的第一步是让系统能启动到 NSH 命令行提示符。本文档提供一份**最小**的 defconfig 参考，仅包含启动 NSH 所必需的配置项，便于参赛者：
+
+- 快速判断哪些 CONFIG **必须修改**（与目标硬件强相关）；
+- 哪些 CONFIG **可直接复用**（与硬件无关的运行时支持）；
+- 完成 L0 启动后，按子系统顺序**增量启用**功能。
+
+### 2、推荐工作流
+
+```
+Step 0: 硬件就绪
+        - 目标芯片在 nuttx/arch/<arch>/src/<chip>/ 下已有支持
+        - 板级目录已建立 (boards/<arch>/<chip>/<board>/)
+        - 串口 TX/RX 引脚与上位机连通
+        ↓
+Step 1: 套用本文最小集 → 编译 → 烧录 → 串口看到 NSH 提示符
+        ↓
+Step 2: 按硬件能力增量启用子系统
+        - 文件系统 (FAT / LittleFS)
+        - 网络协议栈 (Ethernet / Wi-Fi)
+        - 图形 (LCD / framebuffer / LVGL)
+        - 传感 (uORB / I2C / SPI sensors)
+        ↓
+Step 3: 移植稳定后做 release 瘦身
+        - 关闭 DEBUG_*、ALLSYMS 等调试项
+        - 调整 stack size 至实测需求
+```
+
+## 二、最小 NSH 必需配置
+
+本节配置项参考 `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig`（35 行）整理而来，并参考了 Mateusz Szafoni 的 [NuttX small systems 系列文章](https://www.railab.me/tags/small-systems/) 对最小化裁剪的实践经验。
+
+### 1、架构与板级标识（必须按目标硬件替换）
+
+```
+CONFIG_ARCH="arm"
+CONFIG_ARCH_CHIP="stm32"
+CONFIG_ARCH_CHIP_STM32=y
+CONFIG_ARCH_CHIP_STM32F303RE=y
+CONFIG_ARCH_BOARD="nucleo-f303re"
+CONFIG_ARCH_BOARD_NUCLEO_F303RE=y
+```
+
+#### 替换原则
+
+| 配置项 | 替换原则 |
+| ---- | ---- |
+| `CONFIG_ARCH=` | 目标 CPU 架构，例如 `"arm"`、`"arm64"`、`"risc-v"`、`"xtensa"` |
+| `CONFIG_ARCH_CHIP=` 与 `CONFIG_ARCH_CHIP_<FAMILY>=y` | 目标 SoC 家族，需与 `nuttx/arch/<arch>/src/<chip>/` 目录一致（如 `stm32`、`stm32h7`、`nrf52`、`esp32s3`） |
+| `CONFIG_ARCH_CHIP_<DEVICE>=y` | 具体型号，例如 `STM32F407VG`、`NRF52840`、`ESP32S3` |
+| `CONFIG_ARCH_BOARD=` 与 `CONFIG_ARCH_BOARD_<NAME>=y` | 板级目录名，需与 `nuttx/boards/<arch>/<chip>/<board>/` 一致 |
+
+### 2、内存布局（必须按目标硬件填写）
+
+```
+CONFIG_RAM_START=0x20000000
+CONFIG_RAM_SIZE=65536
+CONFIG_MM_REGIONS=2
+CONFIG_BOARD_LOOPSPERMSEC=6522
+```
+
+#### 配置项说明
+
+- `CONFIG_RAM_START`：主 SRAM 起始物理地址，参考目标芯片 datasheet（多数 ARM Cortex-M 为 `0x20000000`）。
+- `CONFIG_RAM_SIZE`：主 SRAM 容量，单位字节。
+- `CONFIG_MM_REGIONS`：堆管理器管理的内存区域数量。当芯片存在多块不连续 SRAM（如 STM32F4 的 CCM、STM32H7 的 AXI/AHB SRAM）时需调整为对应数量。
+- `CONFIG_BOARD_LOOPSPERMSEC`：忙等延时校准值，与 CPU 频率相关，可先填一个估算值，启动后通过 `up_mdelay()` 校准。
+
+### 3、串口控制台（必须按目标硬件替换）
+
+```
+CONFIG_STM32_USART2=y
+CONFIG_USART2_SERIAL_CONSOLE=y
+CONFIG_STM32_JTAG_SW_ENABLE=y
+```
+
+#### 替换原则
+
+| 配置项 | 替换原则 |
+| ---- | ---- |
+| `CONFIG_<CHIP>_USART<N>=y` | 启用目标芯片对应 UART 外设。STM32 用 `STM32_USARTx`，nRF52 用 `NRF52_UART0`，ESP32 用 `ESP32_UART0` |
+| `CONFIG_USART<N>_SERIAL_CONSOLE=y` | 指定该 UART 作为系统控制台 |
+| `CONFIG_<CHIP>_JTAG_SW_ENABLE=y` | 视目标芯片可选，用于保留 SWD 调试口 |
+
+参赛者可参考 `nuttx/boards/<arch>/<chip>/<board>/include/board.h` 中的引脚定义，确认串口对应的物理 TX/RX 引脚与电路板设计一致。
+
+### 4、NSH Shell 启动入口（直接复用）
+
+```
+CONFIG_SYSTEM_NSH=y
+CONFIG_INIT_ENTRYPOINT="nsh_main"
+```
+
+#### 配置项说明
+
+- `CONFIG_SYSTEM_NSH=y`：将 NSH 编译为系统应用。
+- `CONFIG_INIT_ENTRYPOINT="nsh_main"`：将 NSH 设为系统启动后的首个用户态任务，串口接通后即进入命令行提示符。
+
+### 5、调度与运行时支持（直接复用）
+
+```
+CONFIG_RR_INTERVAL=200
+CONFIG_SCHED_WAITPID=y
+CONFIG_PREALLOC_TIMERS=4
+CONFIG_IDLETHREAD_STACKSIZE=2048
+CONFIG_TASK_NAME_SIZE=0
+CONFIG_START_DAY=27
+CONFIG_START_YEAR=2013
+```
+
+#### 配置项说明
+
+- `CONFIG_RR_INTERVAL=200`：轮转调度时间片为 200 ms。
+- `CONFIG_SCHED_WAITPID=y`：启用 `waitpid()` 系统调用，NSH 在执行内置命令时依赖此特性。
+- `CONFIG_PREALLOC_TIMERS=4`：预分配 4 个 POSIX 定时器，满足基础需求。
+- `CONFIG_IDLETHREAD_STACKSIZE=2048`：idle 线程栈大小，2 KB 适用于多数 Cortex-M 板。RAM 紧张时可下调至 1024。
+- `CONFIG_TASK_NAME_SIZE=0`：禁用任务名称字符串以节省 RAM。如需 `ps` 命令显示任务名，可设为 16~32。
+- `CONFIG_START_DAY` 与 `CONFIG_START_YEAR`：系统启动时的初始日期，可任意填写。
+
+### 6、调试与诊断（强烈建议保留）
+
+```
+CONFIG_DEBUG_SYMBOLS=y
+CONFIG_ARCH_STACKDUMP=y
+CONFIG_INTELHEX_BINARY=y
+CONFIG_RAW_BINARY=y
+```
+
+#### 配置项说明
+
+- `CONFIG_DEBUG_SYMBOLS=y`：保留调试符号，便于使用 GDB 单步调试与 backtrace 分析。
+- `CONFIG_ARCH_STACKDUMP=y`：系统出现 hardfault 时输出栈内容，移植阶段是定位问题的重要手段。
+- `CONFIG_INTELHEX_BINARY=y` 与 `CONFIG_RAW_BINARY=y`：编译后同时产出 `.hex` 与 `.bin` 两种烧录格式。
+
+### 7、CPU 特性裁剪（按需调整）
+
+```
+# CONFIG_ARCH_FPU is not set
+```
+
+#### 说明
+
+`CONFIG_ARCH_FPU` 控制硬件浮点单元的启用。Cortex-M4F、M7 等带 FPU 的内核如需使用浮点运算，应改为 `CONFIG_ARCH_FPU=y`。Cortex-M0/M3 无 FPU，保持注释状态即可。
+
+### 8、板级辅助（可选）
+
+```
+CONFIG_ARCH_BUTTONS=y
+```
+
+#### 说明
+
+`CONFIG_ARCH_BUTTONS=y`：当板上存在 USER 按钮时启用按钮驱动框架。如目标板无按键，可省略。
+
+## 三、可直接复用的 defconfig 片段
+
+下列 16 项配置与硬件无关，可在任何 ARM Cortex-M 板上原样使用：
+
+```
+CONFIG_RR_INTERVAL=200
+CONFIG_SCHED_WAITPID=y
+CONFIG_PREALLOC_TIMERS=4
+CONFIG_IDLETHREAD_STACKSIZE=2048
+CONFIG_TASK_NAME_SIZE=0
+CONFIG_START_DAY=27
+CONFIG_START_YEAR=2013
+CONFIG_SYSTEM_NSH=y
+CONFIG_INIT_ENTRYPOINT="nsh_main"
+CONFIG_DEBUG_SYMBOLS=y
+CONFIG_ARCH_STACKDUMP=y
+CONFIG_INTELHEX_BINARY=y
+CONFIG_RAW_BINARY=y
+```
+
+参赛者只需根据自己的硬件填写第二节中标注「必须按目标硬件替换」的部分（架构标识、内存布局、串口配置），即可形成完整的 L0 defconfig。
+
+## 四、参考实现
+
+### 1、Nucleo-F303RE（参考板）
+
+完整 defconfig 路径：
+
+```
+nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig
+```
+
+该板搭载 STM32F303RE（Cortex-M4F @ 72 MHz, 512 KB Flash, 64 KB SRAM），板载 ST-Link/V2-1 调试器与 USB 虚拟串口，参赛者只需一根 USB 线即可完成烧录与串口连接，是验证最小 NSH 流程最便捷的硬件参考。
+
+### 2、其他可参考的最小 NSH defconfig
+
+| 参考板 | 路径 | 行数 | 适用场景 |
+| ---- | ---- | ---- | ---- |
+| Nucleo-F303RE | `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` | 35 | ARM Cortex-M4F 主流参考 |
+| nRF52840-DK | `nuttx/boards/arm/nrf52/nrf52840-dk/configs/nsh/defconfig` | 41 | Nordic nRF52 系列参考 |
+| STM32F411-Minimum | `nuttx/boards/arm/stm32/stm32f411-minimum/configs/nsh/defconfig` | 46 | STM32F4 资源紧张场景 |
+| STM32F4Discovery | `nuttx/boards/arm/stm32/stm32f4discovery/configs/nsh/defconfig` | 50 | STM32F4 经典评估板（含部分扩展项） |
+
+## 五、增量启用子系统
+
+L0 启动成功（串口看到 NSH 提示符）后，可按目标板的硬件能力逐步启用子系统。各类子系统的常用 CONFIG 起点如下：
+
+| 子系统 | 主要 CONFIG 起点 |
+| ---- | ---- |
+| 文件系统（FAT、LittleFS、PROCFS） | `CONFIG_FS_FAT`、`CONFIG_FS_LITTLEFS`、`CONFIG_FS_PROCFS` |
+| 网络协议栈（TCP/IP、Wi-Fi） | `CONFIG_NET`、`CONFIG_NET_TCP`、`CONFIG_NET_UDP` |
+| 图形与显示（fb、LCD、LVGL） | `CONFIG_VIDEO_FB`、`CONFIG_GRAPHICS_LVGL` |
+| 传感与 uORB | `CONFIG_SENSORS`、`CONFIG_UORB` |
+| 蓝牙（BLE） | `CONFIG_BLUETOOTH`、`CONFIG_NIMBLE` |
+| 音频 | `CONFIG_AUDIO` |
+| 电源管理 | `CONFIG_PM` |
+
+参赛者也可参考 `vendor/openvela/boards/vela/configs/goldfish-x86_64-ap/defconfig`（253 行）了解 openvela 在子系统全开场景下的完整 CONFIG 集合，作为增量启用时的对照样本。
+
+## 六、功能验证
+
+子系统启用后，建议通过标准化测试用例验证目标硬件上各子系统的功能完整性。openvela 社区维护了一份面向社区开发者的 xTS 测试用例精简集，覆盖了外设驱动、文件系统、网络、媒体等多个子系统，可作为子系统启用后的功能验收手段。
+
+### 1、推荐使用方式
+
+- **L0 启动验证**：参赛者按本文最小集完成 NSH 启动后，通过串口手动输入命令（如 `help`、`uname`、`ps`）验证基础 shell 与系统调用工作正常。
+- **子系统功能验证**：每启用一个子系统后，从 xTS 测试集中选取该子系统对应的用例运行（如启用 SPI/I2C 驱动后跑 SPI_I2C 测试）。
+- **回归验证**：移植稳定后，将整套 xTS 用例作为回归测试集，便于后续配置变更后的功能确认。
+
+### 2、xTS 测试集覆盖范围
+
+| 测试主题 | 适用场景 |
+| ---- | ---- |
+| SPI / I2C 驱动 | 外设驱动启用后验证总线通信（含 BMI160 传感器示例） |
+| Ymodem 文件传输 | 串口文件传输能力验证 |
+| mediatool 媒体测试 | 音视频编解码与播放链路验证 |
+| WiFi 兼容性 | 已适配路由器列表与连接稳定性验证 |
+| 自测试框架（cmocka） | 编写自定义单元测试时的框架使用方法 |
+
+详细的测试步骤、测试资源与依赖配置请参考 [openvela 社区开发者 xTS 测试用例精简集](../../../test_dev_guide/openvela_xts_test_cases.md) 与 [openvela 自测试框架使用指南](../../../test_dev_guide/openvela_testcase_dev_guide.md)。
+
+## 七、新硬件适配 Checklist
+
+参赛者完成 BSP 移植后，建议按以下清单检查 defconfig 完整性与目标硬件兼容性：
+
+- [ ] `CONFIG_ARCH`、`CONFIG_ARCH_CHIP`、`CONFIG_ARCH_BOARD` 三项已替换为目标硬件标识
+- [ ] `CONFIG_RAM_START` 与 `CONFIG_RAM_SIZE` 已按目标芯片 datasheet 填写
+- [ ] 多 SRAM 区芯片（如 STM32F4 含 CCM）已正确设置 `CONFIG_MM_REGIONS`
+- [ ] 串口外设宏（如 `CONFIG_STM32_USART2=y`）已切换至目标芯片对应 UART
+- [ ] `CONFIG_USART<N>_SERIAL_CONSOLE=y` 与 `board.h` 中的引脚定义一致
+- [ ] 串口波特率默认为 115200，与上位机终端一致
+- [ ] `CONFIG_SYSTEM_NSH=y` 与 `CONFIG_INIT_ENTRYPOINT="nsh_main"` 已启用
+- [ ] `CONFIG_DEBUG_SYMBOLS=y` 与 `CONFIG_ARCH_STACKDUMP=y` 已启用，便于排查启动问题
+- [ ] 带 FPU 的内核（M4F/M7）已启用 `CONFIG_ARCH_FPU=y`，无 FPU 的内核（M0/M3）保持关闭
+- [ ] `CONFIG_BOARD_LOOPSPERMSEC` 已根据 CPU 频率设置初始估算值
+
+通过 Checklist 后即可执行 `./build.sh <vendor>:<config> -j` 编译。烧录后，串口接通并出现 `nsh> ` 提示符即代表 L0 启动成功。
+
+## 八、参考资料
+
+### 1、openvela 内部参考
+
+| 资源 | 说明 |
+| ---- | ---- |
+| `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` | 推荐 L0 参考 defconfig（35 行） |
+| `nuttx/boards/arm/stm32/nucleo-f303re/include/board.h` | 板级时钟与引脚定义参考 |
+| `nuttx/boards/arm/nrf52/nrf52840-dk/configs/nsh/defconfig` | nRF52 平台最小 NSH 参考 |
+| `nuttx/boards/sim/sim/sim/configs/nsh/defconfig` | 工具链自检参考 |
+| `vendor/openvela/boards/vela/configs/goldfish-x86_64-ap/defconfig` | 子系统全开示例（253 行），增量启用时的对照样本 |
+| [openvela 芯片移植指南](../../../chip_porting/porting_guide.md) | 从零完成 BSP 移植的完整流程 |
+| [新硬件适配赛道详细指引](../hardware_porting_track_guide.md) | 赛道说明、评分维度与参考资源 |
+| [Kconfig 使用指南](../../../device_dev_guide/build/Kconfig.md) | menuconfig、defconfig、.config 三者关系详解 |
+| [openvela 社区开发者 xTS 测试用例精简集](../../../test_dev_guide/openvela_xts_test_cases.md) | 子系统启用后的功能验证用例集（覆盖外设、文件系统、网络、媒体等） |
+| [openvela 自测试框架使用指南](../../../test_dev_guide/openvela_testcase_dev_guide.md) | 测试框架（cmocka 等）的搭建与使用方法 |
+
+### 2、外部参考资料
+
+Mateusz Szafoni（[@raiden00pl](https://github.com/raiden00pl)）撰写的 NuttX small systems 系列博客，深入探讨了 NuttX 在资源受限 MCU 上的最小化配置实践，对 L0 后续的资源裁剪与子系统增量启用具有重要参考价值：
+
+| 文章 | 主题 |
+| ---- | ---- |
+| [Apache NuttX and small systems - Hello, World !](https://www.railab.me/posts/2024/11/nuttx-and-small-systems-hello-world/) | 在小型 MCU 上启动最小 NuttX 系统 |
+| [Apache NuttX and small systems - NuttX Core Size](https://www.railab.me/posts/2024/12/nuttx-and-small-systems-core-os/) | NuttX 内核体积分析与 Flash/RAM 占用 |
+| [Apache NuttX and small systems - OS components](https://www.railab.me/posts/2025/1/nuttx-and-small-systems-os-components/) | 各 OS 组件的开关与资源代价 |
+| [Apache NuttX and small systems - CAN node example](https://www.railab.me/posts/2025/2/nuttx-and-small-systems-can-node-example/) | 基于 STM32 的 CAN 节点最小实现 |
+| [Apache NuttX and small systems - Modbus slave example](https://www.railab.me/posts/2025/3/nuttx-and-small-systems-modbus-slave-example/) | 64 KB Flash 内塞下 Modbus RTU Slave 应用 |

--- a/zh-cn/contest_2026/hardware_porting/hardware_porting_guide_index.md
+++ b/zh-cn/contest_2026/hardware_porting/hardware_porting_guide_index.md
@@ -7,6 +7,7 @@
 | 文档 | 说明 |
 | ---- | ---- |
 | [新硬件适配赛道详细指引](./hardware_porting_track_guide.md) | 赛道概述、赛题要求、评分加分项、参考资源。 |
+| [最小可运行 NSH 系统 defconfig 参考](./defconfig_reference/minimum_nsh_baseline.md) | L0 起步 defconfig：在新开发板上先启动到 NSH 命令行提示符，再按需逐步启用文件系统、网络、传感器等子系统。 |
 | openvela 芯片移植指南 | 从零完成 BSP 移植的完整流程（位于 docs 仓库 `zh-cn/chip_porting/porting_guide.md`）。 |
 | openvela 驱动开发指南 | UART/SPI/I2C 等各类驱动的适配与使用。[在线文档](https://doc.openvela.com/document?id=198&version=trunk&language=cn) |
 


### PR DESCRIPTION
## Summary

Add a minimum-NSH baseline defconfig reference document for the Hardware Porting Track (`dev-ai-contest-2026` branch). Contest participants receiving a not-yet-supported development board can use this document to bring up NSH on their target hardware first, then incrementally enable filesystem, networking, sensors, graphics and other subsystems.

## Changes

- **`zh-cn/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md`** (new, 289 lines): Chinese version of the L0 starter defconfig reference, structured as 8 sections covering overview, minimum required CONFIGs, reusable defconfig fragment, reference implementations, incremental subsystem enablement, functional validation, adaptation checklist, and references.
- **`en/contest_2026/hardware_porting/defconfig_reference/minimum_nsh_baseline.md`** (new, 289 lines): English version, structurally aligned with the Chinese version.
- **`zh-cn/contest_2026/hardware_porting/hardware_porting_guide_index.md`**: add a row pointing to the new defconfig reference document.

## Why

Hardware Porting Track participants currently lack a starter defconfig template that explicitly separates "must-replace-per-target-hardware" items from "reuse-as-is" items. Without this, contestants either over-enable subsystems (slow first boot, hard to debug) or miss required CONFIGs (NSH never starts).

This document picks `nuttx/boards/arm/stm32/nucleo-f303re/configs/nsh/defconfig` (35 lines) as the reference template — a real-hardware Cortex-M4F NSH config with no extra subsystems. Each section labels CONFIGs as "must replace" or "reuse as-is", so contestants can adapt it to STM32 / nRF52 / ESP32 / RISC-V boards quickly.

The document also references the openvela xTS test case collection (PR #560 / #561 / #564) for post-L0 functional validation, and Mateusz Szafoni's NuttX small-systems blog series for further resource trimming guidance.

## Cross-links verified

- `../../../chip_porting/porting_guide.md` (zh-cn / en, both exist)
- `../../../device_dev_guide/build/Kconfig.md` (zh-cn / en, both exist)
- `../../../test_dev_guide/openvela_xts_test_cases.md` (zh-cn only, English version not yet available — labeled as such in en doc)
- `../../../test_dev_guide/openvela_testcase_dev_guide.md` (zh-cn / en, both exist)
- `../hardware_porting_track_guide.md` (zh-cn only, English version not yet available — labeled as such in en doc)
