### PR TITLE
docs(contest_2026): add AI driver development skill set link

### DIFF
--- a/zh-cn/contest_2026/hardware_porting/hardware_porting_guide_index.md
+++ b/zh-cn/contest_2026/hardware_porting/hardware_porting_guide_index.md
@@ -4,15 +4,16 @@
 
 ## 文档列表
 
-| 文档                                                                                | 说明                                                                                                     |
-| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [新硬件适配赛道详细指引](./hardware_porting_track_guide.md)                         | 赛道概述、赛题要求、评分加分项、参考资源。                                                               |
-| [支持的硬件平台](./supported_hardware.md)                                           | 大赛提供的开发板清单（已支持 + 待适配），含芯片特点、适用场景、开发指南链接。                            |
-| [最小可运行 NSH 系统 defconfig 参考](./defconfig_reference/minimum_nsh_baseline.md) | L0 起步 defconfig：在新开发板上先启动到 NSH 命令行提示符，再按需逐步启用文件系统、网络、传感器等子系统。 |
-| [openvela 芯片移植指南](../../chip_porting/porting_guide.md)                        | 从零完成 BSP 移植的完整流程。                                                                            |
-| [openvela 驱动开发指南](../../device_dev_guide/driver/driver_development.md)        | UART/SPI/I2C 等各类驱动的适配与使用。                                                                    |
-| [参赛代码提交指南](../code_submission_guide.md)                                     | 比赛期间如何获取仓库、提交代码、分赛道仓库说明（适用于所有赛道）。                                       |
-| [AI Coding 日志归集与提交手册](../ai_coding_log_guide.md)                           | 如何安装日志工具、把与 AI 的对话导出并提交到比赛仓（适用于所有赛道）。                                   |
+| 文档                                                                                             | 说明                                                                                                     |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| [新硬件适配赛道详细指引](./hardware_porting_track_guide.md)                                      | 赛道概述、赛题要求、评分加分项、参考资源。                                                               |
+| [openvela AI 驱动开发技能集](../../../../../../.claude/blob/dev-ai-contest-2026/README_zh-cn.md) | AI 辅助驱动开发：`nuttx-driver-development` / `driver-code-reviewer` skill + `driver-workflow` agent。   |
+| [支持的硬件平台](./supported_hardware.md)                                                        | 大赛提供的开发板清单（已支持 + 待适配），含芯片特点、适用场景、开发指南链接。                            |
+| [最小可运行 NSH 系统 defconfig 参考](./defconfig_reference/minimum_nsh_baseline.md)              | L0 起步 defconfig：在新开发板上先启动到 NSH 命令行提示符，再按需逐步启用文件系统、网络、传感器等子系统。 |
+| [openvela 芯片移植指南](../../chip_porting/porting_guide.md)                                     | 从零完成 BSP 移植的完整流程。                                                                            |
+| [openvela 驱动开发指南](../../device_dev_guide/driver/driver_development.md)                     | UART/SPI/I2C 等各类驱动的适配与使用。                                                                    |
+| [参赛代码提交指南](../code_submission_guide.md)                                                  | 比赛期间如何获取仓库、提交代码、分赛道仓库说明（适用于所有赛道）。                                       |
+| [AI Coding 日志归集与提交手册](../ai_coding_log_guide.md)                                        | 如何安装日志工具、把与 AI 的对话导出并提交到比赛仓（适用于所有赛道）。                                   |
 
 ## 如何开始
 


### PR DESCRIPTION
## What changed

Added a link to the **openvela AI 驱动开发技能集** (`.claude` repo, `dev-ai-contest-2026` branch) in the hardware porting track's document index table.

- Placed as the 2nd row in the table, right after the track guide overview, since it's most relevant to the hardware porting track (AI-assisted driver development via the `nuttx-driver-development` / `driver-code-reviewer` skills and `driver-workflow` agent).
- Link points to the `.claude` repo's README (cross-repo reference, confirmed correct).

## Testing

Documentation-only change; no build required.