### PR TITLE
docs(contest_2026): fix registration/benefits status query table links

### DIFF
--- a/zh-cn/contest_2026/contest_overview.md
+++ b/zh-cn/contest_2026/contest_overview.md
@@ -23,8 +23,8 @@
 
 **具体每一步：**
 
-1. **报名 + 提交作品方向**（6 月 8 日起）→ 等待组委会审核。可通过 [报名审核状态查询表](https://rcna6b54jm72.feishu.cn/share/base/query/shrcnLw0VxcviyUZjkupxM0IrRc1) 查询审核进度。
-2. **审核通过**：解锁权益——申领开发板、Xiaomi MiMo Token、嘉立创打样券，并扫码进官方交流群（详见下方「赋能支持」）。可通过 [权益发放状态查询表](https://rcna6b54jm72.feishu.cn/share/base/query/shrcnLtUdjLqXiNkTjSwV1nRaoX1) 查询开发板、MiMo 账号充值、嘉立创打样券等发放情况。
+1. **报名 + 提交作品方向**（6 月 8 日起）→ 等待组委会审核。可通过 [报名审核状态查询表](https://rcna6b54jm72.feishu.cn/share/base/query/shrcnLw0VxcviyUZjkupxM0IrRc) 查询审核进度。
+2. **审核通过**：解锁权益——申领开发板、Xiaomi MiMo Token、嘉立创打样券，并扫码进官方交流群（详见下方「赋能支持」）。可通过 [权益发放状态查询表](https://rcna6b54jm72.feishu.cn/share/base/query/shrcnLtUdjLqXiNkTjSwV1nRaoX) 查询开发板、MiMo 账号充值、嘉立创打样券等发放情况。
 3. **拿到专属仓**：组委会按 `contest2026_<编号>_<队伍名>` 为你创建 GitHub 专属仓库并开通 push 权限。详见 [《参赛代码提交指南》](./code_submission_guide.md)。
 4. **拉取工程**：用组委会提供的 `repo init` + `repo sync` 一键拉取「openvela 全量源码 + 你的专属仓」。详见 [《参赛代码提交指南》](./code_submission_guide.md)。
 5. **开发**：选择你的赛道指引（见下方「三个赛道方向」），鼓励使用 AI Coding；只在专属仓子目录内开发。


### PR DESCRIPTION
## Summary
- Fix the registration approval / benefits status query table links in `contest_overview.md` (correct the trailing token characters of the two Feishu share-base query URLs).

## Context
- Follow-up to #603 (merged). Branched from the latest `dev-ai-contest-2026`.

## Test
- Verified the diff only touches the two query-table URLs in step 1 and step 2.