### PR TITLE
docs(contest): link official velaclaw API reference & move D13x to supported boards

### DIFF
--- a/zh-cn/contest_2026/hardware_porting/supported_hardware.md
+++ b/zh-cn/contest_2026/hardware_porting/supported_hardware.md
@@ -93,6 +93,15 @@
 - **设备介绍**：[匠芯创D12x开发板资料.zip](../attachment/匠芯创D12x开发板资料.zip)
 - **开发指南**：[D12X-Demo68-nor README](../../../../../../vendor_artinchip/blob/dev-ai-contest-2026/README.md)
 
+### 11、D13x 系列 EVM 评估板 — 匠芯创
+
+<img src="../images/aic_d13x.jpg" alt="匠芯创 D13x 系列 EVM 评估板" width="360" />
+
+- **芯片特点**：RISC-V 架构、国产自主、显控一体 MCU
+- **适用场景**：工业 HMI、网关、串口屏等泛工业领域及智慧家居
+- **设备介绍**：[匠芯创开发板资料.zip](../attachment/匠芯创开发板资料.zip)
+- **开发指南**：待补充（等待开发人员提供 D13x 专属 README 链接）
+
 ## 二、待适配开发板
 
 > 以下平台 openvela 尚未完成适配，主办方提供芯片手册、硬件设计文档、参考代码等技术资料，适合「新硬件平台适配」赛道挑战（重点加分方向）。
@@ -117,16 +126,7 @@
 - **设备介绍**：面向端侧 AI 的全功能评估/量产参考平台，BK7258 Wi-Fi 6 AI-SoC（480MHz ARMv8-M），板载双 QSPI 屏、DVP 摄像头、麦克风阵列、陀螺仪、NFC、震动马达、Nand Flash 等；支持端侧语音唤醒（KWS）、AEC、NS、G711/G722 编码及 H.264/MJPEG 硬件编解码，可对接 OpenAI、豆包、DeepSeek 等大模型。[官方文档](https://docs.bekencorp.com/arminodoc/bk_ai_smp/bk7258/zh_CN/v3.1.1/intro/index.html)
 - **上游目标仓（获奖后 PR）**：`vendor_beken`（`dev-ai-contest-2026` 分支，`boards/` 目录）
 
-### 3、D13x 系列 EVM 评估板 — 匠芯创
-
-<img src="../images/aic_d13x.jpg" alt="匠芯创 D13x 系列 EVM 评估板" width="360" />
-
-- **芯片特点**：RISC-V 架构、国产自主、显控一体 MCU
-- **适用场景**：工业 HMI、网关、串口屏等泛工业领域及智慧家居
-- **技术资料**：[匠芯创开发板资料.zip](../attachment/匠芯创开发板资料.zip)
-- **上游目标仓（获奖后 PR）**：`vendor_artinchip`（`dev-ai-contest-2026` 分支创建中，`boards/` 目录）
-
-### 4、STM32N647 开发板 — 意法半导体
+### 3、STM32N647 开发板 — 意法半导体
 
 <img src="../images/stm32n647.jpg" alt="STM32N647 开发板" width="360" />
 
@@ -135,7 +135,7 @@
 - **设备介绍**：[STM32N6 系列](https://www.st.com.cn/zh/microcontrollers-microprocessors/stm32n6-series.html) ｜ [正点原子 DNN647 资料](https://wiki.alientek.com/docs/Boards/STM32/DNN647/TOC/)
 - **上游目标仓（获奖后 PR）**：`vendor_st`（`dev-ai-contest-2026` 分支，`boards/` 目录）
 
-### 5、逻极派 LogicPi A1 边缘 AI 开发板 — Amlogic
+### 4、逻极派 LogicPi A1 边缘 AI 开发板 — Amlogic
 
 <img src="../images/logicpi_a1.png" alt="逻极派 LogicPi A1 边缘 AI 开发板" width="360" />
 
@@ -144,7 +144,7 @@
 - **技术资料**：[LogicPi A1 开发板资料.zip](../attachment/LogicPi%20A1%20开发板资料.zip)
 - **上游目标仓（获奖后 PR）**：`vendor_amlogic`（仓库 / 大赛分支待创建，`boards/` 目录）
 
-### 6、KICKPI-K7（RK3576）— 瑞芯微
+### 5、KICKPI-K7（RK3576）— 瑞芯微
 
 - **芯片特点**：Rockchip RK3576 高性能多核 SoC（含 NPU，详见官方硬件资料）
 - **适用场景**：边缘 AI、多媒体网关、工业控制、嵌入式学习

--- a/zh-cn/contest_2026/quickapp/quickapp_velaclaw.md
+++ b/zh-cn/contest_2026/quickapp/quickapp_velaclaw.md
@@ -175,6 +175,8 @@ vapp hap://app/com.application.lyra.demo
 
 ## 六、在快应用中调用 velaclaw
 
+> 接口规格以 [Xiaomi Vela 官方文档 — system.velaclaw](https://iot.mi.com/vela/quickapp/zh/features/other/velaclaw.html) 为准，本节给出大赛环境下的常用调用方式。
+
 上面运行的是示例应用。如果你要在自己的快应用中使用 velaclaw，核心调用方式如下（该调用代码属于应用源码，需在编译打包前写入你的快应用工程）：
 
 ```javascript


### PR DESCRIPTION
## Changes
- quickapp_velaclaw.md: add a reference to the official `system.velaclaw` API doc in section "六、在快应用中调用 velaclaw", as the authoritative source for the interface spec.
- supported_hardware.md: move "D13x 系列 EVM 评估板 — 匠芯创" from "待适配" (to-be-ported) to "已支持" (supported) as item 11, right after its sibling D12x; remaining to-be-ported items renumbered accordingly.

## TODO
- The D13x "开发指南" (dev guide) link is a placeholder for now, pending the D13x-specific README path from the development team.

## Notes
- Rebased onto the latest `dev-ai-contest-2026`.
