### PR TITLE
docs(ai_coding_log_guide): align with merged zero-touch install (PR #24)

### DIFF
--- a/zh-cn/contest_2026/ai_coding_log_guide.md
+++ b/zh-cn/contest_2026/ai_coding_log_guide.md
@@ -120,7 +120,7 @@ Stop hook 自动写入 staging。
 - "package this conversation"
 - "归档对话"
 
-AI 将先运行 `tools/export-session.py --latest` 进行预览，展示待导出的会话；确认无误后再追加 `--confirm` 正式写入。
+AI 将先运行 `../.claude/skills/contest-log-collector/tools/export-session.py --latest` 进行预览，展示待导出的会话；确认无误后再追加 `--confirm` 正式写入。
 
 ### 2、Slash 命令（Claude Code）
 
@@ -134,19 +134,19 @@ AI 将先运行 `tools/export-session.py --latest` 进行预览，展示待导�
 
 ```bash
 # 1. 列出 staging 中的所有会话，确认待导出项
-python3 tools/export-session.py --list
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --list
 
 # 2. 预览待导出会话（默认仅预览，不写入文件）
-python3 tools/export-session.py --latest
-python3 tools/export-session.py --session <session-id>
-python3 tools/export-session.py --today
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --session <session-id>
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --today
 
 # 3. 核对无误后，追加 --confirm 正式导出
-python3 tools/export-session.py --latest --confirm
-python3 tools/export-session.py --session <session-id> --confirm
-python3 tools/export-session.py --today --confirm
-python3 tools/export-session.py --since 2026-06-15 --confirm
-python3 tools/export-session.py --all --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --session <session-id> --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --today --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --since 2026-06-15 --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --all --confirm
 ```
 
 > 重要：未追加 `--confirm` 时仅为预览，不会写入任何文件。此设计用于避免误导出此前与 AI 进行的个人项目对话。建议流程：`--list` 查看清单 → `--session <id>` 预览 → `--session <id> --confirm` 正式写入。
@@ -198,10 +198,10 @@ git push
 
 ```bash
 # 终端预览（彩色）
-python3 tools/render-log.py logs/<your-github-login>/
+python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/
 
 # 生成 HTML 报告（浏览器打开）
-python3 tools/render-log.py logs/<your-github-login>/ \
+python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/ \
   --format html --out my-report.html
 ```
 
@@ -228,7 +228,7 @@ ls -lt ~/.claude/contest-collector-staging/<your-github-login>/<today>/
 ### 3、导出后合规性自检
 
 ```bash
-python3 tools/validate-log.py logs/
+python3 ../.claude/skills/contest-log-collector/tools/validate-log.py logs/
 ```
 
 应输出 `ALL OK`。若报错，多为工具缺陷，请在组委会群反馈。
@@ -258,7 +258,7 @@ rm <session-id>.jsonl
 
 ### Q3：可以修改 staging 或 logs 中的内容吗？
 
-`tools/validate-log.py` 会检测 seq 缺号、跨字段不一致、manifest 与文件不匹配等篡改行为，修改日志将被视为作弊。但在导出前于 staging 中删除整个会话是允许的，其效果等同于“不打包”，评委不可见。
+`../.claude/skills/contest-log-collector/tools/validate-log.py` 会检测 seq 缺号、跨字段不一致、manifest 与文件不匹配等篡改行为，修改日志将被视为作弊。但在导出前于 staging 中删除整个会话是允许的，其效果等同于“不打包”，评委不可见。
 
 ### Q4：可以临时关闭日志收集吗？
 
@@ -275,13 +275,13 @@ rm <session-id>.jsonl
 
 ```bash
 # 查看尚未导出的会话
-python3 tools/export-session.py --list
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --list
 
 # 预览全部待导出会话（核对是否包含不应上传的个人对话）
-python3 tools/export-session.py --all
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --all
 
 # 核对无误后，追加 --confirm 一次性导出
-python3 tools/export-session.py --all --confirm
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --all --confirm
 git add logs/ && git commit -s -m "logs: final batch" && git push
 ```
 
@@ -322,38 +322,49 @@ git add logs/ && git commit -s -m "logs: final batch" && git push
 
 以下为工具仓库与全局 hook 的目录结构，仅供需要了解内部实现者参考，正常使用无需关注。
 
-`repo sync` 拉取的工程结构如下，其中 `.claude/` 为工具仓库（与 demo 仓库平级），并非安装在 demo 仓库内部：
+`repo sync` 拉取的工程结构如下，其中 `.claude/` 为工具仓库（与 demo 仓库平级），并非安装在 demo 仓库内部。`install.sh` 采用**零侵入**设计：不会向 demo 仓库复制任何文件，工具源全部从 `.claude/` 工具仓直接调用。demo 仓库中**仅在参赛者主动 `--confirm` 导出后**才会出现 `logs/` 目录。
 
 ```text
 <你的工作树>/                            # repo init 拉取的工作树根目录
 ├── .repo/                              # repo 工具元数据
 ├── .claude/                            # 大赛工具仓库（open-vela/.claude，由 manifest 拉取）
 │   └── skills/contest-log-collector/
-│       ├── adapters/                   # snapshot core / opencode plugin 源
-│       ├── commands/                   # slash command 源
-│       ├── tools/                      # export / render / validate 工具源
-│       ├── schema/                     # JSONL 契约源
+│       ├── adapters/                   # snapshot core / opencode plugin 源 (install 会复制到 ~/.claude/)
+│       ├── commands/                   # slash command (Claude Code 自动从 ~/.claude/ 加载)
+│       ├── tools/                      # export / render / validate (参赛者 + 评委直接调用)
+│       ├── schema/                     # JSONL 契约 (validate-log.py 自动加载)
 │       └── onboarding/
-│           ├── install.sh              # 安装脚本
+│           ├── install.sh              # 安装脚本（仅写 ~/.claude/ 与 ~/.config/opencode/）
 │           ├── verify-setup.sh         # 健康检查
-│           ├── USAGE.md                # 本文件（源）
-│           └── JUDGE_GUIDE.md          # 评委指南（源）
+│           ├── USAGE.md                # 选手使用手册
+│           └── JUDGE_GUIDE.md          # 评委指南
 ├── nuttx/  apps/  vendor/  ...         # openvela 全量源码
 └── <你的 demo 仓>/                      # 例如 contest2026_042_openvela
-    ├── .gitignore
-    ├── .claude/  .opencode/  tools/  schema/   # 安装后生成
-    ├── USAGE.md  JUDGE_GUIDE.md
-    └── logs/                           # 主动导出会话后生成
+    ├── (你的代码、README、配置 — install.sh 完全不动)
+    └── logs/                           # 仅在主动 `--confirm` 导出会话后才生成
+        └── <your-github-login>/
+            ├── manifest.json
+            └── <date>/<tool>__<sid>.jsonl
 ```
 
-此外，第一节的 `install.sh` 会在 home 目录部署一份全局 hook：
+此外，第一节的 `install.sh` 会在 home 目录部署全局 hook 与 staging 区（**所有工具状态均位于 home 目录，不进入 demo 仓库**）：
 
 ```text
 ~/.claude/
 ├── settings.json                       # 注入 Stop/SessionEnd hook
 ├── contest-collector.env               # 身份信息（TEAM_ID + GITHUB_LOGIN）
 ├── contest-shared/                     # 全局 hook
+│   ├── snapshot_core.py
+│   ├── get_github_login.py
+│   └── contest-snapshot.sh
 └── contest-collector-staging/          # staging 区（本机全部 AI 对话）
+    └── <your-github-login>/
+        ├── manifest.json
+        └── <date>/<tool>__<sid>.jsonl
+
+~/.config/opencode/plugin/
+└── contest-collector.js                # OpenCode 全局 plugin
 ```
 
 全局 hook 不会自动 push，仅在本机写入文件，提交由参赛者自行控制。
+**demo 仓库中除 `logs/<your-github-login>/...` 外不会出现任何其他工具文件。**


### PR DESCRIPTION
## Summary

The `ai_coding_log_guide.md` added in #593 was a snapshot of the contestant manual from before two tool PRs landed in `open-vela/.claude`:

- **PR #24** ([refactor(install): zero-touch contestant repo](https://github.com/open-vela/.claude/pull/24), merged 2026-06-15 09:07 UTC) — `install.sh` no longer copies any files into the demo repo. Tools live in the sibling `.claude/` tools repo; contestants invoke them via relative path. The demo repo gets only `logs/<github_login>/...` after explicit `--confirm`.
- **PR #25** ([fix(export-session): handle naive --since dates](https://github.com/open-vela/.claude/pull/25), merged just after) — `--since 2026-06-15` no longer crashes on Python 3.11+. No CLI surface change.

PR #593 was created **before #24 was merged** (07:07 UTC vs 09:07 UTC), so the doc shipped with three stale claims that contradict the now-merged behaviour. This PR fixes them.

## Changes

| | Before | After |
|---|---|---|
| Tool invocation prefix | `python3 tools/...` | `python3 ../.claude/skills/contest-log-collector/tools/...` |
| File-layout appendix | "demo repo gets `.claude/ .opencode/ tools/ schema/  # 安装后生成`" | "demo repo only shows `logs/` after `--confirm`; everything else lives in `~/.claude/` and `~/.config/opencode/plugin/`" |
| Natural-language trigger paragraph + Q3 anti-cheat description | bare `tools/...` references | full `../.claude/skills/...` references so contestants can copy-paste |

Total: 1 file, +41 / -30 lines.

## What is NOT changed

All two-stage staging semantics, `--confirm` rules, redaction list, field table, FAQ answers (Q1-Q10), repo naming examples (`contest2026_NNN_openvela`), and reference links remain exactly as written in #593. This PR is strictly a sync with the merged tool behaviour.

## Verification

The new paths were dry-run on a fresh `repo init / repo sync` mock under `/tmp/opencode/zerotouch-real/`:

```
$ cd contest2026_000_openvela
$ python3 ../.claude/skills/contest-log-collector/tools/export-session.py --list      # ok
$ python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest    # preview
$ python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest --confirm
✅ copied -> logs/yanxingyu17/2026-06-15/...
```

End-to-end smoke test that proves the zero-touch property: https://github.com/open-vela/contest2026_000_openvela/pull/2 (2 files / 22 lines committed, all of it under `logs/`).