### PR TITLE
docs: correct STM32H750 board entry to STM32H750B-DK

### DIFF
--- a/zh-cn/contest_2026/hardware_porting/supported_hardware.md
+++ b/zh-cn/contest_2026/hardware_porting/supported_hardware.md
@@ -58,12 +58,12 @@
 - **技术资料**：[BES2800BP.zip](../attachment/BES2800BP.zip)
 - **开发指南**：[BEST1700 AOS EVB README](../../../../../../vendor_bes/blob/dev-ai-contest-2026/boards/best1700_ep/aos_evb/README_zh-cn.md)（BES2800BP 芯片，板/SDK 代号 best1700_ep）
 
-### 7、STM32H750VBT6 — 意法半导体
+### 7、STM32H750B-DK — 意法半导体
 
-<img src="../images/stm32h750vbt6.jpeg" alt="STM32H750VBT6 开发板" width="360" />
+<img src="../images/stm32h750vbt6.jpeg" alt="STM32H750B-DK 开发板" width="360" />
 
-- **芯片特点**：Cortex-M7 480MHz + QSPI Flash
-- **适用场景**：AI 硬件、高性能 MCU 通用开发
+- **芯片特点**：主控 STM32H750XBH6（Cortex-M7 480MHz），板载 4.3" RGB 触摸屏 + SDRAM + QSPI Flash
+- **适用场景**：AI 硬件、高性能 MCU 通用开发、图形 HMI
 - **开发指南**：[STM32H750B-DK README](../../../../../../nuttx/blob/dev-ai-contest-2026/boards/arm/stm32h7/stm32h750b-dk/README_zh-cn.md)
 
 ### 8、STM32H7A3 — 意法半导体


### PR DESCRIPTION
## 变更内容

`supported_hardware.md` 第 7 条开发板标题原为芯片型号 `STM32H750VBT6`（LQFP100 封装），但大赛实际发放、nuttx 已适配的板级支持与 README 均为 ST 官方 **STM32H750B-DK**（主控 STM32H750XBH6，TFBGA240 封装）。

标题写成芯片型号容易让参赛者误以为要自购 VBT6 的第三方板，本 PR 将其修正为实物开发板名，并补充板载主控、屏幕与存储信息。

## 具体修改

- 标题：`STM32H750VBT6` → `STM32H750B-DK`
- 图片 alt 文本同步更新
- 芯片特点：补充主控 `STM32H750XBH6（Cortex-M7 480MHz）` 及板载 4.3" RGB 触摸屏 + SDRAM + QSPI Flash
- 适用场景：补充"图形 HMI"

## 测试

文档改动，无需构建。