### PR TITLE
docs: add dev guide link for 100ask DShanPixVela-Devkit

### DIFF
--- a/zh-cn/contest_2026/hardware_porting/supported_hardware.md
+++ b/zh-cn/contest_2026/hardware_porting/supported_hardware.md
@@ -45,9 +45,10 @@
 
 <img src="../images/dshanpix_vela.png" alt="百问网 DShanPixVela-Devkit" width="360" />
 
-- **芯片特点**：Cortex-A7 + HiFi4 DSP + WiFi/BLE + LCD + 音频
+- **芯片特点**：Cortex-A7 + HiFi4 DSP + WiFi/BLE + 3.5 寸 SPI 屏（电容触摸）+ 音频 + RS485×2 + CAN×2
 - **适用场景**：工业控制、智能显示、AIoT 音视频、教学开发
 - **设备介绍**：[百问网 DShanPixVela-Devkit](https://www.100ask.net/hardware/detail/16)
+- **开发指南**：[r528s3-dshanpi README](../../../../../../vendor_allwinnertech/blob/dev-ai-contest-2026/boards/r528/r528s3-dshanpi/README_zh-cn.md)
 
 ### 6、BES 2800BP — 恒玄科技
 


### PR DESCRIPTION
## What changed

`vendor_allwinnertech` PR #13 (r528s3-dshanpi board BSP) has been merged into `dev-ai-contest-2026`, adding a full board README. This entry in `supported_hardware.md` previously only had a "设备介绍" link to the 100ask product page with no dev guide.

## Details

- Added **开发指南** link pointing to `boards/r528/r528s3-dshanpi/README_zh-cn.md`, matching the format used by other already-adapted boards.
- Refined the chip feature line with details confirmed from the README: 3.5" SPI screen with capacitive touch (previously just said "LCD"), plus RS485×2 and CAN×2 interfaces.

## Testing

Documentation-only change; no build required.