### PR TITLE
docs(ai_coding_log_guide): align with zero-touch install + contest-snapshot shortcut

### DIFF
--- a/zh-cn/contest_2026/ai_coding_log_guide.md
+++ b/zh-cn/contest_2026/ai_coding_log_guide.md
@@ -120,7 +120,7 @@ Stop hook 自动写入 staging。
 - "package this conversation"
 - "归档对话"
 
-AI 将先运行 `tools/export-session.py --latest` 进行预览，展示待导出的会话；确认无误后再追加 `--confirm` 正式写入。
+AI 将先运行 `contest-snapshot --latest` 进行预览，展示待导出的会话；确认无误后再追加 `--confirm` 正式写入。
 
 ### 2、Slash 命令（Claude Code）
 
@@ -132,24 +132,37 @@ AI 将先运行 `tools/export-session.py --latest` 进行预览，展示待导�
 
 ### 3、直接运行脚本
 
+`install.sh` 在 `~/.local/bin/contest-snapshot` 安装了短命令脚本，对长路径进行了封装。请优先使用：
+
 ```bash
 # 1. 列出 staging 中的所有会话，确认待导出项
-python3 tools/export-session.py --list
+contest-snapshot --list
 
 # 2. 预览待导出会话（默认仅预览，不写入文件）
-python3 tools/export-session.py --latest
-python3 tools/export-session.py --session <session-id>
-python3 tools/export-session.py --today
+contest-snapshot --latest
+contest-snapshot --session <session-id>
+contest-snapshot --today
 
 # 3. 核对无误后，追加 --confirm 正式导出
-python3 tools/export-session.py --latest --confirm
-python3 tools/export-session.py --session <session-id> --confirm
-python3 tools/export-session.py --today --confirm
-python3 tools/export-session.py --since 2026-06-15 --confirm
-python3 tools/export-session.py --all --confirm
+contest-snapshot --latest --confirm
+contest-snapshot --session <session-id> --confirm
+contest-snapshot --today --confirm
+contest-snapshot --since 2026-06-15 --confirm
+contest-snapshot --all --confirm
 ```
 
 > 重要：未追加 `--confirm` 时仅为预览，不会写入任何文件。此设计用于避免误导出此前与 AI 进行的个人项目对话。建议流程：`--list` 查看清单 → `--session <id>` 预览 → `--session <id> --confirm` 正式写入。
+
+**若 `contest-snapshot: command not found`**：表示 `~/.local/bin` 不在 `PATH` 中。执行以下任一操作即可：
+
+```bash
+# 方法 1：将 ~/.local/bin 永久加入 PATH（推荐）
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+# 方法 2：使用完整路径作为 fallback（短命令的等价形式）
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest --confirm
+```
 
 ### 4、提交（commit + push）
 
@@ -198,10 +211,10 @@ git push
 
 ```bash
 # 终端预览（彩色）
-python3 tools/render-log.py logs/<your-github-login>/
+python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/
 
 # 生成 HTML 报告（浏览器打开）
-python3 tools/render-log.py logs/<your-github-login>/ \
+python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/ \
   --format html --out my-report.html
 ```
 
@@ -228,7 +241,7 @@ ls -lt ~/.claude/contest-collector-staging/<your-github-login>/<today>/
 ### 3、导出后合规性自检
 
 ```bash
-python3 tools/validate-log.py logs/
+python3 ../.claude/skills/contest-log-collector/tools/validate-log.py logs/
 ```
 
 应输出 `ALL OK`。若报错，多为工具缺陷，请在组委会群反馈。
@@ -258,7 +271,7 @@ rm <session-id>.jsonl
 
 ### Q3：可以修改 staging 或 logs 中的内容吗？
 
-`tools/validate-log.py` 会检测 seq 缺号、跨字段不一致、manifest 与文件不匹配等篡改行为，修改日志将被视为作弊。但在导出前于 staging 中删除整个会话是允许的，其效果等同于“不打包”，评委不可见。
+`../.claude/skills/contest-log-collector/tools/validate-log.py` 会检测 seq 缺号、跨字段不一致、manifest 与文件不匹配等篡改行为，修改日志将被视为作弊。但在导出前于 staging 中删除整个会话是允许的，其效果等同于“不打包”，评委不可见。
 
 ### Q4：可以临时关闭日志收集吗？
 
@@ -275,13 +288,13 @@ rm <session-id>.jsonl
 
 ```bash
 # 查看尚未导出的会话
-python3 tools/export-session.py --list
+contest-snapshot --list
 
 # 预览全部待导出会话（核对是否包含不应上传的个人对话）
-python3 tools/export-session.py --all
+contest-snapshot --all
 
 # 核对无误后，追加 --confirm 一次性导出
-python3 tools/export-session.py --all --confirm
+contest-snapshot --all --confirm
 git add logs/ && git commit -s -m "logs: final batch" && git push
 ```
 
@@ -322,38 +335,52 @@ git add logs/ && git commit -s -m "logs: final batch" && git push
 
 以下为工具仓库与全局 hook 的目录结构，仅供需要了解内部实现者参考，正常使用无需关注。
 
-`repo sync` 拉取的工程结构如下，其中 `.claude/` 为工具仓库（与 demo 仓库平级），并非安装在 demo 仓库内部：
+`repo sync` 拉取的工程结构如下，其中 `.claude/` 为工具仓库（与 demo 仓库平级），并非安装在 demo 仓库内部。`install.sh` 采用**零侵入**设计：不会向 demo 仓库复制任何文件，工具源全部从 `.claude/` 工具仓直接调用。demo 仓库中**仅在参赛者主动 `--confirm` 导出后**才会出现 `logs/` 目录。
 
 ```text
 <你的工作树>/                            # repo init 拉取的工作树根目录
 ├── .repo/                              # repo 工具元数据
 ├── .claude/                            # 大赛工具仓库（open-vela/.claude，由 manifest 拉取）
 │   └── skills/contest-log-collector/
-│       ├── adapters/                   # snapshot core / opencode plugin 源
-│       ├── commands/                   # slash command 源
-│       ├── tools/                      # export / render / validate 工具源
-│       ├── schema/                     # JSONL 契约源
+│       ├── adapters/                   # snapshot core / opencode plugin 源 (install 会复制到 ~/.claude/)
+│       ├── commands/                   # slash command (Claude Code 自动从 ~/.claude/ 加载)
+│       ├── tools/                      # export / render / validate (参赛者 + 评委直接调用)
+│       ├── schema/                     # JSONL 契约 (validate-log.py 自动加载)
 │       └── onboarding/
-│           ├── install.sh              # 安装脚本
+│           ├── install.sh              # 安装脚本（仅写 ~/.claude/、~/.config/opencode/、~/.local/bin/）
 │           ├── verify-setup.sh         # 健康检查
-│           ├── USAGE.md                # 本文件（源）
-│           └── JUDGE_GUIDE.md          # 评委指南（源）
+│           ├── USAGE.md                # 选手使用手册
+│           └── JUDGE_GUIDE.md          # 评委指南
 ├── nuttx/  apps/  vendor/  ...         # openvela 全量源码
 └── <你的 demo 仓>/                      # 例如 contest2026_042_openvela
-    ├── .gitignore
-    ├── .claude/  .opencode/  tools/  schema/   # 安装后生成
-    ├── USAGE.md  JUDGE_GUIDE.md
-    └── logs/                           # 主动导出会话后生成
+    ├── (你的代码、README、配置 — install.sh 完全不动)
+    └── logs/                           # 仅在主动 `--confirm` 导出会话后才生成
+        └── <your-github-login>/
+            ├── manifest.json
+            └── <date>/<tool>__<sid>.jsonl
 ```
 
-此外，第一节的 `install.sh` 会在 home 目录部署一份全局 hook：
+此外，第一节的 `install.sh` 会在 home 目录部署全局 hook、staging 区与短命令快捷脚本（**所有工具状态均位于 home 目录，不进入 demo 仓库**）：
 
 ```text
 ~/.claude/
 ├── settings.json                       # 注入 Stop/SessionEnd hook
 ├── contest-collector.env               # 身份信息（TEAM_ID + GITHUB_LOGIN）
 ├── contest-shared/                     # 全局 hook
+│   ├── snapshot_core.py
+│   ├── get_github_login.py
+│   └── contest-snapshot.sh
 └── contest-collector-staging/          # staging 区（本机全部 AI 对话）
+    └── <your-github-login>/
+        ├── manifest.json
+        └── <date>/<tool>__<sid>.jsonl
+
+~/.config/opencode/plugin/
+└── contest-collector.js                # OpenCode 全局 plugin
+
+~/.local/bin/
+└── contest-snapshot                    # 短命令快捷脚本（封装 export-session.py）
 ```
 
 全局 hook 不会自动 push，仅在本机写入文件，提交由参赛者自行控制。
+**demo 仓库中除 `logs/<your-github-login>/...` 外不会出现任何其他工具文件。**


### PR DESCRIPTION
## Why

The guide was added in #593 from a snapshot that pre-dated two tool changes in `open-vela/.claude`:

| PR | Status | What it changed |
|---|---|---|
| [#24 zero-touch install](https://github.com/open-vela/.claude/pull/24) | merged 2026-06-15 | `install.sh` no longer copies tools into the demo repo. Tools live in the sibling `.claude/` tools repo. Demo repo only receives `logs/<github_login>/...` after explicit `--confirm` export. |
| [#26 contest-snapshot shortcut](https://github.com/open-vela/.claude/pull/26) | OPEN (queued together with this doc PR) | `install.sh` additionally installs `~/.local/bin/contest-snapshot`, a thin wrapper that resolves the sibling `.claude/` via `git rev-parse --show-toplevel` and execs the real `export-session.py`. Forwards all args. |

This PR syncs `ai_coding_log_guide.md` to match both. **Open together with #26**, so contestants see the short command everywhere the moment both PRs land.

## What this PR does

### 1. Rewrite contestant-facing export commands to the short form

16 sites total, in section 3 (three trigger methods), section 5 (verify steps), and Q5 (final-hour playbook). Example:

```diff
-python3 tools/export-session.py --latest --confirm
+contest-snapshot --latest --confirm
```

### 2. Tell contestants what to do if the short command is missing

New paragraph at the bottom of section 3.3:

> **若 `contest-snapshot: command not found`**：表示 `~/.local/bin` 不在 `PATH` 中。
> - 方法 1：`echo PATH... >> ~/.bashrc && source ~/.bashrc`
> - 方法 2：使用完整路径 fallback `python3 ../.claude/skills/contest-log-collector/tools/export-session.py --latest --confirm`

### 3. Judge tools (render / validate) keep the full path

`render-log.py` / `validate-log.py` have no shortcut and stay on the full path:

```
python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/
python3 ../.claude/skills/contest-log-collector/tools/validate-log.py logs/
```

These are judge-side commands run by reviewers/graders, not by contestants in their daily loop, so the shortcut is not needed.

### 4. Appendix file-tree updated

- Removed the misleading line claiming `install.sh` generates `.claude/.opencode/tools/schema/` inside the demo repo (no longer true after PR #24).
- Added `~/.local/bin/contest-snapshot` entry under the home-directory install footprint.
- Added `~/.config/opencode/plugin/contest-collector.js` (where PR #24 moved the OpenCode plugin).
- Added a top paragraph stating the zero-touch property explicitly.

## What is NOT changed

All two-stage staging semantics, `--confirm` rules, redaction list, field table, FAQ answers (Q1-Q10), repo naming examples (`contest2026_NNN_openvela`), and reference links remain exactly as written.

## Diff size

1 file, +57 / -30 lines.

## Verification

E2E proof of the zero-touch + shortcut flow:

```
$ bash ../.claude/skills/contest-log-collector/onboarding/install.sh \
    --team-id contest2026_000_openvela --github-login yanxingyu17

📦 Installing contest collector (machine-wide, zero touch on demo repo)
...
✅ /home/.../.local/bin/contest-snapshot (short command: contest-snapshot)

$ contest-snapshot --list     # short command works
session_id    tool        last_event_at              events
...

$ contest-snapshot --latest --confirm    # writes only logs/<login>/...

$ bash ../.claude/skills/contest-log-collector/onboarding/verify-setup.sh
Passed: 11  Failed: 0
```

Demo repo stays clean (only `logs/`):
https://github.com/open-vela/contest2026_000_openvela/pull/2 (2 files / 22 lines)

## Notes for reviewers

- This PR depends on https://github.com/open-vela/.claude/pull/26 landing, since `contest-snapshot` is installed by PR #26. The doc is forward-looking: if PR #26 is merged before this one, contestants get the short command immediately. If this PR lands first, the doc still has a working fallback to the full python invocation.
- Supersedes the now-closed #596 which only covered the zero-touch path change.