### PR TITLE
docs(contest): update AI Coding log guide for workspace-gated auto-export

### DIFF
--- a/zh-cn/contest_2026/ai_coding_log_guide.md
+++ b/zh-cn/contest_2026/ai_coding_log_guide.md
@@ -1,6 +1,6 @@
 # AI Coding 日志归集与提交手册
 
-本手册面向参赛者，说明在使用 AI 编程工具开发时，如何将与 AI 的对话日志归集并提交至比赛仓库。日志采用两阶段机制：对话先暂存于本机，仅在参赛者主动导出后才会进入比赛仓库，个人对话不会被误传。
+本手册面向参赛者，说明在使用 AI 编程工具开发时，如何将与 AI 的对话日志归集并提交至比赛仓库。系统采用了“工作区检测”与“自动入仓”机制。采集器仅在 `openvela` 工作区内（通过识别 `.repo/` 目录）激活。工作区内的对话会在会话结束时自动写入比赛仓库的日志目录，参赛者只需随代码执行常规提交即可。
 
 > 仓库获取与提交的总体流程，见 [《参赛代码提交指南》](./code_submission_guide.md)。
 
@@ -10,16 +10,18 @@
 
 ```text
 ① 安装    一次性运行 install.sh                                  （见第一节）
-② 开发    使用 Claude Code / AIoT-IDE / OpenCode / Codex 进行开发   （见第二节）
-③ 提交    主动导出选定对话至 logs/，随代码一并提交                （见第三节）
+② 开发    在 openvela 工作区内使用 AI 工具进行开发                  （见第二节）
+③ 提交    检查并提交 logs/ 下的日志记录至远程仓库                  （见第三节）
 ```
 
 **关键术语**
 
-- **staging（本机暂存区）**：位于 `~/.claude/contest-collector-staging/`，AI 对话首先写入此处，不会自动上传。
-- **导出（打包）**：由参赛者主动将选定对话从 staging 复制至比赛仓库的 `logs/` 目录。
-- **hook（钩子）**：随安装部署在本机的程序，在 AI 对话结束时自动将记录写入 staging。
-- **repo init / repo sync**：多仓库管理命令，用于一次性拉取 openvela 全量代码及参赛专属仓库。
+- **工作区闸门（Workspace Gate）**：通过向上遍历查找 `.repo/` 目录实现环境识别。系统仅在工作区内采集记录。
+- **staging（本机缓冲区）**：位于 `~/.claude/contest-collector-staging/`。作为工具内部交换数据的中转站，不再是主要的隐私屏障。
+- **自动入仓**：在工作区内结束会话后，记录会自动写入比赛仓库的 `logs/` 目录。
+- **手动同步**：通过脚本重新导出或选择性同步日志的可选操作。
+- **hook（钩子）**：随安装部署在本机的程序，在会话结束时自动触发日志流转。
+- **repo init / repo sync**：多仓库管理命令，用于拉取 openvela 代码及参赛专属仓库。
 
 ## 一、安装与自检
 
@@ -63,23 +65,24 @@ ls ~/.claude/contest-collector-staging/<your-github-login>/
 
 ## 二、启用 AI 工具
 
-本届支持以下 4 种工具，可任选其一使用。完成第一节的 `install.sh` 后，全局 hook 即已就位。
+本届支持以下 4 种工具，可任选其一使用。完成第一节的 `install.sh` 后，采集钩子即已就位。系统仅在 `openvela` 工作区内进行采集。
 
 ### 1、Claude Code（官方主推，支持 CLI 与 AIoT-IDE 内嵌）
 
 **通过 AIoT-IDE（推荐）**
 
 1. 安装 AIoT-IDE，参见大赛官方 IDE 使用文档。
-2. 在 AIoT-IDE 中于任意位置（包括桌面、子目录或仓库之外）打开 Claude Code 插件并开始对话。
-3. 关闭对话后，记录自动写入 staging。
+2. 在 `openvela` 工作区目录内打开 Claude Code 插件并开始对话。
+3. 关闭对话后，记录自动写入比赛仓 `logs/`。
 
 **通过 Claude Code CLI**
 
 ```bash
-claude   # 可在任意目录运行，不限于仓库内
+# 必须在 openvela 工作区内的目录执行，方可被采集
+claude
 ```
 
-退出时（`/exit` 或 Ctrl+D）记录自动写入 staging。
+退出时（`/exit` 或 Ctrl+D）记录自动写入比赛仓 `logs/`。
 
 ### 2、OpenCode（CLI / TUI / VS Code 扩展）
 
@@ -87,7 +90,7 @@ claude   # 可在任意目录运行，不限于仓库内
 opencode
 ```
 
-OpenCode V1 插件已预装，会话结束后自动写入 staging。
+会话结束后，记录自动写入比赛仓 `logs/`。
 
 ### 3、Codex CLI
 
@@ -95,7 +98,7 @@ OpenCode V1 插件已预装，会话结束后自动写入 staging。
 codex
 ```
 
-Stop hook 自动写入 staging。
+会话结束后，记录自动写入比赛仓 `logs/`。
 
 ### 4、多人协作
 
@@ -103,30 +106,55 @@ Stop hook 自动写入 staging。
 
 1. 各自克隆本地副本。
 2. 将 `~/.claude/contest-collector.env` 中的 GITHUB_LOGIN 修改为本人的 username（重要）。
-3. 各自与 AI 工具协作。
+3. 各自在工作区内与 AI 工具协作。
 
-各成员的 staging 相互独立，分别导出各自的会话即可。
+各成员的日志会按 GitHub 账号自动存放到对应的 `logs/<github_login>/` 目录下。
 
-## 三、导出并提交对话日志
+## 三、自动化入仓与日志提交
 
-工具不会自动将对话写入比赛仓库，需由参赛者主动导出。以下 3 种方式可任选其一。
+在 `openvela` 工作区内进行的 AI 对话，记录会在会话结束时自动写入比赛仓的 `logs/` 目录。
 
-### 1、自然语言指令（推荐）
+### 1、默认流程：自动归集
 
-向 AI 发送如下任一指令：
+你无需执行任何额外的导出指令。在工作区内完成开发并关闭 AI 工具后，日志文件已物理存放在你的 demo 仓下。你可以通过以下操作完成提交：
 
-- "archive this session into the contest repo"
-- "把刚才的会话存到比赛仓库"
-- "package this conversation"
-- "归档对话"
-
-AI 将先运行 `contest-snapshot --latest` 进行预览，展示待导出的会话；确认无误后再追加 `--confirm` 正式写入。
-
-### 2、Slash 命令（Claude Code）
-
-```text
-/contest-snapshot
+```bash
+git add logs/
+git commit -s -m "logs: sync AI sessions"
+git push
 ```
+
+注意：工具仅负责写入本地文件，不会执行 `git push` 操作。物理上传的控制权完全掌握在你手中。
+
+### 2、手动工具：管理与重新导出（可选）
+
+虽然流程已自动化，但你仍可以使用 `contest-snapshot` 脚本来列出或查看记录。该脚本对 `export-session.py` 进行了封装。
+
+```bash
+# 1. 列出当前已采集的会话清单
+contest-snapshot --list
+
+# 2. 预览特定会话的详细内容（不写入文件）
+contest-snapshot --session <session-id>
+
+# 3. 手动重新同步当天的所有会话（通常无需使用）
+contest-snapshot --today --confirm
+```
+
+**若 `contest-snapshot: command not found`**：表示 `~/.local/bin` 不在 `PATH` 中。执行以下任一操作即可：
+
+```bash
+# 方法 1：将 ~/.local/bin 永久加入 PATH（推荐）
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+
+# 方法 2：使用完整路径作为等价形式
+python3 ../.claude/skills/contest-log-collector/tools/export-session.py --list
+```
+
+### 3、多人协作提交
+
+在团队开发模式下，请确保每位成员在 commit 前都拉取了最新的日志文件。各成员的日志按 GitHub 账号区分，合并代码时不会发生冲突。推荐在 push 前执行一次 `git add logs/`。
 
 效果同上，同样遵循“预览 → 确认”两步。
 
@@ -182,148 +210,122 @@ git push
 
 ## 四、隐私保护：工具采集范围说明
 
-### 1、写入 staging 的内容
+### 1、隔离边界：工作区闸门
 
-只要与 AI 工具（Claude Code / OpenCode / Codex / AIoT-IDE）对话，所有对话均会写入 staging，涵盖以下全部场景：
+系统通过识别 `openvela` 工作区根目录下的 `.repo/` 标识来确定采集范围。只有在此目录树内进行的操作才会被记录并自动入仓。
 
-- 在比赛仓库内
-- 在个人项目内
-- 在 `$HOME` 目录内
-- 其他任意位置
+### 2、非工作区不采集
 
-但 staging 不会上传，仅保存于本机 `~/.claude/contest-collector-staging/`。
+在工作区之外进行的任何对话，例如个人项目、系统根目录、个人文档或 `$HOME` 目录等，完全不被采集。这意味着此类对话既不会写入暂存区，也不会进入比赛仓库，在根源上实现了隐私隔离。
 
-### 2、进入比赛仓库的内容（即评委可见）
-
-仅限参赛者主动导出的会话。若与 AI 进行了 50 轮对话而仅导出 10 轮，则评委仅可见该 10 轮，其余 40 轮始终保留在本机。
-
-### 3、记录的字段
+### 3、记录字段
 
 | 字段                             | 内容                               |
 | -------------------------------- | ---------------------------------- |
 | `text`                           | 与 AI 的对话正文                   |
-| `thinking`                       | AI 的思考过程（如工具暴露）        |
+| `thinking`                       | AI 的思考过程                      |
 | `tool_name` / `input` / `output` | AI 调用的工具（read/edit/bash 等） |
-| `model` / `tokens_in/out`        | 所用模型与 token 用量              |
-| `seq`                            | 会话内单调递增序号（用于防作弊）   |
+| `model` / `tokens_in/out`        | 所用模型与使用统计                 |
+| `seq`                            | 会话内递增序号（用于验证一致性）   |
 
-### 4、查看已导出内容
+### 4、查看与核对内容
 
 ```bash
 # 终端预览（彩色）
 python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/
 
-# 生成 HTML 报告（浏览器打开）
+# 生成 HTML 报告供浏览器查看
 python3 ../.claude/skills/contest-log-collector/tools/render-log.py logs/<your-github-login>/ \
   --format html --out my-report.html
 ```
 
 ## 五、验证与排错
 
-### 1、确认 staging 持续累积
+### 1、确认自动导出生效
+
+与 AI 协作并结束会话后，请检查你的 demo 仓目录：
 
 ```bash
-# 与 AI 协作数轮后，另开终端执行：
-ls -lt ~/.claude/contest-collector-staging/<your-github-login>/<today>/
+ls -lt logs/<your-github-login>/<today>/
 ```
 
-应可见 `.jsonl` 文件，且大小随对话推进而增长。
+应可见最新的 `.jsonl` 文件。如果该目录未出现，请检查你是否在 `openvela` 工作区内运行工具。
 
 ### 2、查看 stderr 提示
 
-每次 AI 会话结束，collector 会在 stderr 输出：
+每次 AI 会话结束，采集器会在终端输出：
 
 ```text
-[session-log] captured 3 event(s) -> .../claude-code__abc.jsonl
-              (remember to 'git add logs/' when committing)
+[session-log] auto-exported session -> logs/.../claude-code__abc.jsonl
+              (remember to 'git push' to complete submission)
 ```
 
-### 3、导出后合规性自检
+### 3、合规性自检
 
 ```bash
 python3 ../.claude/skills/contest-log-collector/tools/validate-log.py logs/
 ```
 
-应输出 `ALL OK`。若报错，多为工具缺陷，请在组委会群反馈。
+### 4、排查建议
 
-### 4、未采集到或报错时的排查
-
-请按以下顺序排查：
-
-1. 运行健康检查：`bash ../.claude/skills/contest-log-collector/onboarding/verify-setup.sh`
-2. 查看错误日志：`cat ~/.claude/contest-collector-staging/<your-login>/errors/*.err`
-3. 仍无法解决，请在大赛技术支持群反馈。
+1. 确认当前路径位于 `openvela` 工作区内。
+2. 运行健康检查：`bash ../.claude/skills/contest-log-collector/onboarding/verify-setup.sh`
+3. 查看错误记录：`cat ~/.claude/contest-collector-staging/<your-login>/errors/*.err`
 
 ## 六、常见问题
 
-### Q1：未执行“打包”，对话会自动上传吗？
+### Q1：未执行“打包”操作，对话会自动上传吗？
 
-不会。工具不会自动 push 至任何 git 仓库。staging 位于 `~/.claude/contest-collector-staging/`，与 git 无关。
+物理上传由你控制。工具仅负责将日志写入本机磁盘的 `logs/` 目录，它自身永远不会执行 `git push` 命令。你需要手动提交代码并推送至 GitHub，日志才会真正上传。
 
-### Q2：与 AI 谈及的私人内容（薪资、情感、其他项目）会泄露吗？
+### Q2：与 AI 谈及的私人内容会泄露吗？
 
-只要不主动执行“打包”，此类对话不会进入比赛仓库，仅保存于本机 staging。如有顾虑，可在导出前删除 staging 中对应文件：
+在工作区（识别到 `.repo/` 的目录）之外进行的对话完全不采集，无需担心。如果你在工作区内谈论了敏感内容，记录会在会话结束时自动写入 `logs/`。你可以在执行 `git commit` 前，手动删除对应的 `.jsonl` 文件。
 
-```bash
-ls ~/.claude/contest-collector-staging/<your-login>/<date>/
-rm <session-id>.jsonl
-```
+### Q3：可以修改 logs 中的内容吗？
 
-### Q3：可以修改 staging 或 logs 中的内容吗？
-
-`../.claude/skills/contest-log-collector/tools/validate-log.py` 会检测 seq 缺号、跨字段不一致、manifest 与文件不匹配等篡改行为，修改日志将被视为作弊。但在导出前于 staging 中删除整个会话是允许的，其效果等同于“不打包”，评委不可见。
+`validate-log.py` 脚本会检测序号断档或内容篡改行为。修改日志内容会被视为作弊。如果你需要撤回某次对话，在 `git commit` 前直接删除 `logs/` 下对应的文件即可，这样评委将无法看到该次对话。
 
 ### Q4：可以临时关闭日志收集吗？
 
-不建议。大赛规则要求全程归集（staging 全量采集）。参赛者可控制的是导出哪些会话至比赛仓库，这是为参赛者保留的隐私边界。
+最简单的办法是在工作区外（找不到 `.repo/` 目录的地方）与 AI 对话，此时工具不会进行任何采集。
 
 ### Q5：临近截止如何处理？
 
-截止时间到达后，组委会将：
-
-1. 将仓库权限由 write 降为 read（不可再 push）；
-2. 触发最终归档。
-
-建议在截止前数小时：
+由于会话已自动导出至本地，你只需在截止前确保已完成 `git push` 即可。如果你想做一次最终清查，可以运行以下命令确认是否有遗漏：
 
 ```bash
-# 查看尚未导出的会话
+# 确认本地所有已采集的日志均已入仓
 contest-snapshot --list
-
-# 预览全部待导出会话（核对是否包含不应上传的个人对话）
-contest-snapshot --all
-
-# 核对无误后，追加 --confirm 一次性导出
-contest-snapshot --all --confirm
-git add logs/ && git commit -s -m "logs: final batch" && git push
+git add logs/ && git commit -s -m "logs: final sync" && git push
 ```
 
 ### Q6：工具异常或未采集到日志怎么办？
 
 排查步骤见“五、验证与排错”第 4 条。
 
-### Q7：从仓库子目录（如 `cd src && claude`）启动 AI 可以吗？
+### Q7：从仓库子目录（如 `cd nuttx && claude`）启动 AI 可以吗？
 
-可以。hook 为全局生效，无论当前工作目录位于何处，只要与 Claude Code / OpenCode / Codex 对话，记录均会写入 staging。
+可以。只要你处于 `openvela` 工作区的任何子目录内（包括嵌入式源码目录等），采集器都会通过识别上层的 `.repo/` 目录来激活。反之，若在工作区外的随机目录启动工具，则不会进行采集。
 
 ### Q8：拥有多个 demo 仓库（主仓 + 子模块）时日志如何归集？
 
-按大赛规则，所有日志统一汇集至主 demo 仓库。子模块仓库无需安装日志工具，在主仓库内运行 `export-session.py` 即可。
+按大赛规则，所有日志统一汇集至主 demo 仓库。子模块仓库无需重复配置，在工作区内进行的任何 AI 协作都会自动同步至主仓的 `logs/` 目录下。
 
 ### Q9：可以使用 ChatGPT / Cursor / Cody 等其他工具吗？
 
-暂不支持。本届官方支持的工具为：
+暂不支持。本届官方支持且能自动采集日志的工具为：
 
 - Claude Code（主推，含 AIoT-IDE 内嵌）
 - AIoT-IDE
 - OpenCode
 - Codex
 
-使用其他工具产生的对话不会写入 staging，视为无效工时。
+使用其他三方工具产生的对话无法被采集，将无法计入有效工时。
 
 ### Q10：直接调用 Anthropic API / OpenAI API 可以吗？
 
-不可以。直接调用 API 的对话不在 session transcript 中，工具无法采集，须使用上述 4 种工具之一。
+不可以。直接调用 API 的对话不在 session transcript 中，工具无法采集。请务必使用上述 4 种官方支持的工具。
 
 ## 七、反馈与支持
 
@@ -333,54 +335,45 @@ git add logs/ && git commit -s -m "logs: final batch" && git push
 
 ## 附录：工具自带文件清单（参考，可跳过）
 
-以下为工具仓库与全局 hook 的目录结构，仅供需要了解内部实现者参考，正常使用无需关注。
+以下为工具仓库与全局钩子的目录结构，仅供了解内部实现参考。
 
-`repo sync` 拉取的工程结构如下，其中 `.claude/` 为工具仓库（与 demo 仓库平级），并非安装在 demo 仓库内部。`install.sh` 采用**零侵入**设计：不会向 demo 仓库复制任何文件，工具源全部从 `.claude/` 工具仓直接调用。demo 仓库中**仅在参赛者主动 `--confirm` 导出后**才会出现 `logs/` 目录。
+`repo sync` 拉取的工程结构如下。`.claude/` 为工具仓库（与 demo 仓库平级）。`install.sh` 采用**零侵入**设计。demo 仓库中**在工作区内首次结束 AI 会话后**会自动出现 `logs/` 目录。
 
 ```text
 <你的工作树>/                            # repo init 拉取的工作树根目录
-├── .repo/                              # repo 工具元数据
-├── .claude/                            # 大赛工具仓库（open-vela/.claude，由 manifest 拉取）
+├── .repo/                              # repo 工作区标识
+├── .claude/                            # 大赛工具仓库（open-vela/.claude）
 │   └── skills/contest-log-collector/
-│       ├── adapters/                   # snapshot core / opencode plugin 源 (install 会复制到 ~/.claude/)
-│       ├── commands/                   # slash command (Claude Code 自动从 ~/.claude/ 加载)
-│       ├── tools/                      # export / render / validate (参赛者 + 评委直接调用)
-│       ├── schema/                     # JSONL 契约 (validate-log.py 自动加载)
+│       ├── adapters/                   # 核心采集逻辑
+│       ├── tools/                      # 同步与校验工具
 │       └── onboarding/
-│           ├── install.sh              # 安装脚本（仅写 ~/.claude/、~/.config/opencode/、~/.local/bin/）
-│           ├── verify-setup.sh         # 健康检查
-│           ├── USAGE.md                # 选手使用手册
-│           └── JUDGE_GUIDE.md          # 评委指南
+│           ├── install.sh              # 安装脚本
+│           └── verify-setup.sh         # 健康检查
 ├── nuttx/  apps/  vendor/  ...         # openvela 全量源码
 └── <你的 demo 仓>/                      # 例如 contest2026_042_openvela
-    ├── (你的代码、README、配置 — install.sh 完全不动)
-    └── logs/                           # 仅在主动 `--confirm` 导出会话后才生成
+    ├── (你的代码、README、配置)
+    └── logs/                           # 首次结束 AI 会话后自动生成
         └── <your-github-login>/
             ├── manifest.json
             └── <date>/<tool>__<sid>.jsonl
 ```
 
-此外，第一节的 `install.sh` 会在 home 目录部署全局 hook、staging 区与短命令快捷脚本（**所有工具状态均位于 home 目录，不进入 demo 仓库**）：
+此外，`install.sh` 会在 home 目录部署全局状态（**这些文件不进入 demo 仓库**）：
 
 ```text
 ~/.claude/
-├── settings.json                       # 注入 Stop/SessionEnd hook
-├── contest-collector.env               # 身份信息（TEAM_ID + GITHUB_LOGIN）
-├── contest-shared/                     # 全局 hook
-│   ├── snapshot_core.py
-│   ├── get_github_login.py
-│   └── contest-snapshot.sh
-└── contest-collector-staging/          # staging 区（本机全部 AI 对话）
+├── settings.json                       # 挂载会话结束钩子
+├── contest-collector.env               # 身份信息
+└── contest-collector-staging/          # 本机缓冲区
     └── <your-github-login>/
-        ├── manifest.json
         └── <date>/<tool>__<sid>.jsonl
 
 ~/.config/opencode/plugin/
-└── contest-collector.js                # OpenCode 全局 plugin
+└── contest-collector.js                # OpenCode 插件
 
 ~/.local/bin/
-└── contest-snapshot                    # 短命令快捷脚本（封装 export-session.py）
+└── contest-snapshot                    # 便捷脚本
 ```
 
-全局 hook 不会自动 push，仅在本机写入文件，提交由参赛者自行控制。
-**demo 仓库中除 `logs/<your-github-login>/...` 外不会出现任何其他工具文件。**
+采集器不会自动执行网络上传，仅在本机工作区内流转日志，最终提交由参赛者自行通过 git 完成。
+**demo 仓库中除 `logs/` 目录外不会出现任何采集器相关文件。**


### PR DESCRIPTION
## What this PR does

Updates the contestant-facing "AI Coding 日志归集与提交手册" to match
the new collector behavior shipped in open-vela/.claude PR #27:

- **Workspace gate replaces manual confirm as the privacy boundary.**
  The collector now only activates inside an openvela workspace
  (detected by `.repo/` directory). Sessions outside the workspace
  (personal projects, random dirs) are not collected at all.
- **Auto-export on session end.** Sessions inside the workspace are
  automatically written into `logs/<github_login>/` when they end; no
  `contest-snapshot --confirm` needed for the normal path.
- **git push still required.** The tool only writes local files; the
  contestant decides when to push.

## Sections changed

- Opening paragraph + flow overview → new model
- Key terms → add "workspace gate", reframe staging/export
- §II (AI tools) → sessions auto-write to repo logs/, not just staging
- §III (submit) → auto-export is primary; manual tool is optional
- §IV (privacy) → workspace gate is the boundary, not manual confirm
- FAQ Q1-Q4, Q7 → answers aligned with workspace-gated model
- Appendix → logs/ appears automatically, not only after --confirm

## Verification

- 0 internal-only references
- "openvela" all-lowercase throughout
- No remaining contradictions from old "must manually confirm" model
- `commit -s` applied
