### PR TITLE
ci: add brand-name check for 'VelaClaw' in Markdown

### DIFF
--- a/.github/workflows/brand-name-check.yml
+++ b/.github/workflows/brand-name-check.yml
@@ -1,0 +1,46 @@
+name: brand-name-check
+
+# Fails the PR when the CamelCase brand form 'VelaClaw' appears in Markdown.
+# Please use 'openvelaClaw' (lowercase 'openvela' prefix, capital 'C') in prose.
+#
+# Intentionally NOT flagged:
+#   - lowercase code identifiers: 'velaclaw', '@system.velaclaw',
+#     'velaclaw_client_open', 'velaclaw_ask' (real framework APIs)
+#   - uppercase macro:            'VELACLAW_DAEMON' (real Kconfig / macro name)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  brand-name-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan Markdown for disallowed 'VelaClaw' brand form
+        run: |
+          set -u
+          echo "Scanning Markdown files for CamelCase brand form 'VelaClaw'..."
+          # grep is case-sensitive by default; 'VelaClaw' will NOT match
+          # 'openvelaClaw' (lowercase v) or 'VELACLAW_DAEMON' (all caps).
+          if matches=$(grep -rn --include='*.md' 'VelaClaw' .); then
+            echo ""
+            echo "::error::Disallowed brand form 'VelaClaw' found in Markdown."
+            echo "$matches" | while IFS= read -r line; do
+              file="${line%%:*}"
+              rest="${line#*:}"
+              lineno="${rest%%:*}"
+              echo "::error file=${file},line=${lineno}::Use 'openvelaClaw' instead of 'VelaClaw' in prose."
+            done
+            echo ""
+            echo "Per the openvela naming convention, please use 'openvelaClaw'"
+            echo "(lowercase 'openvela' prefix, capital 'C') as the brand name in prose."
+            echo ""
+            echo "The following identifiers are code / API names and must remain unchanged:"
+            echo "  - lowercase: 'velaclaw', '@system.velaclaw', 'velaclaw_client_open', 'velaclaw_ask'"
+            echo "  - uppercase: 'VELACLAW_DAEMON'"
+            exit 1
+          fi
+          echo "OK: no 'VelaClaw' brand form found."


### PR DESCRIPTION
## Summary

Add a lightweight PR check that fails when the CamelCase brand form `VelaClaw` appears in any Markdown file. The convention is to use `openvelaClaw` (lowercase `openvela` prefix, capital `C`) as the brand name in prose, to reduce trademark risk.

The check is intentionally case-sensitive and does **not** flag the following, which are real framework API / macro names and must remain unchanged:

- lowercase code identifiers: `velaclaw`, `@system.velaclaw`, `velaclaw_client_open`, `velaclaw_ask`
- uppercase macro: `VELACLAW_DAEMON`

## Behavior

- Trigger: `pull_request` (opened / reopened / synchronize).
- Scans all `*.md` files with a plain case-sensitive `grep`.
- On match: emits GitHub Actions `::error file=...,line=...` annotations pointing at each offending line, prints a summary that names the allowed form and the identifiers that are intentionally exempt, and fails the job.
- On no match: prints an `OK` line and passes.

## Scope

- Single new file: `.github/workflows/brand-name-check.yml`
- No other files changed. Documentation-only enforcement.

## ⚠️ Merge order (important)

This check depends on **#636** (the brand rename in `mini_memo_guide.md`) being merged first. If this workflow lands before #636, every subsequent PR against `dev-ai-contest-2026` would fail this check because the base branch still contains the 18 `VelaClaw` occurrences that #636 removes.

Suggested sequencing:
1. Merge #636 (brand rename).
2. Merge this PR (CI enforcement).