### PR TITLE
docs: fix broken sub-repo relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The name "Vela" is originated from the Latin term for "sail," which is also the 
 
 ## What's New
 
-- **On-Device AI Agent Capability Upgrade**: openvela provides the **[ai_agent](../../../packages_ai_agent/blob/dev/README.md)** AI Agent framework, supporting multiple LLM backends, 35+ built-in tools, a Skills system, proactive tasks, and multi-channel access. It runs on-device intelligent applications on small devices such as watches, glasses, and speakers with only about 256KB of RAM.
+- **On-Device AI Agent Capability Upgrade**: openvela provides the **[ai_agent](../../../../open-vela/packages_ai_agent/blob/dev/README.md)** AI Agent framework, supporting multiple LLM backends, 35+ built-in tools, a Skills system, proactive tasks, and multi-channel access. It runs on-device intelligent applications on small devices such as watches, glasses, and speakers with only about 256KB of RAM.
 
 - **Enhanced AI-Assisted Development**: openvela introduces the official AI development skill set **[.claude](https://github.com/open-vela/.claude)**. Combined with AI coding tools like Claude Code, you can set up the environment, build, adapt drivers, and debug using natural language, significantly lowering the development barrier.
 
@@ -194,21 +194,21 @@ Here are some typical native application examples demonstrating the usage of dif
 - [Relation Calculator](../../../../open-vela/packages_demos/blob/dev/relation_calculator/Readme.md): Demonstrates complex conditional logic and algorithm implementation.
 - [Whack-a-Mole](../../../../open-vela/packages_demos/blob/dev/Whackmole/README.md): Demonstrates a game loop, random number generation, and animation effects.
 
-To see the full list of native apps, please visit the [Native App Examples Repository](../../../packages_demos/blob/dev/README_zh-cn.md).
+To see the full list of native apps, please visit the [Native App Examples Repository](../../../../open-vela/packages_demos/blob/dev/README.md).
 
 ### AI Agent Apps
 
 An on-device AI Agent framework running on openvela, supporting multiple LLM backends, 35+ built-in tools, a Skills system, proactive tasks, and multi-channel access. It runs on small devices with around 256KB of RAM.
 
-- [ai_agent](../../../packages_ai_agent/blob/dev/README.md): An AI Agent framework providing conversation, tool calling, Skills, proactive tasks, the MCP protocol, multi-device collaboration, and more. It serves as the core foundation for AI hardware application development.
+- [ai_agent](../../../../open-vela/packages_ai_agent/blob/dev/README.md): An AI Agent framework providing conversation, tool calling, Skills, proactive tasks, the MCP protocol, multi-device collaboration, and more. It serves as the core foundation for AI hardware application development.
 
 ### Quick Apps
 
-- [Mi Band Weather App](../../.././packages_fe_examples/blob/dev/weather/README.md): Presents a clean and intuitive seven-day weather forecast.
-- [Music Player](../../.././packages_fe_examples/blob/dev/player/README.md): Demonstrates a basic music player, including playback, volume control, and playlist viewing.
-- [Calendar](../../.././packages_fe_examples/blob/dev/calendar/README.md): Demonstrates a basic calendar.
+- [Mi Band Weather App](../../../../open-vela/packages_fe_examples/blob/dev/weather/README.md): Presents a clean and intuitive seven-day weather forecast.
+- [Music Player](../../../../open-vela/packages_fe_examples/blob/dev/player/README.md): Demonstrates a basic music player, including playback, volume control, and playlist viewing.
+- [Calendar](../../../../open-vela/packages_fe_examples/blob/dev/calendar/README.md): Demonstrates a basic calendar.
 
-More Quick App examples are continuously being added. To see all examples, please visit the [Quick App Examples Repository](../../../packages_fe_examples).
+More Quick App examples are continuously being added. To see all examples, please visit the [Quick App Examples Repository](../../../../open-vela/packages_fe_examples).
 
 ## Code contribution
 

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -65,7 +65,7 @@ Vela 的命名源自拉丁语中船帆的含义，也是南方星空中船帆星
 
 ## 最新动态
 
-- 端侧 AI Agent 能力升级：openvela 提供 **[ai_agent](../../../packages_ai_agent/blob/dev/README.md)** AI Agent 框架，支持多 LLM 后端、35+ 内置工具、Skills 技能系统、主动任务与多渠道接入，仅需约 256KB RAM 即可在手表、眼镜、音箱等小型设备上运行端侧智能应用。
+- 端侧 AI Agent 能力升级：openvela 提供 **[ai_agent](../../../../open-vela/packages_ai_agent/blob/dev/README.md)** AI Agent 框架，支持多 LLM 后端、35+ 内置工具、Skills 技能系统、主动任务与多渠道接入，仅需约 256KB RAM 即可在手表、眼镜、音箱等小型设备上运行端侧智能应用。
 
 - AI 辅助开发体验升级：openvela 推出官方 AI 开发技能集 **[.claude](https://github.com/open-vela/.claude)**，配合 Claude Code 等 AI 编程工具，用自然语言即可完成环境搭建、编译构建、驱动适配与调试，显著降低开发门槛。
 
@@ -195,21 +195,21 @@ git clone https://github.com/open-vela/.claude.git .claude
 - [亲戚计算器](../../../../open-vela/packages_demos/blob/dev/relation_calculator/Readme_zh-cn.md)：演示复杂的条件逻辑与算法实现。
 - [打地鼠](../../../../open-vela/packages_demos/blob/dev/Whackmole/README_zh-cn.md)：演示游戏循环、随机数生成和动画效果。
 
-查看完整的原生应用列表，请访问[原生应用示例仓库](../../../packages_demos/blob/dev/README_zh-cn.md)。
+查看完整的原生应用列表，请访问[原生应用示例仓库](../../../../open-vela/packages_demos/blob/dev/README_zh-cn.md)。
 
 ### AI Agent 应用
 
 运行在 openvela 上的端侧 AI Agent 框架，支持多 LLM 后端、35+ 内置工具、Skills 技能系统、主动任务与多渠道接入，可在约 256KB RAM 的小型设备上运行。
 
-- [ai_agent](../../../packages_ai_agent/blob/dev/README.md)：AI Agent 框架，提供对话、工具调用、Skills、主动任务、MCP 协议、多设备协作等能力，是 AI 硬件应用开发的核心基座。
+- [ai_agent](../../../../open-vela/packages_ai_agent/blob/dev/README.md)：AI Agent 框架，提供对话、工具调用、Skills、主动任务、MCP 协议、多设备协作等能力，是 AI 硬件应用开发的核心基座。
 
 ### 快应用（Quick Apps）
 
-- [小米手环天气预报应用](../../.././packages_fe_examples/blob/dev/weather/README.md)：提供简洁直观的未来七日天气信息展示。
-- [音乐播放器](../../.././packages_fe_examples/blob/dev/player/README.md)：演示一个基础的音乐播放器，包含音乐的播放，音量调节，歌单查看。
-- [日历](../../.././packages_fe_examples/blob/dev/calendar/README.md)：演示一个基础的日历。
+- [小米手环天气预报应用](../../../../open-vela/packages_fe_examples/blob/dev/weather/README.md)：提供简洁直观的未来七日天气信息展示。
+- [音乐播放器](../../../../open-vela/packages_fe_examples/blob/dev/player/README.md)：演示一个基础的音乐播放器，包含音乐的播放，音量调节，歌单查看。
+- [日历](../../../../open-vela/packages_fe_examples/blob/dev/calendar/README.md)：演示一个基础的日历。
 
-快应用相关示例正在持续丰富中。查看所有示例，请访问[快应用示例仓库](../../../packages_fe_examples)。
+快应用相关示例正在持续丰富中。查看所有示例，请访问[快应用示例仓库](../../../../open-vela/packages_fe_examples)。
 
 ## 参与贡献
 


### PR DESCRIPTION
## Summary

Fix broken cross-repository relative links in `README.md` and `README_zh-cn.md`. Several links to `packages_ai_agent`, `packages_demos`, and `packages_fe_examples` used inconsistent, non-resolving relative prefixes (`../../../` and `../../.././`), so they 404'd on GitHub.

They are now aligned with the proven-working format already used by the sub-repository list and the demos native-app links: `../../../../open-vela/<repo>/...`.

## Changes

- Fix `ai_agent` links in the *What's New* and *AI Agent* sections (both EN/ZH)
- Fix the `packages_demos` native-app examples repository link (both EN/ZH)
- Fix `packages_fe_examples` quick-app links (weather / player / calendar) and the repository link (both EN/ZH)
- Point the English *Native App Examples Repository* link to `README.md` instead of `README_zh-cn.md`

## Notes

- Release-notes files (`release_notes/v5.*.md`) use a different but internally-consistent and correct 5-level pattern pinned to `trunk-5.x` tags, so they were intentionally left unchanged.

## Test

Verified no `../../../` or `../../.././` broken prefixes remain and that all sub-repo links now use the `../../../../open-vela/<repo>/...` format.