### PR TITLE
docs(contest_2026): add 100ASK openvela course introduction

### DIFF
--- a/zh-cn/contest_2026/100ask_openvela_course.md
+++ b/zh-cn/contest_2026/100ask_openvela_course.md
@@ -1,0 +1,34 @@
+# openvela 快速入门与工程实践课程（百问网）
+
+> 百问网（100ASK）韦东山团队与 openvela 官方联合推出的 openvela 完整实战课程。课程从开发环境搭建讲起，最终落地一台能听、会说、带动态表情的 AI 语音机器人。
+
+## 课程资料
+
+| 资源     | 地址                                                                                                             |
+| -------- | ---------------------------------------------------------------------------------------------------------------- |
+| 视频课程 | [B 站：openvela 快速入门与工程实践](https://www.bilibili.com/video/BV1th3e6gENh/)                                |
+| 配套文档 | [《openvela 快速入门与工程实践》Rev 1.2](./attachment/openvela快速入门与工程实践_v1.2.pdf)（2026/04/08，342 页） |
+
+配套开发板为 [百问网 DShanPixVela-Devkit](https://www.100ask.net/hardware/detail/16)（全志 R528，openvela 板级代号 `r528s3-dshanpi`），是本届大赛支持硬件之一，板级说明见 [r528s3-dshanpi README](../../../../../vendor_allwinnertech/blob/dev-ai-contest-2026/boards/r528/r528s3-dshanpi/README_zh-cn.md)。
+
+## 课程内容
+
+课程共 9 章、124 讲：
+
+1. **openvela 开发环境搭建与体验** —— 环境搭建、体验 openvela、VSCode 配置
+2. **openvela 系统介绍** —— 裸机开发的缺陷、RTOS 的优势与挑战、为何选择 openvela
+3. **openvela 多任务系统开发** —— 任务/线程/调度、FIFO 与 RR 调度实验、消息队列、信号量、互斥量、信号、openvelaRPC，含调度与 IPC 的源码分析
+4. **openvela 驱动程序开发** —— 驱动模型与驱动分层、I2C 与 SPI 控制器驱动、触摸屏驱动、Framebuffer 与 SPI LCD 驱动实例
+5. **openvela 文件系统** —— VFS 使用与内部实现、binfs / procfs / tmpfs / romfs
+6. **openvela 的启动与构建** —— 启动流程、GCC 与 Makefile 基础、Kconfig、构建脚本解析
+7. **跨核通信** —— RPMSG 分层与通道建立、基于 VirtIO 的跨核通信
+8. **openvela 调试技术** —— `ps` / `top` / `memdump` / `dumpstack` 等命令的使用与内部机制、堆实现、栈回溯、Crash log 解读、GDB 与 Coredump
+9. **项目实战：AI 语音聊天机器人** —— 麦克风采集与 Opus 编解码、HTTPS 设备激活、WebSocket 上云交互、LVGL 显示文本与动态表情、系统集成
+
+## 对参赛者的价值
+
+- **配套开发板即大赛支持硬件**：选用 DShanPixVela-Devkit 的团队可直接按课程流程搭建环境、编译烧写。
+- **通用能力不限开发板**：第 3、4、6、8 章（多任务与 IPC、驱动开发、构建系统、调试技术）适用于所有 openvela 开发板。
+- **语音类作品的参考实现**：第 9 章的完整链路（麦克风采集 → Opus 编码 → WebSocket 上云 → 解码播放 → LVGL 表情渲染）与多数语音交互类作品的技术路径一致。
+
+> 课程与配套资料由百问网维护并持续更新（当前配套文档为 Rev 1.2）。开发板购买与课程咨询请访问[百问网官网](https://www.100ask.net/)，资料下载见[百问网 r528s3-dshanpi 资料页](https://download.100ask.net/project/item7/index.html)。

--- a/zh-cn/contest_2026/100ask_openvela_course.md
+++ b/zh-cn/contest_2026/100ask_openvela_course.md
@@ -1,4 +1,4 @@
-# openvela 快速入门与工程实践课程（百问网）
+# openvela 快速入门与工程实践课程
 
 > 百问网（100ASK）韦东山团队与 openvela 官方联合推出的 openvela 完整实战课程。课程从开发环境搭建讲起，最终落地一台能听、会说、带动态表情的 AI 语音机器人。
 
@@ -31,4 +31,4 @@
 - **通用能力不限开发板**：第 3、4、6、8 章（多任务与 IPC、驱动开发、构建系统、调试技术）适用于所有 openvela 开发板。
 - **语音类作品的参考实现**：第 9 章的完整链路（麦克风采集 → Opus 编码 → WebSocket 上云 → 解码播放 → LVGL 表情渲染）与多数语音交互类作品的技术路径一致。
 
-> 课程与配套资料由百问网维护并持续更新（当前配套文档为 Rev 1.2）。开发板购买与课程咨询请访问[百问网官网](https://www.100ask.net/)，资料下载见[百问网 r528s3-dshanpi 资料页](https://download.100ask.net/project/item7/index.html)。
+> 课程与配套资料由百问网维护并持续更新（当前配套文档为 Rev 1.2）。完整资料下载见[百问网 r528s3-dshanpi 资料页](https://download.100ask.net/project/item7/index.html)。


### PR DESCRIPTION
## Summary

Adds an introduction page for the **openvela Quick Start and Engineering Practice** course, jointly published by the 100ASK team (led by Weidongshan) and openvela. The course goes from setting up the development environment to building an AI voice robot that listens, speaks, and shows animated expressions.

The page carries two resources:

- **Video course**: Bilibili link ([BV1th3e6gENh](https://www.bilibili.com/video/BV1th3e6gENh/))
- **Companion handbook**: *openvela Quick Start and Engineering Practice* Rev 1.2 (2026-04-08, 342 pages), attached under `zh-cn/contest_2026/attachment/`

## Content

- Course resources table (video link + handbook attachment)
- Companion board mapping: 100ASK DShanPixVela-Devkit (Allwinner R528, board name `r528s3-dshanpi`), one of the supported boards of this contest, with a link to its board README
- Outline of the 9 chapters / 124 lessons: environment setup, RTOS concepts, multitasking and IPC, driver development (I2C / SPI / framebuffer / LCD), file systems, boot and build system, inter-core communication (RPMSG / VirtIO), debugging techniques, and the final AI voice chat robot project
- A short section on what contest participants can reuse: the board-specific setup flow, the board-independent fundamentals (chapters 3, 4, 6, 8), and the chapter 9 voice pipeline as a reference implementation

## Files

| File | Change | Size |
| --- | --- | --- |
| `zh-cn/contest_2026/100ask_openvela_course.md` | new | 34 lines |
| `zh-cn/contest_2026/attachment/openvela快速入门与工程实践_v1.2.pdf` | new | 25.8 MB |

## Note on the attachment size

The handbook as supplied is 87.4 MB, which exceeds GitHub's recommended 50 MB per-file limit. The images inside it are embedded at full capture resolution, so it has been recompressed to 120 DPI, bringing it down to **25.8 MB (-71%)** — comparable to the existing `BES2800BP.zip` (26.0 MB) in the same directory.

Verified after recompression:

- all 342 pages present
- text layer intact (the PDF remains searchable and copyable)
- text labels inside embedded diagrams and terminal screenshots remain legible

For reference, the alternatives measured were: plain `zip -9` 78.8 MB (-10%, not worthwhile since PDF streams are already compressed), 150 DPI 43.7 MB (-50%), and 72 DPI 5.9 MB (-93%, rejected because text inside diagrams became blurry).

## Other notes

- The handbook cover labels the SoC as T113-S3, while the kernel configuration options used in its body are `CONFIG_R528_*` and the board directory is `r528s3-dshanpi`. Readers are pointed to the repository board name.
- The board README already links the same handbook on the [100ASK download page](https://download.100ask.net/project/item7/index.html) along with a second Bilibili playlist ([BV19PsAzCEuy](https://www.bilibili.com/video/BV19PsAzCEuy)). If that playlist has been superseded by BV1th3e6gENh, the board README should be updated separately.
- Chinese only for now, consistent with other contest documents under `contest_2026/`. An English version can be added if needed.
